### PR TITLE
refactor(app): remove abstract method requirement from AgentCoreRLApp

### DIFF
--- a/src/agentcore_rl_toolkit/app.py
+++ b/src/agentcore_rl_toolkit/app.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 import os
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import wraps
@@ -36,25 +35,31 @@ class TrainingConfig:
             raise ValueError(f"Missing required training config field: {e}") from e
 
 
-class AgentCoreRLApp(BedrockAgentCoreApp, ABC):
+class AgentCoreRLApp(BedrockAgentCoreApp):
     def __init__(self):
         super().__init__()
         self.s3_client = boto3.client("s3")
         self.sqs_client = boto3.client("sqs")
 
-    @abstractmethod
     def create_openai_compatible_model(self, **kwargs):
         """Create an OpenAI-compatible model for this framework.
 
-        Must be implemented by framework-specific subclasses.
+        Optional: Override in framework-specific subclasses, or create model directly
+        in your entrypoint (see examples/strands_migration_agent/dev_app.py).
 
         Args:
             **kwargs: Framework-specific model parameters
 
         Returns:
             Framework-specific model instance configured for vLLM server
+
+        Raises:
+            NotImplementedError: If called without override. Create model directly instead.
         """
-        pass
+        raise NotImplementedError(
+            "create_openai_compatible_model() is optional. "
+            "Either override in a subclass or create your model directly in the entrypoint."
+        )
 
     def _get_model_config(self):
         """Get and validate model configuration from environment."""

--- a/tests/test_rollout_entrypoint.py
+++ b/tests/test_rollout_entrypoint.py
@@ -7,16 +7,9 @@ from starlette.testclient import TestClient
 from agentcore_rl_toolkit import AgentCoreRLApp
 
 
-class MockAgentCoreRLApp(AgentCoreRLApp):
-    """Minimal concrete implementation for testing."""
-
-    def create_openai_compatible_model(self, **kwargs):
-        return None
-
-
 def test_wrapper_signature_has_context():
     """Test that the wrapper's signature includes (payload, context) for BedrockAgentCoreApp."""
-    app = MockAgentCoreRLApp()
+    app = AgentCoreRLApp()
 
     @app.rollout_entrypoint
     async def my_handler(payload: dict):
@@ -32,7 +25,7 @@ def test_wrapper_signature_has_context():
 
 def test_wrapper_preserves_function_name():
     """Test that @wraps preserves the original function name."""
-    app = MockAgentCoreRLApp()
+    app = AgentCoreRLApp()
 
     @app.rollout_entrypoint
     async def my_custom_handler(payload: dict):
@@ -44,7 +37,7 @@ def test_wrapper_preserves_function_name():
 
 def test_entrypoint_with_payload_only():
     """Test that user function with signature (payload) works."""
-    app = MockAgentCoreRLApp()
+    app = AgentCoreRLApp()
 
     @app.rollout_entrypoint
     async def handler(payload: dict):
@@ -59,7 +52,7 @@ def test_entrypoint_with_payload_only():
 
 def test_entrypoint_with_payload_and_context():
     """Test that user function with signature (payload, context) works."""
-    app = MockAgentCoreRLApp()
+    app = AgentCoreRLApp()
 
     @app.rollout_entrypoint
     async def handler(payload: dict, context):
@@ -78,7 +71,7 @@ def test_entrypoint_with_payload_and_context():
 
 def test_entrypoint_with_sync_handler():
     """Test that sync user function works."""
-    app = MockAgentCoreRLApp()
+    app = AgentCoreRLApp()
 
     @app.rollout_entrypoint
     def handler(payload: dict):


### PR DESCRIPTION
*Description of changes:*

- AgentCoreRLApp no longer enforces the `create_openai_compatible_model` contract as the model will be created at the app entry point moving forward to provide more flexibility (passing different inference url, sampling parameters, etc).
- Correspondingly, we no longer need a mock app for unit tests. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
