### PR TITLE
fix: specify main build context in docker build script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,32 +3,32 @@ build/
 dist/
 *.egg-info/
 *.egg
+uv.lock
 
 # Python cache
-__pycache__/
-__pycache__*
-*.py[cod]
-*$py.class
-*.so
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+**/*.so
 .Python
 
 # Virtual environments
-.venv/
+**/.venv/
 .env
-venv/
-env/
+**/venv/
+**/env/
 ENV/
 
 # Testing
-.pytest_cache/
+**/.pytest_cache/
 .coverage
 .coverage*
 htmlcov/
 .tox/
 *.cover
 .hypothesis/
-.mypy_cache/
-.ruff_cache/
+**/.mypy_cache/
+**/.ruff_cache/
 
 # Development
 *.log
@@ -57,6 +57,7 @@ docs/
 
 # Project specific
 tests/
+examples/
 
 # Bedrock AgentCore specific - keep config but exclude runtime files
 .bedrock_agentcore.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,8 @@ uv run pytest tests/
 # Build and push Docker image to ECR (current approach, may change)
 ./scripts/build_docker_image_and_push_to_ecr.sh \
   --dockerfile=examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_rl/Dockerfile \
-  --tag=latest
+  --tag=latest \
+  --context=examples/strands_math_agent
 
 # Run example locally
 cd examples/strands_math_agent && uv sync && uv run python rl_app.py
@@ -288,7 +289,8 @@ This package relies on [bedrock-agentcore-starter-toolkit](https://github.com/aw
    ```bash
    ./scripts/build_docker_image_and_push_to_ecr.sh \
      --dockerfile=examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_rl/Dockerfile \
-     --tag=latest
+     --tag=latest \
+     --context=examples/strands_math_agent
    ```
 3. Training engine takes ECR URI as config for deployment
 4. Environment variables (model inference address, model name, etc.) are injected by the training engine
@@ -350,7 +352,8 @@ uv run pytest tests/
 # Ensure .env is configured with AWS_REGION, AWS_ACCOUNT, ECR_REPO_NAME
 ./scripts/build_docker_image_and_push_to_ecr.sh \
   --dockerfile=examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_rl/Dockerfile \
-  --tag=my-tag
+  --tag=my-tag \
+  --context=examples/strands_math_agent
 ```
 
 ### Running an Example Locally

--- a/README.md
+++ b/README.md
@@ -183,7 +183,10 @@ Then edit `.env` and fill in your values:
 ```bash
 # Use examples/strands_math_agent as an example
 chmod +x scripts/build_docker_image_and_push_to_ecr.sh
-bash ./scripts/build_docker_image_and_push_to_ecr.sh --dockerfile=examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_rl/Dockerfile --tag=dev
+./scripts/build_docker_image_and_push_to_ecr.sh \
+  --dockerfile=examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_rl/Dockerfile \
+  --tag=dev \
+  --context=examples/strands_math_agent
 ```
 
 ### Start Training with veRL


### PR DESCRIPTION
*Description of changes:* 

Due to docker template change, the original build script will pick up the wrong build context when used at the project root. This CR adds an arg to specify the desired build context. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
