### PR TITLE
fix(app, example): fix vLLMModel bug and change math agent docker

### DIFF
--- a/examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_dev/Dockerfile
+++ b/examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_dev/Dockerfile
@@ -10,20 +10,12 @@ ENV UV_SYSTEM_PYTHON=1 \
     AWS_REGION=us-west-2 \
     AWS_DEFAULT_REGION=us-west-2
 
-
-
 COPY . .
-# Install from pyproject.toml directory
-RUN cd . && uv pip install .
-
-
-
+# Install local toolkit from build context, then install example deps
+RUN --mount=type=bind,from=toolkit,source=.,target=/toolkit \
+    uv pip install /toolkit && uv pip install .
 
 RUN uv pip install aws-opentelemetry-distro==0.12.2
-
-
-# Signal that this is running in Docker for host binding logic
-ENV DOCKER_CONTAINER=1
 
 # Create non-root user
 RUN useradd -m -u 1000 bedrock_agentcore
@@ -33,9 +25,5 @@ EXPOSE 9000
 EXPOSE 8000
 EXPOSE 8080
 
-# Copy entire project (respecting .dockerignore)
-COPY . .
-
 # Use the full module path
-
 CMD ["opentelemetry-instrument", "python", "-m", "rl_app"]

--- a/examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_rl/Dockerfile
+++ b/examples/strands_math_agent/.bedrock_agentcore/strands_math_agent_rl/Dockerfile
@@ -10,20 +10,12 @@ ENV UV_SYSTEM_PYTHON=1 \
     AWS_REGION=us-west-2 \
     AWS_DEFAULT_REGION=us-west-2
 
-
-
 COPY . .
-# Install from pyproject.toml directory
-RUN cd . && uv pip install .
-
-
-
+# Install local toolkit from build context, then install example deps
+RUN --mount=type=bind,from=toolkit,source=.,target=/toolkit \
+    uv pip install /toolkit && uv pip install .
 
 RUN uv pip install aws-opentelemetry-distro==0.12.2
-
-
-# Signal that this is running in Docker for host binding logic
-ENV DOCKER_CONTAINER=1
 
 # Create non-root user
 RUN useradd -m -u 1000 bedrock_agentcore
@@ -33,9 +25,5 @@ EXPOSE 9000
 EXPOSE 8000
 EXPOSE 8080
 
-# Copy entire project (respecting .dockerignore)
-COPY . .
-
 # Use the full module path
-
 CMD ["opentelemetry-instrument", "python", "-m", "rl_app"]

--- a/examples/strands_math_agent/README.md
+++ b/examples/strands_math_agent/README.md
@@ -243,7 +243,7 @@ Assume the vLLM server has been set up per the instructions above.
 # Make sure you're in examples/strands_math_agent/
 
 # Build Docker
-docker build --build-context toolkit=../.. -t math_rl:dev --load . -f .bedrock_agentcore/strands_math_agent_rl/Dockerfile
+docker build --build-context toolkit=../.. -t math_rl:dev --load . -f .bedrock_agentcore/strands_math_agent_dev/Dockerfile
 
 # Run Docker
 # In addition to overriding the docker CMD, we also directly use the host's network so that the agent
@@ -275,7 +275,7 @@ Currently, ACR requires ARM64 containers (AWS Graviton), so only containers buil
 # Run only once
 docker buildx create --use
 
-docker buildx build --build-context toolkit=../.. --platform linux/arm64 -t math_rl:dev --load . -f .bedrock_agentcore/strands_math_agent_rl/Dockerfile
+docker buildx build --build-context toolkit=../.. --platform linux/arm64 -t math_rl:dev --load . -f .bedrock_agentcore/strands_math_agent_dev/Dockerfile
 ```
 
 ### Manual deployment

--- a/examples/strands_math_agent/README.md
+++ b/examples/strands_math_agent/README.md
@@ -243,7 +243,7 @@ Assume the vLLM server has been set up per the instructions above.
 # Make sure you're in examples/strands_math_agent/
 
 # Build Docker
-docker build -t math_rl:dev --load . -f .bedrock_agentcore/strands_math_agent_rl/Dockerfile
+docker build --build-context toolkit=../.. -t math_rl:dev --load . -f .bedrock_agentcore/strands_math_agent_rl/Dockerfile
 
 # Run Docker
 # In addition to overriding the docker CMD, we also directly use the host's network so that the agent
@@ -275,7 +275,7 @@ Currently, ACR requires ARM64 containers (AWS Graviton), so only containers buil
 # Run only once
 docker buildx create --use
 
-docker buildx build --platform linux/arm64 -t math_rl:dev --load . -f .bedrock_agentcore/strands_math_agent_rl/Dockerfile
+docker buildx build --build-context toolkit=../.. --platform linux/arm64 -t math_rl:dev --load . -f .bedrock_agentcore/strands_math_agent_rl/Dockerfile
 ```
 
 ### Manual deployment

--- a/examples/strands_math_agent/rl_app.py
+++ b/examples/strands_math_agent/rl_app.py
@@ -34,10 +34,12 @@ def invoke_agent(payload: dict):
     """
     base_url = payload["_rollout"]["base_url"]
     model_id = payload["_rollout"]["model_id"]
+    params = payload["_rollout"].get("sampling_params", {})
 
     model = vLLMModel(
         client_args={"api_key": "EMPTY", "base_url": base_url},
         model_id=model_id,
+        params=params,
     )
 
     agent = Agent(

--- a/src/agentcore_rl_toolkit/frameworks/strands/vllm_model.py
+++ b/src/agentcore_rl_toolkit/frameworks/strands/vllm_model.py
@@ -43,7 +43,9 @@ class vLLMModel(OpenAIModel):
         request = super().format_request(messages, tool_specs, system_prompt, tool_choice, **kwargs)
         request["stream"] = False
         request.pop("stream_options", None)
-        request["extra_body"] = {"return_token_ids": True}
+        existing_extra = request.get("extra_body", {})
+        existing_extra["return_token_ids"] = True
+        request["extra_body"] = existing_extra
         return request
 
     @override


### PR DESCRIPTION
Avoid removing existing extra_body dict in vLLMModel, pass sampling params to math rl_app, and change math agent Docker to install agentcore-rl-toolkit from toolkit path.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
