### PR TITLE
refactor(app): derive session_id from ACR header instead of _rollout payload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,7 @@ Since the client won't get results directly from HTTP:
 **AgentCoreRLApp** (`src/agentcore_rl_toolkit/app.py`)
 - Inherits `BedrockAgentCoreApp` - drop-in replacement
 - Provides `@app.rollout_entrypoint` decorator
-- Expects `_rollout` dict in payload following `RolloutConfig` model (experiment id, session id, input id, base_url, model_id)
+- Expects `_rollout` dict in payload following `RolloutConfig` model (experiment id, input id, s3_bucket, base_url, model_id)
 - Framework-agnostic: works with any agent framework, not just Strands
 
 #### Utilities

--- a/src/agentcore_rl_toolkit/client.py
+++ b/src/agentcore_rl_toolkit/client.py
@@ -257,7 +257,6 @@ class RolloutClient:
         # Build rollout config
         rollout_config = {
             "exp_id": self.exp_id,
-            "session_id": session_id,
             "input_id": input_id,
             "s3_bucket": self.s3_bucket,
             **self.extra_config,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -410,7 +410,6 @@ class TestRolloutClient:
 
             assert payload["prompt"] == "test"
             assert payload["_rollout"]["exp_id"] == "exp-001"
-            assert payload["_rollout"]["session_id"] == "sess-1"
             assert payload["_rollout"]["input_id"] == "input-1"
             assert payload["_rollout"]["s3_bucket"] == "test-bucket"
             assert payload["_rollout"]["base_url"] == "http://localhost:8000"


### PR DESCRIPTION
*Description of changes:*

- Move session_id out of RolloutConfig and instead read it from the ACR-provided HTTP header (context.session_id), falling back to UUID for local testing. 
- This simplifies the client payload and ensures the S3 key uses the authoritative ACR session identity.
- Slightly unrelated, but the s3 result key is now `exp_id/input_id/session_id.json` instead of a flat `exp_id/input_id_session_id.json` for easier per-prompt grouping and analysis. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
