### PR TITLE
doc: improve doc for the math agent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,13 @@ AgentCore runtime is currently supported by:
 ACR deploys agents as Docker containers. Most Dockerfiles can be auto-generated with the [AgentCore CLI](https://aws.github.io/bedrock-agentcore-starter-toolkit/api-reference/cli.html). Example command:
 
 ```bash
-# Run from project root
-agentcore configure --entrypoint examples/strands_math_agent/rl_app.py \
-  --requirements-file examples/strands_math_agent/pyproject.toml \
+# Run from examples/strands_math_agent
+agentcore configure --entrypoint rl_app.py \
+  --requirements-file pyproject.toml \
   --deployment-type container --disable-memory --non-interactive
 ```
 
-You can further customize these files if needed. Pre-generated Dockerfiles for all examples are provided in `.bedrock_agentcore/`. Once you have a Dockerfile, follow these steps to build and push your agent image to ECR.
+You can further customize these Dockerfiles if needed. Once you have a Dockerfile, follow these steps to build and push your agent image to ECR.
 
 ### Setup Credentials and Environment Variables
 
@@ -183,7 +183,7 @@ Then edit `.env` and fill in your values:
 ```bash
 # Use examples/strands_math_agent as an example
 chmod +x scripts/build_docker_image_and_push_to_ecr.sh
-bash ./scripts/build_docker_image_and_push_to_ecr.sh --dockerfile=.bedrock_agentcore/examples_strands_math_agent_rl_app/Dockerfile --tag=dev
+bash ./scripts/build_docker_image_and_push_to_ecr.sh --dockerfile=examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_rl/Dockerfile --tag=dev
 ```
 
 ### Start Training with veRL

--- a/examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_basic/Dockerfile
+++ b/examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_basic/Dockerfile
@@ -12,9 +12,9 @@ ENV UV_SYSTEM_PYTHON=1 \
 
 
 
-COPY examples/strands_math_agent examples/strands_math_agent
+COPY . .
 # Install from pyproject.toml directory
-RUN cd examples/strands_math_agent && uv pip install .
+RUN cd . && uv pip install .
 
 
 

--- a/examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_rl/Dockerfile
+++ b/examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_rl/Dockerfile
@@ -12,19 +12,14 @@ ENV UV_SYSTEM_PYTHON=1 \
 
 
 
-COPY examples/strands_math_agent examples/strands_math_agent
+COPY . .
 # Install from pyproject.toml directory
-RUN cd examples/strands_math_agent && uv pip install .
+RUN cd . && uv pip install .
 
 
 
 
 RUN uv pip install aws-opentelemetry-distro==0.12.2
-
-# [TODO]: remove the following lines after being able to add this agentcore-rl-toolkit as
-# a dependency in examples/strands_math_agent/pyproject.toml
-COPY . .
-RUN uv pip install --force-reinstall --no-deps .
 
 
 # Signal that this is running in Docker for host binding logic

--- a/examples/strands_math_agent/README.md
+++ b/examples/strands_math_agent/README.md
@@ -1,74 +1,121 @@
 # Strands Math Agent
 
+We provide instructions to run `basic_app.py` and `rl_app.py` both as local servers and as
+http endpoints deployed to AgentCore Runtime (ACR).
+
 ## Installation
 
 ```bash
 cd examples/strands_math_agent
 
-# Option A: Use the main project's venv (if already activated)
-uv pip install -e .
-
-# Option B: Create a separate venv for this example
 uv venv --python 3.13
 source .venv/bin/activate
 uv pip install -e .
-uv pip install -e ../../ --force-reinstall --no-deps . # install the parent repo
-
 ```
 
-## Run Basic App With Bedrock API
+## Setup AWS Credentials
+
+Since the basic app uses Amazon Bedrock to access Claude models, you'll need to configure AWS credentials and ensure model access. Make sure `aws sts get-caller-identity` returns the right identity. If not, follow the [developer guide](https://docs.aws.amazon.com/en_us/serverless-application-model/latest/developerguide/serverless-getting-started-set-up-credentials.html) to set up AWS Credentials. After setup, run `aws sts get-caller-identity` again to verify.
+
+
+## Run Basic App Locally with Bedrock API
+
+### Start the application server
 ```bash
+# Go to the example folder
 cd examples/strands_math_agent
 
-# start the server in one terminal
+# Start the server in one terminal
 python basic_app.py
 
-# submit the following request in another terminal
+# Submit the following request in another terminal
 curl -X POST http://localhost:8080/invocations \
      -H "Content-Type: application/json" \
      -d '{"prompt": "Toula went to the bakery and bought various types of pastries. She bought 3 dozen donuts which cost $68 per dozen, 2 dozen mini cupcakes which cost $80 per dozen, and 6 dozen mini cheesecakes for $55 per dozen. How much was the total cost?"}'
 ```
 
-## Run Basic App Inside Docker Locally
+## Run Basic App Hosted on ACR
 
-### Build Docker
+### Deploy
+Once the app works locally, we can deploy it to ACR. It's straightforward with the AgentCore CLI.
+
+First, configure the agent. The configs will be saved to `.bedrock_agentcore.yaml`, and the Dockerfile will be saved under `.bedrock_agentcore`.
 
 ```bash
-# Make sure you are at the project root.
-cd ../../
+agentcore configure --entrypoint basic_app.py --name strands_math_agent_basic --requirements-file pyproject.toml --deployment-type container --disable-memory --non-interactive
+```
+Then, we can deploy the agent by specifying its name.
 
-# Build Docker
-docker build -t math:dev --load . -f .bedrock_agentcore/examples_strands_math_agent_basic_app/Dockerfile
-
-# Run Docker
-# Note that we override the docker CMD to avoid cluttering error logs due to missing OTLP collector, which is not set up locally.
-docker run -p 8080:8080 --env-file examples/strands_math_agent/.env math:dev python -m basic_app
-
-# Submit request
-curl -X POST http://localhost:8080/invocations \
-     -H "Content-Type: application/json" \
-     -d '{"prompt": "Toula went to the bakery and bought various types of pastries. She bought 3 dozen donuts which cost $68 per dozen, 2 dozen mini cupcakes which cost $80 per dozen, and 6 dozen mini cheesecakes for $55 per dozen. How much was the total cost?"}'
+```bash
+agentcore deploy --agent strands_math_agent_basic
 ```
 
-## Run RL App With a Local vLLM Server
-```bash
+### Invoke
 
-# Start vLLM server (assume access to GPU)
+To invoke the deployed endpoint, simply use `agentcore invoke` with the payload. Check `agentcore invoke --help` for other optional arguments.
+
+```bash
+agentcore invoke --agent strands_math_agent_basic '{"prompt": "Toula went to the bakery and bought various types of pastries. She bought 3 dozen donuts which cost $68 per dozen, 2 dozen mini cupcakes which cost $80 per dozen, and 6 dozen mini cheesecakes for $55 per dozen. How much was the total cost?"}'
+```
+
+## Run RL App Locally with a vLLM Server
+
+The most common setup during RL training is to use a local inference engine to serve the model being trained and generate responses. So, we will try to replicate this setting and let the RL app use a local model.
+
+### Start a local vLLM server
+
+This step assumes access to GPU locally. To start with, install vLLM in a separate repo and environment
+if needed. Then, start the vLLM server.
+
+```bash
+# Assume you are inside examples/strands_math_agent, navigate outside the project repo entirely
+cd ....
+
+# Create a new project directory
+mkdir vllm-server
+cd vllm-server
+
+# Initialize uv env and add vLLM as a dependency
+uv init
+uv add vllm
+
+# Start the vLLM server using Qwen3-4B-Instruct-2507 as an example.
 CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-4B-Instruct-2507 --max-model-len 8192 --port 4000 --enable-auto-tool-choice --tool-call-parser hermes
+```
 
+### Configure environment
+To inform the RL app where the inference server is, we will use environment variables.
+
+```bash
 # Create .env file from examples/strands_math_agent/.env.example
 cp .env.example .env
 
-# Update the following env vars in .env if needed
+# Update the following env vars in .env if needed, otherwise the default values should just work
 BASE_URL=http://localhost:4000/v1
 MODEL_ID=Qwen/Qwen3-4B-Instruct-2507
+```
 
-# Submit request
-# Note: the main difference between this request to RL app and that to basic app is the "_training"
-# field. This field will be prepared automatically by the training framework (veRL) during RL training,
-# but when we test it out locally, we will need to specify them, especially s3 bucket name and sqs url.
-# You will need to create a sqs queue and s3 bucket if you don't have existing ones.
+### Setup S3 and SQS
 
+As explained in the main [README](../../README.md#key-features), RL apps follow a fire-and-forget pattern where rollout and reward are saved to S3, then a notification is sent to SQS. We recommend setting up these resources and testing locally first to catch any issues early.
+
+```bash
+# Create S3 bucket and SQS queue
+aws s3 mb s3://agentcore-rl
+aws sqs create-queue --queue-name agentcore-rl --no-cli-pager
+```
+
+### Start the application server
+
+Now we can test the RL app similar to what we did with the basic app above.
+
+```bash
+# Start the server in one terminal
+python rl_app.py
+
+# Submit the following request in another terminal
+# Note in the payload, we also provide the ground truth answer to calculate reward.
+# Replace {REGION} and {ACCOUNT} with your AWS region and account ID.
 curl -X POST http://localhost:8080/invocations \
      -H "Content-Type: application/json" \
      -d '{
@@ -76,29 +123,150 @@ curl -X POST http://localhost:8080/invocations \
        "answer": "694",
        "_training": {
          "exp_id": "test",
-         "sqs_url": "https://sqs.{region}.amazonaws.com/{account_id}/{queue_name}",
-         "s3_bucket": "{bucket_name}",
+         "sqs_url": "https://sqs.{REGION}.amazonaws.com/{ACCOUNT}/agentcore-rl",
+         "s3_bucket": "agentcore-rl",
          "session_id": "session_123",
          "input_id": "prompt_123"
        }
      }'
 ```
+You should see the rollout and reward saved to `s3://agentcore-rl/test/prompt_123_session_123.json`.
 
-## Run RL App Inside Docker Locally
+> **Note:** The `_training` config in the request payload is optional. If not provided, S3 save and SQS notification will be skipped. During training, this field will be generated automatically by the training engine. However, we recommend testing the full flow locally.
 
-### Build Docker
+
+## Run RL App Hosted on ACR
+Similar to the basic app, we can also deploy our RL app to ACR with the CLI tool. One caveat, however, is to make sure ACR can access the locally hosted vLLM server. By default, ACR is deployed to public net. So if the vLLM server resides in a VPC, ACR will not be able to access it.
+
+### Deploy
+
+**Option 1**
+
+Assuming the vLLM server is hosted on an AWS managed instance inside a VPC, we can deploy the ACR to the same VPC to ensure access. This corresponds to the scenario where users use the training infra from AWS.
+
 ```bash
-# Make sure you are at the project root.
-cd ../../
+# Get BASE_URL with private IP
+BASE_URL="http://$(hostname -I | awk '{print $1}'):4000/v1"
+MODEL_ID=Qwen/Qwen3-4B-Instruct-2507
+
+# Specify subnet and security group info from your instance's network details
+SUBNET_ID="subnet-0123456789abcdefg"
+SECURITY_GROUP_ID="sg-0123456789abcdefg"
+
+# Configure the agent with details above
+agentcore configure --entrypoint rl_app.py --name strands_math_agent_rl --requirements-file pyproject.toml --deployment-type container --vpc --subnets $SUBNET_ID --security-groups $SECURITY_GROUP_ID --disable-memory --non-interactive
+```
+
+**Option 2**
+It's also possible that the inference servers are presented as public URLs. In this case, we can directly deploy ACR to public net. The agent can invoke the inference server much like it uses an external API model.
+
+```bash
+agentcore configure --entrypoint rl_app.py --name strands_math_agent_rl --requirements-file pyproject.toml --deployment-type container --disable-memory --non-interactive
+```
+
+While this option is feasible thanks to the [decoupled design](../../README.md#high-level-training-architecture), we have not extensively tested it yet. We will explore this path in the near future, and potentially add API key auth option.
+
+Deploy the agent after it has been configured through either option mentioned above.
+
+```bash
+agentcore deploy --agent strands_math_agent_rl --env BASE_URL=$BASE_URL --env MODEL_ID=$MODEL_ID
+```
+
+### Setup IAM Permissions for ACR
+
+The S3 bucket and SQS queue were already created in the local setup section. Now we need to grant the ACR agent's execution role permission to access them.
+
+```bash
+# Find your rl agent's execution_role in .bedrock_agentcore.yaml and set the role name
+# e.g., arn:aws:iam::123456789:role/AmazonBedrockAgentCoreSDKRuntime-us-west-2-abc123 -> AmazonBedrockAgentCoreSDKRuntime-us-west-2-abc123
+ROLE_NAME="YOUR_ROLE_NAME_HERE"
+
+# Add S3 and SQS permissions to the execution role
+aws iam put-role-policy --role-name $ROLE_NAME \
+  --policy-name RLToolkitAccess \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["s3:PutObject", "s3:GetObject"],
+        "Resource": "arn:aws:s3:::agentcore-rl/*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["sqs:SendMessage"],
+        "Resource": "arn:aws:sqs:*:*:agentcore-rl"
+      }
+    ]
+  }'
+```
+
+### Invoke
+
+```bash
+# Replace {REGION} and {ACCOUNT} with your AWS region and account ID.
+agentcore invoke --agent strands_math_agent_rl '{
+  "prompt": "Toula went to the bakery and bought various types of pastries. She bought 3 dozen donuts which cost $68 per dozen, 2 dozen mini cupcakes which cost $80 per dozen, and 6 dozen mini cheesecakes for $55 per dozen. How much was the total cost?",
+  "answer": "694",
+  "_training": {
+    "exp_id": "test",
+    "sqs_url": "https://sqs.{REGION}.amazonaws.com/{ACCOUNT}/agentcore-rl",
+    "s3_bucket": "agentcore-rl",
+    "session_id": "session_213",
+    "input_id": "prompt_213"
+  }
+}'
+```
+
+You should be able to see the rollout and reward saved to `s3://agentcore-rl/test/prompt_213_session_213.json`.
+
+## Appendix
+
+The following covers instructions for a set of common dev workflows.
+
+### Run Basic App Inside Docker Locally
+
+```bash
+# Make sure you're in examples/strands_math_agent/
 
 # Build Docker
-docker build -t math_rl:dev --load . -f .bedrock_agentcore/examples_strands_math_agent_rl_app/Dockerfile
+docker build -t math:dev --load . -f .bedrock_agentcore/strands_math_agent_basic/Dockerfile
+```
+
+Add AWS credentials to your `.env` file since Docker can't access your host's AWS credential chain. Append these lines:
+
+```bash
+AWS_ACCESS_KEY_ID=your_access_key_id
+AWS_SECRET_ACCESS_KEY=your_secret_access_key
+AWS_REGION=us-west-2
+```
+
+```bash
+# Run Docker
+# Note that we override the docker CMD to avoid cluttering error logs due to missing OTLP collector, which is not set up locally.
+docker run -p 8080:8080 --env-file .env math:dev python -m basic_app
+
+# Submit request
+curl -X POST http://localhost:8080/invocations \
+     -H "Content-Type: application/json" \
+     -d '{"prompt": "Toula went to the bakery and bought various types of pastries. She bought 3 dozen donuts which cost $68 per dozen, 2 dozen mini cupcakes which cost $80 per dozen, and 6 dozen mini cheesecakes for $55 per dozen. How much was the total cost?"}'
+```
+
+### Run RL App Inside Docker Locally
+
+Assume the vLLM server has been set up per the instructions above.
+
+```bash
+# Make sure you're in examples/strands_math_agent/
+
+# Build Docker
+docker build -t math_rl:dev --load . -f .bedrock_agentcore/strands_math_agent_rl/Dockerfile
 
 # Run Docker
 # In addition to overriding the docker CMD, we also directly use the host's network so that the agent
 # can access the locally hosted model via http://localhost:4000/v1. Alternatively, replace `localhost`
 # with IP of your machine in BASE_URL and keep the port mapping (-p 8080:8080)
-docker run --network host --env-file examples/strands_math_agent/.env math_rl:dev python -m rl_app
+docker run --network host --env-file .env math_rl:dev python -m rl_app
 
 # Submit request
 curl -X POST http://localhost:8080/invocations \
@@ -108,10 +276,52 @@ curl -X POST http://localhost:8080/invocations \
        "answer": "694",
        "_training": {
          "exp_id": "test",
-         "sqs_url": "https://sqs.{region}.amazonaws.com/{account_id}/{queue_name}",
-         "s3_bucket": "{bucket_name}",
-         "session_id": "session_123",
-         "input_id": "prompt_123"
+         "sqs_url": "https://sqs.{REGION}.amazonaws.com/{ACCOUNT}/agentcore-rl",
+         "s3_bucket": "agentcore-rl",
+         "session_id": "session_321",
+         "input_id": "prompt_321"
        }
      }'
+```
+
+### Build Docker images for ACR
+Currently, ACR requires ARM64 containers (AWS Graviton), so only containers built on ARM64 machines will work when deployed to agentcore runtime. By default, the `AgentCore CLI` handles this automatically by building ARM64 containers in the cloud with CodeBuild. But if you want to test or debug, you can also build to ARM64 locally using `docker buildx`.
+
+```bash
+# Run only once
+docker buildx create --use
+
+docker buildx build --platform linux/arm64 -t math_rl:dev --load . -f .bedrock_agentcore/strands_math_agent_rl/Dockerfile
+```
+
+### Manual deployment
+Instead of letting `AgentCore CLI` handle everything, we can also build docker image (ARM64) and push to ECR on our own. See `scripts/build_docker_image_and_push_to_ecr.sh` for more detail.
+
+We can also use an existing IAM role for the agent's execution role instead of using the auto-generated one. See [doc](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-permissions.html) for essential permissions for ACR.
+
+```bash
+agentcore configure -e my_agent.py --execution-role arn:aws:iam::111122223333:role/MyRole
+```
+
+And in general, for more manual control over deployment, you can use boto3.
+
+```python
+import boto3
+
+# Create the client
+client = boto3.client('bedrock-agentcore-control', region_name="us-east-1")
+
+# Call the CreateAgentRuntime operation
+response = client.create_agent_runtime(
+    agentRuntimeName='hello-strands',
+    agentRuntimeArtifact={
+        'containerConfiguration': {
+            # Your ECR image Uri
+            'containerUri': '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-agent:latest'
+        }
+    },
+    networkConfiguration={"networkMode":"PUBLIC"},
+    # Your AgentCore Runtime role arn
+    roleArn='arn:aws:iam::123456789012:role/AgentRuntimeRole'
+)
 ```

--- a/examples/strands_math_agent/pyproject.toml
+++ b/examples/strands_math_agent/pyproject.toml
@@ -5,11 +5,7 @@ description = "Example: Strands Math Agent using Bedrock AgentCore RL Toolkit"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "bedrock-agentcore>=1.0.3",
-    "bedrock-agentcore-starter-toolkit<=0.2.0",
-    "boto3>=1.40.55",
-    "python-dotenv>=1.0.0",
-    # TODO: replace the above dependencies with agentcore-rl-toolkit>=0.1.0 after PyPI indexing
+    "agentcore-rl-toolkit>=0.1.0",
     "strands-agents[openai]>=1.18.0",
     "strands-agents-tools>=0.2.16",
 ]


### PR DESCRIPTION
1. Added comprehensive instructions to run the `strands_math_agent` example. 
2. Updated the example's dependency as the project is now published on PyPI. As a result of this, we no longer need to build docker image at the project root. The docker files now reside in the example agent's folder. Instructions on building containers have been updated correspondingly as well.
3. Updated AGENTS.md correspondingly. Also removed some references to code not yet released. 