### PR TITLE
refactor(app): rename _training to _rollout for the injected config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ Since the client won't get results directly from HTTP:
 **AgentCoreRLApp** (`src/agentcore_rl_toolkit/app.py`)
 - Inherits `BedrockAgentCoreApp` - drop-in replacement
 - Provides `@app.rollout_entrypoint` decorator
-- Expects `_training` dict in payload following `TrainingConfig` model (experiment id, session id, input id)
+- Expects `_rollout` dict in payload following `RolloutConfig` model (experiment id, session id, input id)
 
 **StrandsAgentCoreRLApp** (`src/agentcore_rl_toolkit/frameworks/strands/app.py`)
 - Framework-specific RL app extending `AgentCoreRLApp`
@@ -421,7 +421,6 @@ uv run pre-commit install
 - No CI/CD pipeline yet (planned)
 
 ### Design Improvements
-- **User experience**: `_training` dict requirement is awkward for evaluation use cases; naming is ambiguous
 - **Model creation**: `create_openai_compatible_model()` may need to be separated from `AgentCoreRLApp` for better separation of concerns
 - **Token collection**: Need to collect token IDs directly to avoid retokenization issues causing training instability (see [rLLM SDK](https://rllm-project.readthedocs.io/en/latest/core-concepts/sdk/#1-define-your-agent-function) for reference)
 

--- a/examples/strands_migration_agent/README.md
+++ b/examples/strands_migration_agent/README.md
@@ -117,7 +117,7 @@ curl -X POST http://localhost:8080/invocations \
     "repo_uri": "s3://{BUCKET}/tars/test/15093015999__EJServer/15093015999__EJServer.tar.gz",
     "metadata_uri": "s3://{BUCKET}/tars/test/15093015999__EJServer/metadata.json",
     "require_maximal_migration": false,
-    "_training": {
+    "_rollout": {
         "exp_id": "dev",
         "s3_bucket": "agentcore-rl",
         "session_id": "session_x",

--- a/examples/strands_migration_agent/dev_app.py
+++ b/examples/strands_migration_agent/dev_app.py
@@ -39,8 +39,8 @@ reward_fn = MigrationReward()
 
 @app.rollout_entrypoint
 def invoke_agent(payload: dict):
-    base_url = payload.get("_training", {}).get("base_url")
-    model_id = payload.get("_training", {}).get("model_id")
+    base_url = payload.get("_rollout", {}).get("base_url")
+    model_id = payload.get("_rollout", {}).get("model_id")
 
     model = vLLMModel(
         client_args={"api_key": "abc", "base_url": base_url}, model_id=model_id, params={"max_completion_tokens": 8192}

--- a/src/agentcore_rl_toolkit/client.py
+++ b/src/agentcore_rl_toolkit/client.py
@@ -205,7 +205,7 @@ class RolloutClient:
         # Optional model inference config (for vLLM/SGLang servers)
         base_url: str = None,
         model_id: str = None,
-        # Additional config passed through to _training (e.g., sampling params)
+        # Additional config passed through to _rollout (e.g., sampling params)
         **extra_config,
     ):
         """
@@ -219,7 +219,7 @@ class RolloutClient:
             tps_limit: ACR invocation rate limit (default: 25)
             base_url: Optional vLLM/SGLang server URL
             model_id: Optional model ID for inference
-            **extra_config: Additional config passed to _training (e.g., temperature, top_p)
+            **extra_config: Additional config passed to _rollout (e.g., temperature, top_p)
         """
         self.agent_runtime_arn = agent_runtime_arn
         self.s3_bucket = s3_bucket
@@ -267,7 +267,7 @@ class RolloutClient:
         if self.model_id:
             rollout_config["model_id"] = self.model_id
 
-        full_payload = {**payload, "_training": rollout_config}
+        full_payload = {**payload, "_rollout": rollout_config}
 
         # Invoke via boto3 with timing
         invoke_start = time.time()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -380,8 +380,8 @@ class TestRolloutClient:
             assert future.s3_bucket == "test-bucket"
             assert future.result_key == "exp/key.json"
 
-    def test_invoke_builds_training_config(self):
-        """Test invoke() correctly builds _training config."""
+    def test_invoke_builds_rollout_config(self):
+        """Test invoke() correctly builds _rollout config."""
         with patch("agentcore_rl_toolkit.client.boto3") as mock_boto3:
             mock_acr = MagicMock()
             mock_s3 = MagicMock()
@@ -409,13 +409,13 @@ class TestRolloutClient:
             payload = json.loads(call_args.kwargs["payload"])
 
             assert payload["prompt"] == "test"
-            assert payload["_training"]["exp_id"] == "exp-001"
-            assert payload["_training"]["session_id"] == "sess-1"
-            assert payload["_training"]["input_id"] == "input-1"
-            assert payload["_training"]["s3_bucket"] == "test-bucket"
-            assert payload["_training"]["base_url"] == "http://localhost:8000"
-            assert payload["_training"]["model_id"] == "test-model"
-            assert payload["_training"]["temperature"] == 0.7
+            assert payload["_rollout"]["exp_id"] == "exp-001"
+            assert payload["_rollout"]["session_id"] == "sess-1"
+            assert payload["_rollout"]["input_id"] == "input-1"
+            assert payload["_rollout"]["s3_bucket"] == "test-bucket"
+            assert payload["_rollout"]["base_url"] == "http://localhost:8000"
+            assert payload["_rollout"]["model_id"] == "test-model"
+            assert payload["_rollout"]["temperature"] == 0.7
 
     def test_invoke_future_has_session_id(self):
         """Test invoke() returns future with session_id and agentcore_client set."""

--- a/tests/test_rollout_entrypoint.py
+++ b/tests/test_rollout_entrypoint.py
@@ -84,8 +84,8 @@ def test_entrypoint_with_sync_handler():
     assert response.json() == {"status": "processing"}
 
 
-def test_response_includes_result_location_with_training_config():
-    """Test that response includes s3_bucket and result_key when _training config is provided."""
+def test_response_includes_result_location_with_rollout_config():
+    """Test that response includes s3_bucket and result_key when _rollout config is provided."""
     app = AgentCoreRLApp()
 
     @app.rollout_entrypoint
@@ -97,7 +97,7 @@ def test_response_includes_result_location_with_training_config():
         "/invocations",
         json={
             "prompt": "test",
-            "_training": {
+            "_rollout": {
                 "exp_id": "exp-123",
                 "session_id": "sess-456",
                 "input_id": "input-789",
@@ -113,8 +113,8 @@ def test_response_includes_result_location_with_training_config():
     assert result["result_key"] == "exp-123/input-789_sess-456.json"
 
 
-def test_response_without_training_config():
-    """Test that response is minimal when no _training config is provided."""
+def test_response_without_rollout_config():
+    """Test that response is minimal when no _rollout config is provided."""
     app = AgentCoreRLApp()
 
     @app.rollout_entrypoint


### PR DESCRIPTION
*Description of changes:*

For the injected config, rename from "_training" to "_rollout" to avoid semantic confusion, as the fields will be used for both evaluation and training (rollout in general). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
