### PR TITLE
refactor(app): remove SQS dependency, use S3-only result delivery

### DIFF
--- a/examples/strands_migration_agent/README.md
+++ b/examples/strands_migration_agent/README.md
@@ -119,7 +119,6 @@ curl -X POST http://localhost:8080/invocations \
     "require_maximal_migration": false,
     "_training": {
         "exp_id": "dev",
-        "sqs_url": "https://sqs.{REGION}.amazonaws.com/{ACCOUNT}/agentcore-rl",
         "s3_bucket": "agentcore-rl",
         "session_id": "session_x",
         "input_id": "prompt_y",

--- a/tests/test_rollout_entrypoint.py
+++ b/tests/test_rollout_entrypoint.py
@@ -102,7 +102,6 @@ def test_response_includes_result_location_with_training_config():
                 "session_id": "sess-456",
                 "input_id": "input-789",
                 "s3_bucket": "my-bucket",
-                "sqs_url": "https://sqs.us-east-1.amazonaws.com/123/queue",
             },
         },
     )


### PR DESCRIPTION
*Description of changes:*
- Replace SQS notification with S3 HEAD polling for rollout results.
- TrainingConfig no longer requires `sqs_url`.
- Update docs and tests to reflect the simplified architecture.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
