### PR TITLE
fix(migration-agent): reduce context explosion from spammy Maven output and agent loops

### DIFF
--- a/examples/strands_migration_agent/Dockerfile
+++ b/examples/strands_migration_agent/Dockerfile
@@ -40,7 +40,14 @@ ENV PATH=$MAVEN_HOME/bin:$PATH
 
 RUN echo "=== Maven Installation Verification ===" && mvn --version
 
-# 3. Install git
+# 3. Install Node.js (prevents some frontend plugins from downloading it
+#    at runtime, which incurs latency & introduces spammy logs)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nodejs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# 4. Install git
 RUN apt-get update && \
     apt-get install -y git && \
     apt-get clean && \

--- a/examples/strands_migration_agent/dev_app.py
+++ b/examples/strands_migration_agent/dev_app.py
@@ -28,10 +28,13 @@ system_prompt = (
     + "functional equivalence as the original repo in Java8, which means no additional "
     + "test should be ignored, skipped or disabled for the purpose of this migration.\n"
     + "Do not perform any work outside the repository folder the user provides.\n"
-    + "Tips:\n- When executing maven commands, try to keep the logs concise by filtering "
-    + "out unuseful information. For example, use the `-ntp` flag (e.g., mvn -ntp clean verify) "
-    + "to suppress download chatters; use `tail` or `head` to get logs progressively, "
-    + "if needed (e.g. mvn -ntp clean verify | tail -n 50)."
+    + "Rules:\n"
+    + "- Always use the `-ntp` flag with Maven to suppress download logs.\n"
+    + "- Always pipe Maven output through `tail -n 100` to limit output size. "
+    + "Example: mvn -ntp clean verify 2>&1 | tail -n 100\n"
+    + "- If you need to see earlier output, run a separate command with `head -n 100`.\n"
+    + "- When you have finished the task, generate a paragraph summarizing the changes you made "
+    + "without using any tools."
 )
 
 reward_fn = MigrationReward()

--- a/examples/strands_migration_agent/utils.py
+++ b/examples/strands_migration_agent/utils.py
@@ -31,18 +31,23 @@ def load_metadata_from_s3(s3_uri: str) -> dict:
 
 def setup_repo_environment(repo_path: str):
     """
-    1. Attempt to download dependencies (best-effort)
+    1. Pre-warm Maven caches (best-effort)
     2. Make sure git works.
     """
+    # Run full build lifecycle to pre-warm all caches: project dependencies,
+    # plugin dependencies, and plugin runtime downloads (e.g. frontend-maven-plugin
+    # fetching Node.js) that `dependency:go-offline` would miss.
+    # The build will likely fail (repo is still Java 8), but that's fine —
+    # the goal is to cache downloads so the agent's later `mvn clean verify` is quieter.
     result = subprocess.run(
-        ["mvn", "dependency:resolve", "-ntp"],
+        ["mvn", "clean", "verify"],
         cwd=repo_path,
         capture_output=True,
     )
     if result.returncode == 0:
-        logger.info("Dependencies downloaded successfully")
+        logger.info("Pre-warm build succeeded")
     else:
-        logger.warning("Dependency resolution failed (agent will handle during migration)")
+        logger.info("Pre-warm build failed (expected — repo not yet migrated)")
 
     # ensure git works
     subprocess.run(


### PR DESCRIPTION
*Description of changes:*

Mainly improvements on the strands migration agent example:
- Pre-install Node.js in Docker image to avoid runtime download
- Tighten system prompt to enforce output limits and clean termination,
- Pre-warm full Maven build lifecycle to cache plugin dependencies.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
