### PR TITLE
feat(client): add RolloutClient with S3 HEAD polling

### DIFF
--- a/src/agentcore_rl_toolkit/__init__.py
+++ b/src/agentcore_rl_toolkit/__init__.py
@@ -1,6 +1,16 @@
 from .app import AgentCoreRLApp
+from .client import BatchItem, BatchResult, RolloutClient, RolloutFuture
 from .frameworks.strands import StrandsAgentCoreRLApp
 from .frameworks.strands.rollout_collector import RolloutCollector as StrandsRolloutCollector
 from .reward_function import RewardFunction
 
-__all__ = ["AgentCoreRLApp", "StrandsAgentCoreRLApp", "StrandsRolloutCollector", "RewardFunction"]
+__all__ = [
+    "AgentCoreRLApp",
+    "StrandsAgentCoreRLApp",
+    "StrandsRolloutCollector",
+    "RewardFunction",
+    "RolloutClient",
+    "RolloutFuture",
+    "BatchResult",
+    "BatchItem",
+]

--- a/src/agentcore_rl_toolkit/client.py
+++ b/src/agentcore_rl_toolkit/client.py
@@ -1,0 +1,347 @@
+"""Client for invoking agents and collecting rollouts via S3 polling."""
+
+import json
+import time
+import uuid
+from dataclasses import dataclass
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+
+@dataclass
+class BatchItem:
+    """Result wrapper for batch execution, distinguishing success from error.
+
+    Attributes:
+        success: True if the request completed, False if it failed.
+        result: The rollout result dict (populated when success=True).
+        error: Error message (populated when success=False).
+        index: Index of the payload in the original payloads list.
+    """
+
+    success: bool
+    result: dict = None
+    error: str = None
+    index: int = None
+
+
+class RolloutFuture:
+    """Future representing an async rollout result, polled via S3 HEAD."""
+
+    def __init__(
+        self,
+        s3_client,
+        s3_bucket: str,
+        result_key: str,
+        initial_interval: float = 0.5,
+        max_interval: float = 30.0,
+        backoff_factor: float = 1.5,
+    ):
+        self.s3_client = s3_client
+        self.s3_bucket = s3_bucket
+        self.result_key = result_key
+        self._result = None
+        self._done = False
+
+        # Per-future backoff state
+        self._poll_interval = initial_interval
+        self._initial_interval = initial_interval
+        self._max_interval = max_interval
+        self._backoff_factor = backoff_factor
+        self._last_poll_time = 0.0
+
+    def done(self) -> bool:
+        """Check if result is ready (non-blocking). Updates backoff state."""
+        if self._done:
+            return True
+        try:
+            self.s3_client.head_object(Bucket=self.s3_bucket, Key=self.result_key)
+            self._done = True
+            return True
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                # Update backoff state after each poll
+                self._last_poll_time = time.time()
+                self._poll_interval = min(self._poll_interval * self._backoff_factor, self._max_interval)
+                return False
+            raise
+
+    def time_until_next_poll(self) -> float:
+        """Returns seconds until this future should be polled again."""
+        if self._done:
+            return float("inf")
+        elapsed = time.time() - self._last_poll_time
+        return max(0, self._poll_interval - elapsed)
+
+    def ready_to_poll(self) -> bool:
+        """Returns True if enough time has passed since last poll."""
+        return self.time_until_next_poll() <= 0
+
+    def result(self, timeout: float = None) -> dict:
+        """
+        Block until result is ready, polling S3 HEAD with exponential backoff.
+
+        Args:
+            timeout: Max time to wait in seconds. If None, waits indefinitely
+                until the result appears. For long-running tasks, consider
+                setting a timeout to avoid infinite waits if the server fails
+                to save the result.
+
+        Returns:
+            The rollout result dictionary from S3
+
+        Raises:
+            TimeoutError: If timeout is reached before result is ready.
+        """
+        if self._result is not None:
+            return self._result
+
+        start = time.time()
+
+        while True:
+            if self.done():
+                response = self.s3_client.get_object(Bucket=self.s3_bucket, Key=self.result_key)
+                self._result = json.loads(response["Body"].read())
+                return self._result
+
+            if timeout and (time.time() - start) > timeout:
+                raise TimeoutError(f"Result not ready after {timeout}s")
+
+            # Use the per-future backoff interval
+            time.sleep(self._poll_interval)
+
+
+class RolloutClient:
+    """Client for invoking agents and collecting rollouts with full lifecycle management.
+
+    Note:
+        This client is NOT thread-safe. Use separate client instances for
+        concurrent access from multiple threads.
+    """
+
+    def __init__(
+        self,
+        agent_runtime_arn: str,
+        s3_bucket: str,
+        exp_id: str,
+        region: str = None,
+        max_retry_attempts: int = 5,
+        # ACR constraints
+        max_concurrent_sessions: int = 100,
+        tps_limit: int = 25,
+        # Optional model inference config (for vLLM/SGLang servers)
+        base_url: str = None,
+        model_id: str = None,
+        # Additional config passed through to _training (e.g., sampling params)
+        **extra_config,
+    ):
+        """
+        Initialize RolloutClient for invoking agents and collecting rollouts.
+
+        Args:
+            agent_runtime_arn: ARN of the ACR agent runtime
+            s3_bucket: S3 bucket for storing rollout results
+            exp_id: Experiment ID for organizing results
+            region: AWS region (default: from environment)
+            max_retry_attempts: Max retries for transient errors (default: 5)
+            max_concurrent_sessions: Max ACR sessions to run concurrently (default: 100)
+            tps_limit: ACR invocation rate limit (default: 25)
+            base_url: Optional vLLM/SGLang server URL
+            model_id: Optional model ID for inference
+            **extra_config: Additional config passed to _training (e.g., temperature, top_p)
+        """
+        self.agent_runtime_arn = agent_runtime_arn
+        self.s3_bucket = s3_bucket
+        self.exp_id = exp_id
+        self.base_url = base_url
+        self.model_id = model_id
+        self.extra_config = extra_config
+        self.max_concurrent_sessions = max_concurrent_sessions
+        self.tps_limit = tps_limit
+
+        # Configure boto3 with adaptive retry for 429/503
+        config = Config(retries={"max_attempts": max_retry_attempts, "mode": "adaptive"})
+        self.agentcore_client = boto3.client("bedrock-agentcore", region_name=region, config=config)
+        self.s3_client = boto3.client("s3", region_name=region, config=config)
+
+        # Rate limiting state
+        self._last_invoke_time = 0.0
+        self._min_invoke_interval = 1.0 / tps_limit
+
+    def _parse_response(self, response: dict) -> dict:
+        """Parse ACR invocation response."""
+        return json.loads(response["response"].read())
+
+    def _rate_limited_invoke(self, payload: dict, session_id: str, input_id: str) -> RolloutFuture:
+        """Invoke with TPS rate limiting."""
+        # Enforce TPS limit
+        now = time.time()
+        elapsed = now - self._last_invoke_time
+        if elapsed < self._min_invoke_interval:
+            time.sleep(self._min_invoke_interval - elapsed)
+        self._last_invoke_time = time.time()
+
+        # Build rollout config
+        rollout_config = {
+            "exp_id": self.exp_id,
+            "session_id": session_id,
+            "input_id": input_id,
+            "s3_bucket": self.s3_bucket,
+            **self.extra_config,
+        }
+        if self.base_url:
+            rollout_config["base_url"] = self.base_url
+        if self.model_id:
+            rollout_config["model_id"] = self.model_id
+
+        full_payload = {**payload, "_training": rollout_config}
+
+        # Invoke via boto3
+        response = self.agentcore_client.invoke_agent_runtime(
+            agentRuntimeArn=self.agent_runtime_arn,
+            runtimeSessionId=session_id,
+            payload=json.dumps(full_payload),
+        )
+
+        data = self._parse_response(response)
+        return RolloutFuture(
+            s3_client=self.s3_client,
+            s3_bucket=data["s3_bucket"],
+            result_key=data["result_key"],
+        )
+
+    def invoke(self, payload: dict, session_id: str = None, input_id: str = None) -> RolloutFuture:
+        """
+        Single invocation, returns Future for the result.
+
+        Args:
+            payload: The payload to send to the agent
+            session_id: Optional session ID (default: auto-generated UUID)
+            input_id: Optional input ID (default: auto-generated UUID)
+
+        Returns:
+            RolloutFuture that can be awaited or polled for the result
+
+        Usage:
+            future = client.invoke({"prompt": "...", "answer": "42"})
+            result = future.result(timeout=60)
+        """
+        session_id = session_id or str(uuid.uuid4())
+        input_id = input_id or str(uuid.uuid4())
+        return self._rate_limited_invoke(payload, session_id, input_id)
+
+    def run_batch(
+        self,
+        payloads: list[dict],
+        initial_interval: float = 0.5,
+        max_interval: float = 30.0,
+        backoff_factor: float = 1.5,
+    ) -> "BatchResult":
+        """
+        Run batch with full lifecycle management.
+
+        Handles:
+        - TPS rate limiting (default 25/sec)
+        - Session concurrency limiting
+        - Automatic completion polling via S3 HEAD with exponential backoff
+        - Yielding results as they complete
+
+        Note:
+            Results are yielded in completion order, NOT input order. This is more
+            efficient as it doesn't require buffering. Use item.index to
+            correlate results with inputs.
+
+        Args:
+            payloads: List of payloads to process
+            initial_interval: Starting poll interval (default 0.5s)
+            max_interval: Cap on poll interval (default 30s)
+            backoff_factor: Multiply interval by this each poll (default 1.5x)
+
+        Returns:
+            BatchResult iterator that yields BatchItem for each payload
+
+        Usage:
+            for item in client.run_batch(payloads):
+                if item.success:
+                    process(item.result)
+                else:
+                    log.warning(f"Payload {item.index} failed: {item.error}")
+        """
+        return BatchResult(
+            client=self,
+            payloads=payloads,
+            max_concurrent=self.max_concurrent_sessions,
+            initial_interval=initial_interval,
+            max_interval=max_interval,
+            backoff_factor=backoff_factor,
+        )
+
+
+class BatchResult:
+    """Iterator that manages batch execution lifecycle with adaptive polling."""
+
+    def __init__(
+        self,
+        client: RolloutClient,
+        payloads: list[dict],
+        max_concurrent: int,
+        initial_interval: float = 0.5,
+        max_interval: float = 30.0,
+        backoff_factor: float = 1.5,
+    ):
+        self.client = client
+        self.payloads = list(payloads)
+        self.max_concurrent = max_concurrent
+        self.initial_interval = initial_interval
+        self.max_interval = max_interval
+        self.backoff_factor = backoff_factor
+
+    def __iter__(self):
+        """Yield BatchItem as sessions complete, with per-future exponential backoff.
+
+        Yields BatchItem for each payload, with success=True for completed results
+        and success=False for errors. This allows batch processing to continue
+        even when some requests fail.
+        """
+        pending_payloads = list(enumerate(self.payloads))  # (index, payload)
+        active_futures: dict[str, tuple[int, RolloutFuture]] = {}  # key -> (index, future)
+
+        while pending_payloads or active_futures:
+            # Start new sessions up to max_concurrent (respects TPS via _rate_limited_invoke)
+            while pending_payloads and len(active_futures) < self.max_concurrent:
+                idx, payload = pending_payloads.pop(0)
+                session_id = str(uuid.uuid4())
+                input_id = str(uuid.uuid4())
+                try:
+                    future = self.client._rate_limited_invoke(payload, session_id, input_id)
+                    # Override future's backoff settings
+                    future._poll_interval = self.initial_interval
+                    future._initial_interval = self.initial_interval
+                    future._max_interval = self.max_interval
+                    future._backoff_factor = self.backoff_factor
+                    active_futures[future.result_key] = (idx, future)
+                except Exception as e:
+                    yield BatchItem(success=False, error=str(e), index=idx)
+
+            # Poll futures that are ready (per-future backoff)
+            completed_keys = []
+            for key, (idx, future) in active_futures.items():
+                if future.ready_to_poll() and future.done():
+                    completed_keys.append(key)
+                    try:
+                        result = future.result()
+                        yield BatchItem(success=True, result=result, index=idx)
+                    except Exception as e:
+                        yield BatchItem(success=False, error=str(e), index=idx)
+
+            # Remove completed from active
+            for key in completed_keys:
+                del active_futures[key]
+
+            # Sleep until next future is ready to poll
+            if active_futures and not completed_keys:
+                min_wait = min(f.time_until_next_poll() for _, f in active_futures.values())
+                if min_wait > 0:
+                    time.sleep(min_wait)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,439 @@
+"""Tests for RolloutClient, RolloutFuture, and BatchResult."""
+
+import io
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from agentcore_rl_toolkit import BatchItem, BatchResult, RolloutClient, RolloutFuture
+
+
+def mock_streaming_body(data: dict) -> io.BytesIO:
+    """Create a mock StreamingBody-like object for ACR responses."""
+    return io.BytesIO(json.dumps(data).encode())
+
+
+class TestRolloutFuture:
+    """Tests for RolloutFuture S3 polling behavior."""
+
+    def test_done_returns_true_when_object_exists(self):
+        """Test done() returns True when S3 HEAD succeeds."""
+        mock_s3 = MagicMock()
+        mock_s3.head_object.return_value = {}
+
+        future = RolloutFuture(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            result_key="exp/input_session.json",
+        )
+
+        assert future.done() is True
+        assert future._done is True
+        mock_s3.head_object.assert_called_once_with(Bucket="test-bucket", Key="exp/input_session.json")
+
+    def test_done_returns_false_on_404(self):
+        """Test done() returns False when S3 returns 404."""
+        mock_s3 = MagicMock()
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}},
+            "HeadObject",
+        )
+
+        future = RolloutFuture(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            result_key="exp/input_session.json",
+        )
+
+        assert future.done() is False
+        assert future._done is False
+
+    def test_done_updates_backoff_on_404(self):
+        """Test done() increases poll interval after 404."""
+        mock_s3 = MagicMock()
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}},
+            "HeadObject",
+        )
+
+        future = RolloutFuture(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            result_key="exp/input_session.json",
+            initial_interval=1.0,
+            backoff_factor=2.0,
+            max_interval=10.0,
+        )
+
+        assert future._poll_interval == 1.0
+        # Each done() call polls S3 HEAD; on 404, it increases the backoff interval
+        future.done()
+        assert future._poll_interval == 2.0  # 1.0 * 2.0
+        future.done()
+        assert future._poll_interval == 4.0  # 2.0 * 2.0
+        future.done()
+        assert future._poll_interval == 8.0  # 4.0 * 2.0
+        future.done()
+        assert future._poll_interval == 10.0  # capped at max_interval
+
+    def test_done_caches_result(self):
+        """Test done() only calls S3 once after success."""
+        mock_s3 = MagicMock()
+        mock_s3.head_object.return_value = {}
+
+        future = RolloutFuture(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            result_key="exp/input_session.json",
+        )
+
+        assert future.done() is True
+        assert future.done() is True
+        assert future.done() is True
+        mock_s3.head_object.assert_called_once()
+
+    def test_done_raises_on_non_404_error(self):
+        """Test done() raises on non-404 errors."""
+        mock_s3 = MagicMock()
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"}},
+            "HeadObject",
+        )
+
+        future = RolloutFuture(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            result_key="exp/input_session.json",
+        )
+
+        with pytest.raises(ClientError):
+            future.done()
+
+    def test_result_returns_parsed_json(self):
+        """Test result() fetches and parses S3 object."""
+        mock_s3 = MagicMock()
+        mock_s3.head_object.return_value = {}
+
+        mock_body = MagicMock()
+        mock_body.read.return_value = json.dumps({"rollout_data": [], "rewards": [1.0]}).encode()
+        mock_s3.get_object.return_value = {"Body": mock_body}
+
+        future = RolloutFuture(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            result_key="exp/input_session.json",
+        )
+
+        result = future.result()
+
+        assert result == {"rollout_data": [], "rewards": [1.0]}
+        mock_s3.get_object.assert_called_once_with(Bucket="test-bucket", Key="exp/input_session.json")
+
+    def test_result_caches_result(self):
+        """Test result() only fetches once."""
+        mock_s3 = MagicMock()
+        mock_s3.head_object.return_value = {}
+
+        mock_body = MagicMock()
+        mock_body.read.return_value = json.dumps({"data": "test"}).encode()
+        mock_s3.get_object.return_value = {"Body": mock_body}
+
+        future = RolloutFuture(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            result_key="exp/input_session.json",
+        )
+
+        result1 = future.result()
+        result2 = future.result()
+
+        assert result1 == result2
+        mock_s3.get_object.assert_called_once()
+
+    def test_time_until_next_poll(self):
+        """Test time_until_next_poll() returns correct value."""
+        mock_s3 = MagicMock()
+
+        future = RolloutFuture(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            result_key="exp/input_session.json",
+            initial_interval=1.0,
+        )
+
+        # Before any poll, should be ready immediately
+        assert future.time_until_next_poll() <= 0
+
+        # Simulate a poll that returned 404
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}},
+            "HeadObject",
+        )
+        future.done()
+
+        # Just after poll, should wait ~1.5s (initial_interval * backoff_factor)
+        wait_time = future.time_until_next_poll()
+        assert wait_time > 0
+        assert wait_time <= future._poll_interval
+
+    def test_ready_to_poll(self):
+        """Test ready_to_poll() returns True when interval elapsed."""
+        mock_s3 = MagicMock()
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}},
+            "HeadObject",
+        )
+
+        future = RolloutFuture(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            result_key="exp/input_session.json",
+            initial_interval=0.1,  # Short interval for testing
+        )
+
+        # Before any poll
+        assert future.ready_to_poll() is True
+
+        # Right after poll
+        future.done()
+        assert future.ready_to_poll() is False
+
+        # After waiting
+        time.sleep(0.2)
+        assert future.ready_to_poll() is True
+
+
+class TestRolloutClient:
+    """Tests for RolloutClient."""
+
+    def test_init_sets_attributes(self):
+        """Test RolloutClient initializes correctly."""
+        with patch("agentcore_rl_toolkit.client.boto3"):
+            client = RolloutClient(
+                agent_runtime_arn="arn:aws:bedrock-agentcore:us-east-1:123:agent/test",
+                s3_bucket="test-bucket",
+                exp_id="exp-001",
+                region="us-east-1",
+                max_concurrent_sessions=50,
+                tps_limit=10,
+                base_url="http://localhost:8000",
+                model_id="test-model",
+                temperature=0.7,
+            )
+
+            assert client.agent_runtime_arn == "arn:aws:bedrock-agentcore:us-east-1:123:agent/test"
+            assert client.s3_bucket == "test-bucket"
+            assert client.exp_id == "exp-001"
+            assert client.max_concurrent_sessions == 50
+            assert client.tps_limit == 10
+            assert client.base_url == "http://localhost:8000"
+            assert client.model_id == "test-model"
+            assert client.extra_config == {"temperature": 0.7}
+
+    def test_invoke_returns_future(self):
+        """Test invoke() returns a RolloutFuture."""
+        with patch("agentcore_rl_toolkit.client.boto3") as mock_boto3:
+            mock_acr = MagicMock()
+            mock_s3 = MagicMock()
+            mock_boto3.client.side_effect = lambda service, **kwargs: (
+                mock_acr if service == "bedrock-agentcore" else mock_s3
+            )
+
+            # Mock ACR response with StreamingBody-like object
+            mock_acr.invoke_agent_runtime.return_value = {
+                "response": mock_streaming_body(
+                    {"status": "processing", "s3_bucket": "test-bucket", "result_key": "exp/key.json"}
+                )
+            }
+
+            client = RolloutClient(
+                agent_runtime_arn="arn:aws:bedrock-agentcore:us-east-1:123:agent/test",
+                s3_bucket="test-bucket",
+                exp_id="exp-001",
+            )
+
+            future = client.invoke({"prompt": "test"})
+
+            assert isinstance(future, RolloutFuture)
+            assert future.s3_bucket == "test-bucket"
+            assert future.result_key == "exp/key.json"
+
+    def test_invoke_builds_training_config(self):
+        """Test invoke() correctly builds _training config."""
+        with patch("agentcore_rl_toolkit.client.boto3") as mock_boto3:
+            mock_acr = MagicMock()
+            mock_s3 = MagicMock()
+            mock_boto3.client.side_effect = lambda service, **kwargs: (
+                mock_acr if service == "bedrock-agentcore" else mock_s3
+            )
+
+            mock_acr.invoke_agent_runtime.return_value = {
+                "response": mock_streaming_body({"status": "processing", "s3_bucket": "bucket", "result_key": "key"})
+            }
+
+            client = RolloutClient(
+                agent_runtime_arn="arn:aws:test",
+                s3_bucket="test-bucket",
+                exp_id="exp-001",
+                base_url="http://localhost:8000",
+                model_id="test-model",
+                temperature=0.7,
+            )
+
+            client.invoke({"prompt": "test"}, session_id="sess-1", input_id="input-1")
+
+            # Check the payload sent to ACR
+            call_args = mock_acr.invoke_agent_runtime.call_args
+            payload = json.loads(call_args.kwargs["payload"])
+
+            assert payload["prompt"] == "test"
+            assert payload["_training"]["exp_id"] == "exp-001"
+            assert payload["_training"]["session_id"] == "sess-1"
+            assert payload["_training"]["input_id"] == "input-1"
+            assert payload["_training"]["s3_bucket"] == "test-bucket"
+            assert payload["_training"]["base_url"] == "http://localhost:8000"
+            assert payload["_training"]["model_id"] == "test-model"
+            assert payload["_training"]["temperature"] == 0.7
+
+    def test_run_batch_returns_batch_result(self):
+        """Test run_batch() returns a BatchResult."""
+        with patch("agentcore_rl_toolkit.client.boto3"):
+            client = RolloutClient(
+                agent_runtime_arn="arn:aws:test",
+                s3_bucket="test-bucket",
+                exp_id="exp-001",
+            )
+
+            payloads = [{"prompt": "q1"}, {"prompt": "q2"}]
+            result = client.run_batch(payloads)
+
+            assert isinstance(result, BatchResult)
+            assert result.payloads == payloads
+            assert result.max_concurrent == client.max_concurrent_sessions
+
+
+class TestBatchResult:
+    """Tests for BatchResult."""
+
+    def test_batch_yields_all_results(self):
+        """Test iterating over BatchResult yields all results."""
+        with patch("agentcore_rl_toolkit.client.boto3") as mock_boto3:
+            mock_acr = MagicMock()
+            mock_s3 = MagicMock()
+            mock_boto3.client.side_effect = lambda service, **kwargs: (
+                mock_acr if service == "bedrock-agentcore" else mock_s3
+            )
+
+            # Track invoke calls to generate unique keys
+            invoke_count = [0]
+
+            def mock_invoke(*args, **kwargs):
+                invoke_count[0] += 1
+                return {
+                    "response": mock_streaming_body(
+                        {
+                            "status": "processing",
+                            "s3_bucket": "bucket",
+                            "result_key": f"key{invoke_count[0]}.json",
+                        }
+                    )
+                }
+
+            mock_acr.invoke_agent_runtime.side_effect = mock_invoke
+            mock_s3.head_object.return_value = {}
+
+            # Return different results for each key
+            def mock_get_object(Bucket, Key):
+                idx = int(Key.replace("key", "").replace(".json", ""))
+                body = MagicMock()
+                body.read.return_value = json.dumps({"result": idx}).encode()
+                return {"Body": body}
+
+            mock_s3.get_object.side_effect = mock_get_object
+
+            client = RolloutClient(
+                agent_runtime_arn="arn:aws:test",
+                s3_bucket="test-bucket",
+                exp_id="exp-001",
+                tps_limit=1000,  # High limit to speed up test
+            )
+
+            payloads = [{"prompt": "q1"}, {"prompt": "q2"}, {"prompt": "q3"}]
+
+            # Stream results as they complete
+            items = []
+            for item in client.run_batch(payloads):
+                assert isinstance(item, BatchItem)
+                assert item.success is True
+                assert item.error is None
+                items.append(item)
+
+            assert len(items) == 3
+            # Results may not be in order since they complete as they're polled
+            result_values = sorted([item.result["result"] for item in items])
+            assert result_values == [1, 2, 3]
+
+    def test_batch_continues_on_invocation_error(self):
+        """Test that batch continues processing when one invocation fails."""
+        with patch("agentcore_rl_toolkit.client.boto3") as mock_boto3:
+            mock_acr = MagicMock()
+            mock_s3 = MagicMock()
+            mock_boto3.client.side_effect = lambda service, **kwargs: (
+                mock_acr if service == "bedrock-agentcore" else mock_s3
+            )
+
+            # First call succeeds, second fails, third succeeds
+            invoke_count = [0]
+
+            def mock_invoke(*args, **kwargs):
+                invoke_count[0] += 1
+                if invoke_count[0] == 2:
+                    raise Exception("ACR invocation failed")
+                return {
+                    "response": mock_streaming_body(
+                        {
+                            "status": "processing",
+                            "s3_bucket": "bucket",
+                            "result_key": f"key{invoke_count[0]}.json",
+                        }
+                    )
+                }
+
+            mock_acr.invoke_agent_runtime.side_effect = mock_invoke
+            mock_s3.head_object.return_value = {}
+
+            def mock_get_object(Bucket, Key):
+                idx = int(Key.replace("key", "").replace(".json", ""))
+                body = MagicMock()
+                body.read.return_value = json.dumps({"result": idx}).encode()
+                return {"Body": body}
+
+            mock_s3.get_object.side_effect = mock_get_object
+
+            client = RolloutClient(
+                agent_runtime_arn="arn:aws:test",
+                s3_bucket="test-bucket",
+                exp_id="exp-001",
+                tps_limit=1000,
+            )
+
+            payloads = [{"prompt": "q1"}, {"prompt": "q2"}, {"prompt": "q3"}]
+
+            # Stream results, separating successes and errors
+            successes = []
+            errors = []
+            for item in client.run_batch(payloads):
+                if item.success:
+                    successes.append(item)
+                else:
+                    errors.append(item)
+
+            assert len(successes) == 2
+            assert len(errors) == 1
+
+            # Error item should have index and error message
+            assert errors[0].index == 1
+            assert "ACR invocation failed" in errors[0].error


### PR DESCRIPTION
*Description of changes:*

- Add RolloutFuture with per-future exponential backoff
- Add BatchResult iterator for streaming batch results
- Add BatchItem wrapper for success/error distinction
- TPS rate limiting and session concurrency control

With this PR, UX will be streamlined to the following 

```python

from agentcore_rl_toolkit import RolloutClient

client = RolloutClient(...)

# client acknowledges the payload is received, returning the s3 bucket and result key
future = client.invoke(payload)

# under the hood, future.result() repeatedly poll S3 with HEAD to check its existence
result = future.result()
```

SQS will be optional and removed later so users don't have to worry about it. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.