### PR TITLE
feat(client): add input_id attribute to RolloutFuture

### DIFF
--- a/src/agentcore_rl_toolkit/client.py
+++ b/src/agentcore_rl_toolkit/client.py
@@ -45,6 +45,7 @@ class RolloutFuture:
         max_interval: float = 30.0,
         backoff_factor: float = 1.5,
         session_id: str = None,
+        input_id: str = None,
         agentcore_client=None,
         agent_runtime_arn: str = None,
     ):
@@ -52,6 +53,7 @@ class RolloutFuture:
         self.s3_bucket = s3_bucket
         self.result_key = result_key
         self.session_id = session_id
+        self.input_id = input_id
         self.agentcore_client = agentcore_client
         self.agent_runtime_arn = agent_runtime_arn
         self._result = None
@@ -284,6 +286,7 @@ class RolloutClient:
             s3_bucket=data["s3_bucket"],
             result_key=data["result_key"],
             session_id=session_id,
+            input_id=input_id,
             agentcore_client=self.agentcore_client,
             agent_runtime_arn=self.agent_runtime_arn,
         )


### PR DESCRIPTION
*Description of changes:*

Enables callers to group rollout futures by input before results arrive, which is needed for GRPO-style training.

Code example:

```python
import uuid                                                                                                       
from collections import defaultdict
from agentcore_rl_toolkit import RolloutClient                                                                    
                
client = RolloutClient(
    agent_runtime_arn="arn:aws:bedrock-agentcore:us-west-2:123:agent/my-agent",
    s3_bucket="my-rollout-bucket",
    exp_id="grpo-exp-001",
    base_url="http://training-cluster:8000/v1",
    model_id="my-policy-model",
)

# GRPO: N rollouts per input
inputs = [
    {"prompt": "What is 2+3?", "answer": "5"},
    {"prompt": "What is 7*8?", "answer": "56"},
]
N = 4  # rollouts per input

# Fire off all rollouts, tagging each future with its input_id
futures = []
for item in inputs:
    input_id = str(uuid.uuid4())
    for _ in range(N):
        future = client.invoke(item, input_id=input_id)
        futures.append(future)

# Group futures by input_id *before* any results arrive
groups = defaultdict(list)
for f in futures:
    groups[f.input_id].append(f)

# Process each group — all N rollouts for the same input together
for input_id, group in groups.items():
    results = [f.result(timeout=300) for f in group]
    rewards = [r["rewards"] for r in results]
    rollouts = [r["rollout_data"] for r in results]
    # Feed (rollouts, rewards) into GRPO update for this input
    print(f"Input: {input_id}  rewards: {rewards}")


```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
