### PR TITLE
fix(app): validate rollout config before launching background task

### DIFF
--- a/tests/test_rollout_entrypoint.py
+++ b/tests/test_rollout_entrypoint.py
@@ -2,6 +2,7 @@
 
 import inspect
 
+import pytest
 from starlette.testclient import TestClient
 
 from agentcore_rl_toolkit import AgentCoreRLApp
@@ -129,3 +130,50 @@ def test_response_without_rollout_config():
     assert result == {"status": "processing"}
     assert "s3_bucket" not in result
     assert "result_key" not in result
+
+
+def test_entrypoint_rejects_empty_rollout_config():
+    """Test that _rollout: {} returns HTTP 500 with missing field error."""
+    app = AgentCoreRLApp()
+
+    @app.rollout_entrypoint
+    async def handler(payload: dict):
+        return {"rollout_data": [{"test": True}], "rewards": [1.0]}
+
+    client = TestClient(app)
+    response = client.post(
+        "/invocations",
+        json={"prompt": "test", "_rollout": {}},
+    )
+
+    assert response.status_code == 500
+    assert "Missing required rollout config field" in response.json()["error"]
+
+
+@pytest.mark.parametrize("missing_field", ["exp_id", "session_id", "input_id", "s3_bucket"])
+def test_entrypoint_rejects_rollout_config_missing_single_field(missing_field):
+    """Test that omitting any single required field returns HTTP 500 with the field name in error."""
+    app = AgentCoreRLApp()
+
+    @app.rollout_entrypoint
+    async def handler(payload: dict):
+        return {"rollout_data": [{"test": True}], "rewards": [1.0]}
+
+    complete_config = {
+        "exp_id": "exp-123",
+        "session_id": "sess-456",
+        "input_id": "input-789",
+        "s3_bucket": "my-bucket",
+    }
+    incomplete_config = {k: v for k, v in complete_config.items() if k != missing_field}
+
+    client = TestClient(app)
+    response = client.post(
+        "/invocations",
+        json={"prompt": "test", "_rollout": incomplete_config},
+    )
+
+    assert response.status_code == 500
+    error_msg = response.json()["error"]
+    assert "Missing required rollout config field" in error_msg
+    assert missing_field in error_msg


### PR DESCRIPTION
*Description of changes:*

Move RolloutConfig.from_dict() into rollout_entrypoint_wrapper so missing fields from injected `_rollout` config (e.g., s3 bucket) return HTTP 500 immediately instead of returning seemingly normally and failing after the agent completes the rollout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
