### PR TITLE
feat(client): add async methods to RolloutClient and RolloutFuture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,16 +304,46 @@ This package relies on [bedrock-agentcore-starter-toolkit](https://github.com/aw
 
 Users can evaluate agents before and after training using the same `rl_app.py`.
 
-**RolloutClient** (`src/agentcore_rl_toolkit/client.py`) provides two invocation patterns:
+**RolloutClient** (`src/agentcore_rl_toolkit/client.py`) provides both sync and async invocation patterns:
+
+**Sync API** (blocking — suitable for scripts and simple loops):
 - **`invoke()`**: Returns a `RolloutFuture` for fine-grained control — ideal for training loops (e.g., GRPO) where you submit individual rollouts and group results by `input_id`
 - **`run_batch()`**: Higher-level API for batch evaluation — manages concurrency, timeouts, and polling automatically
 
-Concretely, `invoke()` sends the request to ACR and returns a `RolloutFuture` immediately — meaning ACR has received the request and a background agent session is processing it. Calling `future.result(timeout=...)` blocks until the result appears in S3, polling with exponential backoff. It returns the complete rollout data (token IDs, rewards, etc.) once the agent finishes and writes to S3.
+**Async API** (non-blocking — suitable for `asyncio` event loops in RL training frameworks):
+- **`invoke_async()`**: Like `invoke()` but doesn't block the event loop. Cold starts on one request don't block submission of others.
+- **`run_batch_async()`**: Like `run_batch()` but returns an async iterator with concurrent submission.
+- **`RolloutFuture`** supports `await future`, `future.result_async(timeout=...)`, and `future.done_async()`.
 
-Both patterns share the same infrastructure:
+Concretely, `invoke()` / `invoke_async()` sends the request to ACR and returns a `RolloutFuture` immediately — meaning ACR has received the request and a background agent session is processing it. Calling `future.result(timeout=...)` or `await future.result_async(timeout=...)` blocks/waits until the result appears in S3, polling with exponential backoff. It returns the complete rollout data (token IDs, rewards, etc.) once the agent finishes and writes to S3.
+
+Both sync and async patterns share the same infrastructure:
 - **Rate limiting**: Handles ACR TPS limits (25)
 - **Concurrency control**: Manages ACR session limits (1000/account) and model API rate limits
 - **S3 HEAD polling**: Polls S3 for completed results using efficient HEAD requests
+
+**Async usage example:**
+
+```python
+import asyncio
+from agentcore_rl_toolkit import RolloutClient
+
+client = RolloutClient(agent_runtime_arn="arn:...", s3_bucket="my-bucket", exp_id="exp-1")
+
+async def run():
+    # Fire all requests concurrently (cold starts don't block each other)
+    tasks = [asyncio.create_task(client.invoke_async(p)) for p in payloads]
+    futures = await asyncio.gather(*tasks)
+
+    # Wait for all results concurrently
+    results = await asyncio.gather(*[f.result_async(timeout=300) for f in futures])
+    # Or without timeout: results = await asyncio.gather(*futures)
+
+    # Or use run_batch_async for managed concurrency:
+    async for item in client.run_batch_async(payloads, max_concurrent_sessions=100):
+        if item.success:
+            process(item.result)
+```
 
 **Note:** For evaluation, pass the appropriate `base_url`, `model_id`, and optionally `sampling_params` in the `_rollout` payload to point to the desired inference server (training cluster or hosted cloud model).
 
@@ -435,7 +465,6 @@ uv run pre-commit install
 
 ### Design Improvements
 - **Model gateway**: `vLLMModel` is currently framework specific under `frameworks/strands/`. In the future, we want to eliminate the need for a customized model to collect token ids. Instead, a gateway server will be used to direct model inference calls, automatically intercept the token ids, and persist to databases so that users don't have to manually collect them. This will also better reveal the status of a rollout session and preserve partial rollouts.
-- **Async client**: `RolloutClient` and `RolloutFuture` are currently synchronous (blocking). We plan to add async-compatible versions so they can be used natively in `asyncio` event loops.
 
 ---
 

--- a/examples/strands_migration_agent/eval_utils.py
+++ b/examples/strands_migration_agent/eval_utils.py
@@ -1,0 +1,70 @@
+"""Shared utilities for evaluation scripts."""
+
+import json
+from pathlib import Path
+
+import boto3
+import tomllib
+
+
+def load_config(config_path: str = "config.toml") -> dict:
+    """Load configuration from TOML file if it exists."""
+    path = Path(__file__).parent / config_path
+    if path.exists():
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    return {}
+
+
+def get_s3_folder_uris(s3_uri: str) -> list[str]:
+    """
+    Get full S3 URIs for folders under a specific S3 path.
+
+    Args:
+        s3_uri: Can be full URI (s3://bucket/prefix/) or just bucket name
+    """
+    path = s3_uri.replace("s3://", "")
+    bucket_name = path.split("/")[0]
+    prefix = "/".join(path.split("/")[1:])
+
+    s3 = boto3.client("s3")
+
+    folder_uris = []
+    paginator = s3.get_paginator("list_objects_v2")
+
+    for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix, Delimiter="/"):
+        for prefix_obj in page.get("CommonPrefixes", []):
+            folder_path = prefix_obj["Prefix"]
+            folder_uris.append(f"s3://{bucket_name}/{folder_path}")
+
+    return folder_uris
+
+
+def prepare_payload(folder_uri: str) -> dict:
+    """
+    Prepare a single payload for a repository folder.
+
+    Args:
+        folder_uri: S3 folder URI like "s3://migration-bench/15093015999__EJServer/"
+
+    Returns:
+        Payload dictionary (without _rollout config, RolloutClient adds that)
+    """
+    folder_uri = folder_uri.rstrip("/")
+    repo_name = folder_uri.split("/")[-1]
+
+    repo_uri = f"{folder_uri}/{repo_name}.tar.gz"
+    metadata_uri = f"{folder_uri}/metadata.json"
+
+    return {
+        "prompt": "Please help migrate this repo: {repo_path}. There are {num_tests} test cases in it.",
+        "repo_uri": repo_uri,
+        "metadata_uri": metadata_uri,
+        "require_maximal_migration": False,
+    }
+
+
+def append_result_to_file(result_path: Path, item_data: dict):
+    """Append a single result to the JSON file (one JSON object per line)."""
+    with open(result_path, "a") as f:
+        f.write(json.dumps(item_data) + "\n")

--- a/examples/strands_migration_agent/evaluate.py
+++ b/examples/strands_migration_agent/evaluate.py
@@ -1,81 +1,16 @@
 """Evaluation script for migration agent using RolloutClient.run_batch()."""
 
 import argparse
-import json
 import logging
 import time
 from pathlib import Path
 
-import boto3
-import tomllib
+from eval_utils import append_result_to_file, get_s3_folder_uris, load_config, prepare_payload
 
 from agentcore_rl_toolkit import RolloutClient
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-def load_config(config_path: str = "config.toml") -> dict:
-    """Load configuration from TOML file if it exists."""
-    path = Path(__file__).parent / config_path
-    if path.exists():
-        with open(path, "rb") as f:
-            return tomllib.load(f)
-    return {}
-
-
-def get_s3_folder_uris(s3_uri: str) -> list[str]:
-    """
-    Get full S3 URIs for folders under a specific S3 path.
-
-    Args:
-        s3_uri: Can be full URI (s3://bucket/prefix/) or just bucket name
-    """
-    path = s3_uri.replace("s3://", "")
-    bucket_name = path.split("/")[0]
-    prefix = "/".join(path.split("/")[1:])
-
-    s3 = boto3.client("s3")
-
-    folder_uris = []
-    paginator = s3.get_paginator("list_objects_v2")
-
-    for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix, Delimiter="/"):
-        for prefix_obj in page.get("CommonPrefixes", []):
-            folder_path = prefix_obj["Prefix"]
-            folder_uris.append(f"s3://{bucket_name}/{folder_path}")
-
-    return folder_uris
-
-
-def prepare_payload(folder_uri: str) -> dict:
-    """
-    Prepare a single payload for a repository folder.
-
-    Args:
-        folder_uri: S3 folder URI like "s3://migration-bench/15093015999__EJServer/"
-
-    Returns:
-        Payload dictionary (without _rollout config, RolloutClient adds that)
-    """
-    folder_uri = folder_uri.rstrip("/")
-    repo_name = folder_uri.split("/")[-1]
-
-    repo_uri = f"{folder_uri}/{repo_name}.tar.gz"
-    metadata_uri = f"{folder_uri}/metadata.json"
-
-    return {
-        "prompt": "Please help migrate this repo: {repo_path}. There are {num_tests} test cases in it.",
-        "repo_uri": repo_uri,
-        "metadata_uri": metadata_uri,
-        "require_maximal_migration": False,
-    }
-
-
-def append_result_to_file(result_path: Path, item_data: dict):
-    """Append a single result to the JSON file (one JSON object per line)."""
-    with open(result_path, "a") as f:
-        f.write(json.dumps(item_data) + "\n")
 
 
 def main():

--- a/examples/strands_migration_agent/evaluate_async.py
+++ b/examples/strands_migration_agent/evaluate_async.py
@@ -1,0 +1,279 @@
+"""Async evaluation script for migration agent using RolloutClient async APIs."""
+
+import argparse
+import asyncio
+import logging
+import time
+from pathlib import Path
+
+from eval_utils import append_result_to_file, get_s3_folder_uris, load_config, prepare_payload
+
+from agentcore_rl_toolkit import RolloutClient
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def run_batch_mode(client, payloads, s3_folder_uris, result_path, max_concurrent, timeout):
+    """Run evaluation using client.run_batch_async() — managed async batch lifecycle."""
+    completed = 0
+    succeeded = 0
+    failed = 0
+    task_successes = 0
+
+    async for item in client.run_batch_async(payloads, max_concurrent_sessions=max_concurrent, timeout=timeout):
+        completed += 1
+
+        record = {
+            "index": item.index,
+            "success": item.success,
+            "input_uri": s3_folder_uris[item.index],
+        }
+
+        if item.success:
+            succeeded += 1
+            record["result"] = item.result
+            record["elapsed"] = item.elapsed
+            rewards = item.result.get("rewards", [])
+            if rewards and rewards[0] == 1:
+                task_successes += 1
+            logger.info(
+                f"[{completed}/{len(payloads)}] Index {item.index} completed in {item.elapsed:.1f}s - "
+                f"rewards: {rewards}"
+            )
+        else:
+            failed += 1
+            record["error"] = item.error
+            record["elapsed"] = item.elapsed
+            logger.warning(
+                f"[{completed}/{len(payloads)}] Index {item.index} failed in {item.elapsed:.1f}s: {item.error}"
+            )
+
+        append_result_to_file(result_path, record)
+
+    return succeeded, failed, task_successes
+
+
+async def run_individual_mode(client, payloads, s3_folder_uris, result_path, timeout):
+    """Run evaluation using invoke_async() + gather — two-step pattern for training frameworks."""
+    # Step 1: Fire all invoke_async concurrently
+    # (rate limiter paces at 25 TPS, cold starts don't block each other)
+    # return_exceptions=True so one failed submission doesn't cancel the rest
+    submit_tasks = [asyncio.create_task(client.invoke_async(p)) for p in payloads]
+    submit_results = await asyncio.gather(*submit_tasks, return_exceptions=True)
+
+    # Separate successful futures from submission failures
+    futures = []  # (idx, RolloutFuture)
+    submit_failures = []  # (idx, Exception)
+    for idx, result in enumerate(submit_results):
+        if isinstance(result, BaseException):
+            submit_failures.append((idx, result))
+        else:
+            futures.append((idx, result))
+
+    if submit_failures:
+        logger.warning(f"{len(submit_failures)} submissions failed, {len(futures)} succeeded")
+    logger.info(f"{len(futures)} requests submitted, gathering results...")
+
+    # Step 2: Gather all results concurrently
+    results = await asyncio.gather(
+        *[f.result_async(timeout=timeout) for _, f in futures],
+        return_exceptions=True,
+    )
+
+    # Process results
+    succeeded = 0
+    failed = 0
+    task_successes = 0
+
+    # Record submission failures first
+    for idx, exc in submit_failures:
+        failed += 1
+        record = {
+            "index": idx,
+            "input_uri": s3_folder_uris[idx],
+            "success": False,
+            "error": f"Submission failed: {exc}",
+            "elapsed": 0.0,
+        }
+        logger.warning(f"[{failed}/{len(payloads)}] Index {idx} submission failed: {exc}")
+        append_result_to_file(result_path, record)
+
+    # Record gather results
+    for i, result in enumerate(results):
+        idx, future = futures[i]
+        record = {
+            "index": idx,
+            "input_uri": s3_folder_uris[idx],
+        }
+
+        if isinstance(result, BaseException):
+            failed += 1
+            record["success"] = False
+            record["error"] = str(result)
+            record["elapsed"] = future.elapsed()
+            logger.warning(
+                f"[{succeeded + failed}/{len(payloads)}] Index {idx} failed " f"in {future.elapsed():.1f}s: {result}"
+            )
+        else:
+            succeeded += 1
+            record["success"] = True
+            record["result"] = result
+            record["elapsed"] = future.elapsed()
+            rewards = result.get("rewards", [])
+            if rewards and rewards[0] == 1:
+                task_successes += 1
+            logger.info(
+                f"[{succeeded + failed}/{len(payloads)}] Index {idx} completed "
+                f"in {future.elapsed():.1f}s - rewards: {rewards}"
+            )
+
+        append_result_to_file(result_path, record)
+
+    return succeeded, failed, task_successes
+
+
+async def main():
+    config = load_config()
+    agentcore_config = config.get("agentcore", {})
+    eval_config = config.get("eval", {})
+
+    parser = argparse.ArgumentParser(description="Async evaluation of migration agent on benchmark")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=["batch", "individual"],
+        default="batch",
+        help="Evaluation mode: 'batch' uses run_batch_async, 'individual' uses invoke_async + gather",
+    )
+    parser.add_argument(
+        "--agent_arn",
+        type=str,
+        default=agentcore_config.get("agent_arn"),
+        help="Agent ARN (example: arn:aws:bedrock-agentcore:{region}:{account_id}:runtime/{agent_id})",
+    )
+    parser.add_argument(
+        "--s3_input_bucket",
+        type=str,
+        default=eval_config.get("s3_input_bucket"),
+        help="S3 bucket for retrieving input repositories",
+    )
+    parser.add_argument(
+        "--s3_output_bucket",
+        type=str,
+        default=eval_config.get("s3_output_bucket"),
+        help="S3 bucket for storing rollout results",
+    )
+    parser.add_argument(
+        "--base_url",
+        type=str,
+        default=eval_config.get("base_url"),
+        help="vLLM server URL for model inference",
+    )
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        default=eval_config.get("model_id"),
+        help="Model ID for inference",
+    )
+    parser.add_argument(
+        "--exp_id",
+        type=str,
+        default="eval_async",
+        help="Experiment ID for organizing results",
+    )
+    parser.add_argument(
+        "--max_concurrent",
+        type=int,
+        default=100,
+        help="Max concurrent ACR sessions (batch mode only)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=3600.0,
+        help="Timeout in seconds per request (default: 3600s / 60 min)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit number of repositories to evaluate (for testing)",
+    )
+
+    args = parser.parse_args()
+
+    # Validation
+    if not args.agent_arn:
+        parser.error("--agent_arn is required (or set agentcore.agent_arn in config.toml)")
+    if not args.s3_input_bucket:
+        parser.error("--s3_input_bucket is required")
+    if not args.s3_output_bucket:
+        parser.error("--s3_output_bucket is required")
+
+    # Get repository folders
+    logger.info(f"Listing repositories from {args.s3_input_bucket}...")
+    s3_folder_uris = get_s3_folder_uris(args.s3_input_bucket)
+    if not s3_folder_uris:
+        logger.error(f"No folders found in {args.s3_input_bucket}")
+        return
+
+    # Apply limit if specified
+    if args.limit:
+        s3_folder_uris = s3_folder_uris[: args.limit]
+
+    logger.info(f"Found {len(s3_folder_uris)} repositories to evaluate")
+
+    # Prepare payloads
+    payloads = [prepare_payload(uri) for uri in s3_folder_uris]
+
+    # Setup results directory and file
+    results_dir = Path(__file__).parent / "results"
+    results_dir.mkdir(exist_ok=True)
+    result_path = results_dir / f"{args.exp_id}.jsonl"
+
+    # Error if file already exists to prevent accidental overwrites
+    if result_path.exists():
+        logger.error(f"Results file already exists: {result_path}")
+        logger.error("Delete the file or use a different --exp_id")
+        return
+
+    logger.info(f"Results will be written to: {result_path}")
+
+    # Create client
+    client = RolloutClient(
+        agent_runtime_arn=args.agent_arn,
+        s3_bucket=args.s3_output_bucket,
+        exp_id=args.exp_id,
+        base_url=args.base_url,
+        model_id=args.model_id,
+    )
+
+    # Run evaluation
+    logger.info(f"Starting async evaluation (mode={args.mode}, timeout={args.timeout}s)...")
+    benchmark_start = time.time()
+
+    if args.mode == "batch":
+        logger.info(f"Batch mode: max_concurrent={args.max_concurrent}")
+        succeeded, failed, task_successes = await run_batch_mode(
+            client, payloads, s3_folder_uris, result_path, args.max_concurrent, args.timeout
+        )
+    else:
+        logger.info(f"Individual mode: submitting all {len(payloads)} requests concurrently")
+        succeeded, failed, task_successes = await run_individual_mode(
+            client, payloads, s3_folder_uris, result_path, args.timeout
+        )
+
+    # Summary
+    total_repos = len(payloads)
+    success_rate = task_successes / total_repos if total_repos > 0 else 0
+    total_time = time.time() - benchmark_start
+    logger.info("=" * 50)
+    logger.info(f"Evaluation complete: {succeeded} succeeded, {failed} failed")
+    logger.info(f"Task success rate: {task_successes}/{total_repos} ({success_rate:.1%})")
+    logger.info(f"Total benchmark time: {total_time:.1f}s ({total_time / 60:.1f}m)")
+    logger.info(f"Results saved to: {result_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
+    "pytest-asyncio>=0.23",
     "mypy>=1.0",
     "pre-commit>=3.0",
 ]

--- a/src/agentcore_rl_toolkit/__init__.py
+++ b/src/agentcore_rl_toolkit/__init__.py
@@ -1,5 +1,5 @@
 from .app import AgentCoreRLApp
-from .client import BatchItem, BatchResult, RolloutClient, RolloutFuture
+from .client import AsyncBatchResult, BatchItem, BatchResult, RolloutClient, RolloutFuture
 from .reward_function import RewardFunction
 
 __all__ = [
@@ -8,5 +8,6 @@ __all__ = [
     "RolloutClient",
     "RolloutFuture",
     "BatchResult",
+    "AsyncBatchResult",
     "BatchItem",
 ]

--- a/src/agentcore_rl_toolkit/client.py
+++ b/src/agentcore_rl_toolkit/client.py
@@ -1,5 +1,6 @@
 """Client for invoking agents and collecting rollouts via S3 polling."""
 
+import asyncio
 import json
 import logging
 import time
@@ -132,6 +133,63 @@ class RolloutFuture:
         """True if cancellation was attempted (may not have succeeded)."""
         return self._cancelled
 
+    async def done_async(self) -> bool:
+        """Check if result is ready (non-blocking, async). Updates backoff state.
+
+        Like ``done()`` but wraps the S3 HEAD call in ``asyncio.to_thread()``
+        so it doesn't block the event loop.
+        """
+        if self._done or self._cancelled:
+            return True
+        try:
+            await asyncio.to_thread(self.s3_client.head_object, Bucket=self.s3_bucket, Key=self.result_key)
+            self._done = True
+            return True
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                self._last_poll_time = time.time()
+                self._poll_interval = min(self._poll_interval * self._backoff_factor, self._max_interval)
+                return False
+            raise
+
+    def _fetch_result(self) -> dict:
+        """Fetch and parse the result from S3. Contains blocking I/O."""
+        response = self.s3_client.get_object(Bucket=self.s3_bucket, Key=self.result_key)
+        return json.loads(response["Body"].read())
+
+    async def _async_poll(self) -> dict:
+        """Poll until result is ready, using asyncio.sleep for backoff."""
+        if self._cancelled:
+            raise CancelledError("Future was cancelled")
+        if self._result is not None:
+            return self._result
+
+        while True:
+            if await self.done_async():
+                self._result = await asyncio.to_thread(self._fetch_result)
+                return self._result
+            await asyncio.sleep(self._poll_interval)
+
+    def __await__(self):
+        return self._async_poll().__await__()
+
+    async def result_async(self, timeout: float = None) -> dict:
+        """Async version of ``result()``.
+
+        Args:
+            timeout: Max time to wait in seconds. If None, waits indefinitely.
+
+        Returns:
+            The rollout result dictionary from S3.
+
+        Raises:
+            CancelledError: If the future was cancelled.
+            TimeoutError: If timeout is reached before result is ready.
+        """
+        if timeout is not None:
+            return await asyncio.wait_for(self._async_poll(), timeout=timeout)
+        return await self
+
     def result(self, timeout: float = None) -> dict:
         """
         Block until result is ready, polling S3 HEAD with exponential backoff.
@@ -158,8 +216,7 @@ class RolloutFuture:
 
         while True:
             if self.done():
-                response = self.s3_client.get_object(Bucket=self.s3_bucket, Key=self.result_key)
-                self._result = json.loads(response["Body"].read())
+                self._result = self._fetch_result()
                 return self._result
 
             if timeout and (time.time() - start) > timeout:
@@ -172,8 +229,13 @@ class RolloutFuture:
 class RolloutClient:
     """Client for invoking agents and collecting rollouts with full lifecycle management.
 
+    Provides both sync and async APIs. Sync methods (``invoke``, ``run_batch``)
+    block the caller. Async methods (``invoke_async``, ``run_batch_async``) are
+    suitable for use inside ``asyncio`` event loops.
+
     Note:
-        This client is NOT thread-safe. Use separate client instances for
+        This client is NOT thread-safe. Do not mix sync and async calls
+        concurrently on the same instance. Use separate client instances for
         concurrent access from multiple threads.
     """
 
@@ -247,16 +309,8 @@ class RolloutClient:
         """Parse ACR invocation response."""
         return json.loads(response["response"].read())
 
-    def _rate_limited_invoke(self, payload: dict, session_id: str, input_id: str) -> RolloutFuture:
-        """Invoke with TPS rate limiting."""
-        # Enforce TPS limit
-        now = time.time()
-        elapsed = now - self._last_invoke_time
-        if elapsed < self._min_invoke_interval:
-            time.sleep(self._min_invoke_interval - elapsed)
-        self._last_invoke_time = time.time()
-
-        # Build rollout config
+    def _build_full_payload(self, payload: dict, input_id: str) -> dict:
+        """Build the full payload with _rollout config."""
         rollout_config = {
             "exp_id": self.exp_id,
             "input_id": input_id,
@@ -267,8 +321,18 @@ class RolloutClient:
             rollout_config["base_url"] = self.base_url
         if self.model_id:
             rollout_config["model_id"] = self.model_id
+        return {**payload, "_rollout": rollout_config}
 
-        full_payload = {**payload, "_rollout": rollout_config}
+    def _rate_limited_invoke(self, payload: dict, session_id: str, input_id: str) -> RolloutFuture:
+        """Invoke with TPS rate limiting."""
+        # Enforce TPS limit
+        now = time.time()
+        elapsed = now - self._last_invoke_time
+        if elapsed < self._min_invoke_interval:
+            time.sleep(self._min_invoke_interval - elapsed)
+        self._last_invoke_time = time.time()
+
+        full_payload = self._build_full_payload(payload, input_id)
 
         # Invoke via boto3 with timing
         invoke_start = time.time()
@@ -281,6 +345,50 @@ class RolloutClient:
         logger.info(f"Invoked session {session_id[:8]}... in {invoke_elapsed:.1f}s")
 
         data = self._parse_response(response)
+        return RolloutFuture(
+            s3_client=self.s3_client,
+            s3_bucket=data["s3_bucket"],
+            result_key=data["result_key"],
+            session_id=session_id,
+            input_id=input_id,
+            agentcore_client=self.agentcore_client,
+            agent_runtime_arn=self.agent_runtime_arn,
+        )
+
+    def _get_async_lock(self) -> asyncio.Lock:
+        """Lazily create and return the async rate-limiting lock."""
+        if not hasattr(self, "_async_lock"):
+            self._async_lock = asyncio.Lock()
+        return self._async_lock
+
+    async def _async_rate_limited_invoke(self, payload: dict, session_id: str, input_id: str) -> RolloutFuture:
+        """Invoke with async TPS rate limiting.
+
+        The lock is held only during the timing check and released before the
+        HTTP call, so cold starts on one request don't block submission of others.
+        """
+        async with self._get_async_lock():
+            now = time.time()
+            elapsed = now - self._last_invoke_time
+            if elapsed < self._min_invoke_interval:
+                await asyncio.sleep(self._min_invoke_interval - elapsed)
+            self._last_invoke_time = time.time()
+
+        full_payload = self._build_full_payload(payload, input_id)
+
+        # Invoke via boto3 in a thread (includes response parsing which reads streaming body)
+        def _invoke_and_parse():
+            invoke_start = time.time()
+            response = self.agentcore_client.invoke_agent_runtime(
+                agentRuntimeArn=self.agent_runtime_arn,
+                runtimeSessionId=session_id,
+                payload=json.dumps(full_payload),
+            )
+            invoke_elapsed = time.time() - invoke_start
+            logger.info(f"Invoked session {session_id[:8]}... in {invoke_elapsed:.1f}s")
+            return self._parse_response(response)
+
+        data = await asyncio.to_thread(_invoke_and_parse)
         return RolloutFuture(
             s3_client=self.s3_client,
             s3_bucket=data["s3_bucket"],
@@ -310,6 +418,27 @@ class RolloutClient:
         session_id = session_id or str(uuid.uuid4())
         input_id = input_id or str(uuid.uuid4())
         return self._rate_limited_invoke(payload, session_id, input_id)
+
+    async def invoke_async(self, payload: dict, session_id: str = None, input_id: str = None) -> RolloutFuture:
+        """Async version of ``invoke()``. Returns a ``RolloutFuture``.
+
+        Args:
+            payload: The payload to send to the agent
+            session_id: Optional session ID (default: auto-generated UUID)
+            input_id: Optional input ID (default: auto-generated UUID)
+
+        Returns:
+            RolloutFuture that can be awaited or polled for the result
+
+        Usage::
+
+            future = await client.invoke_async({"prompt": "...", "answer": "42"})
+            result = await future.result_async(timeout=60)
+            # or simply: result = await future
+        """
+        session_id = session_id or str(uuid.uuid4())
+        input_id = input_id or str(uuid.uuid4())
+        return await self._async_rate_limited_invoke(payload, session_id, input_id)
 
     def run_batch(
         self,
@@ -359,6 +488,40 @@ class RolloutClient:
                     log.warning(f"Payload {item.index} failed: {item.error}")
         """
         return BatchResult(
+            client=self,
+            payloads=payloads,
+            max_concurrent=max_concurrent_sessions,
+            timeout=timeout,
+            initial_interval=initial_interval,
+            max_interval=max_interval,
+            backoff_factor=backoff_factor,
+            log_interval=log_interval,
+        )
+
+    def run_batch_async(
+        self,
+        payloads: list[dict],
+        max_concurrent_sessions: int,
+        timeout: float = 900.0,
+        initial_interval: float = 0.5,
+        max_interval: float = 30.0,
+        backoff_factor: float = 1.5,
+        log_interval: float = 30.0,
+    ) -> "AsyncBatchResult":
+        """Async version of ``run_batch()``. Returns an async iterator.
+
+        Same semantics as ``run_batch`` but submissions and polling use
+        ``asyncio`` so cold starts on one request don't block others.
+
+        Usage::
+
+            async for item in client.run_batch_async(payloads, max_concurrent_sessions=10):
+                if item.success:
+                    process(item.result)
+                else:
+                    log.warning(f"Payload {item.index} failed: {item.error}")
+        """
+        return AsyncBatchResult(
             client=self,
             payloads=payloads,
             max_concurrent=max_concurrent_sessions,
@@ -465,3 +628,114 @@ class BatchResult:
                     min_wait = min(min_wait, max(0, min_timeout_wait))
                 if min_wait > 0:
                     time.sleep(min_wait)
+
+
+class AsyncBatchResult:
+    """Async iterator that manages batch execution lifecycle with adaptive polling.
+
+    Submissions are dispatched as concurrent tasks so that cold starts on one
+    request don't block submission of others.
+    """
+
+    def __init__(
+        self,
+        client: RolloutClient,
+        payloads: list[dict],
+        max_concurrent: int,
+        timeout: float = 900.0,
+        initial_interval: float = 0.5,
+        max_interval: float = 30.0,
+        backoff_factor: float = 1.5,
+        log_interval: float = 30.0,
+    ):
+        self.client = client
+        self.payloads = list(payloads)
+        self.max_concurrent = max_concurrent
+        self.timeout = timeout
+        self.initial_interval = initial_interval
+        self.max_interval = max_interval
+        self.backoff_factor = backoff_factor
+        self.log_interval = log_interval
+
+    async def _run(self):
+        """Yield ``BatchItem`` as sessions complete."""
+        pending_payloads = list(enumerate(self.payloads))  # (index, payload)
+        # Tasks that are still submitting (HTTP call in progress)
+        submitting: dict[asyncio.Task, tuple[int, float]] = {}  # task -> (index, start_time)
+        # Futures whose submission completed and are now polling S3
+        active_futures: dict[str, tuple[int, RolloutFuture]] = {}  # key -> (index, future)
+        last_status_log = time.time()
+
+        while pending_payloads or submitting or active_futures:
+            # Fire new submissions as concurrent tasks
+            while pending_payloads and (len(submitting) + len(active_futures)) < self.max_concurrent:
+                idx, payload = pending_payloads.pop(0)
+                session_id = str(uuid.uuid4())
+                input_id = str(uuid.uuid4())
+                task = asyncio.create_task(self.client._async_rate_limited_invoke(payload, session_id, input_id))
+                submitting[task] = (idx, time.time())
+
+            # Collect completed submissions → move to active_futures
+            done_tasks = [t for t in submitting if t.done()]
+            for task in done_tasks:
+                idx, start = submitting.pop(task)
+                try:
+                    future = task.result()
+                    future._poll_interval = self.initial_interval
+                    future._initial_interval = self.initial_interval
+                    future._max_interval = self.max_interval
+                    future._backoff_factor = self.backoff_factor
+                    active_futures[future.result_key] = (idx, future)
+                except Exception as e:
+                    yield BatchItem(success=False, error=str(e), index=idx, elapsed=time.time() - start)
+
+            # Poll active futures that are ready and check for timeouts
+            completed_keys = []
+            for key, (idx, future) in active_futures.items():
+                if future.elapsed() > self.timeout:
+                    completed_keys.append(key)
+                    await asyncio.to_thread(future.cancel)
+                    yield BatchItem(
+                        success=False,
+                        error=f"Timeout after {self.timeout}s",
+                        index=idx,
+                        elapsed=future.elapsed(),
+                    )
+                elif future.ready_to_poll() and await future.done_async():
+                    completed_keys.append(key)
+                    try:
+                        result = await future.result_async()
+                        yield BatchItem(success=True, result=result, index=idx, elapsed=future.elapsed())
+                    except Exception as e:
+                        yield BatchItem(success=False, error=str(e), index=idx, elapsed=future.elapsed())
+
+            for key in completed_keys:
+                del active_futures[key]
+
+            # Log status periodically
+            if active_futures and (time.time() - last_status_log) >= self.log_interval:
+                elapsed_times = [f.elapsed() for _, f in active_futures.values()]
+                min_elapsed = min(elapsed_times)
+                max_elapsed = max(elapsed_times)
+                logger.info(
+                    f"[Status] {len(active_futures)} active, {len(submitting)} submitting, "
+                    f"{len(pending_payloads)} pending, elapsed: {min_elapsed:.0f}s-{max_elapsed:.0f}s"
+                )
+                last_status_log = time.time()
+
+            # Sleep until next event
+            if (active_futures or submitting) and not completed_keys and not done_tasks:
+                min_wait = float("inf")
+                if active_futures:
+                    min_wait = min(f.time_until_next_poll() for _, f in active_futures.values())
+                    if self.timeout:
+                        min_timeout_wait = min(self.timeout - f.elapsed() for _, f in active_futures.values())
+                        min_wait = min(min_wait, max(0, min_timeout_wait))
+                # If only submitting tasks are pending, use a short sleep
+                if submitting and min_wait == float("inf"):
+                    min_wait = 0.1
+                if min_wait > 0 and min_wait != float("inf"):
+                    await asyncio.sleep(min_wait)
+
+    def __aiter__(self):
+        return self._run().__aiter__()

--- a/src/agentcore_rl_toolkit/client.py
+++ b/src/agentcore_rl_toolkit/client.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import time
+import traceback
 import uuid
 from concurrent.futures import CancelledError
 from dataclasses import dataclass
@@ -13,6 +14,11 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
+
+
+def _format_exception(exc: BaseException) -> str:
+    """Format an exception with its full traceback."""
+    return "".join(traceback.format_exception(exc))
 
 
 @dataclass
@@ -309,8 +315,11 @@ class RolloutClient:
         """Parse ACR invocation response."""
         return json.loads(response["response"].read())
 
-    def _build_full_payload(self, payload: dict, input_id: str) -> dict:
-        """Build the full payload with _rollout config."""
+    def _build_full_payload(self, payload: dict, input_id: str, **overrides) -> dict:
+        """Build the full payload with _rollout config.
+
+        Merge order (last wins): required fields → client defaults → per-invocation overrides.
+        """
         rollout_config = {
             "exp_id": self.exp_id,
             "input_id": input_id,
@@ -321,9 +330,10 @@ class RolloutClient:
             rollout_config["base_url"] = self.base_url
         if self.model_id:
             rollout_config["model_id"] = self.model_id
+        rollout_config.update(overrides)
         return {**payload, "_rollout": rollout_config}
 
-    def _rate_limited_invoke(self, payload: dict, session_id: str, input_id: str) -> RolloutFuture:
+    def _rate_limited_invoke(self, payload: dict, session_id: str, input_id: str, **overrides) -> RolloutFuture:
         """Invoke with TPS rate limiting."""
         # Enforce TPS limit
         now = time.time()
@@ -332,7 +342,7 @@ class RolloutClient:
             time.sleep(self._min_invoke_interval - elapsed)
         self._last_invoke_time = time.time()
 
-        full_payload = self._build_full_payload(payload, input_id)
+        full_payload = self._build_full_payload(payload, input_id, **overrides)
 
         # Invoke via boto3 with timing
         invoke_start = time.time()
@@ -361,7 +371,9 @@ class RolloutClient:
             self._async_lock = asyncio.Lock()
         return self._async_lock
 
-    async def _async_rate_limited_invoke(self, payload: dict, session_id: str, input_id: str) -> RolloutFuture:
+    async def _async_rate_limited_invoke(
+        self, payload: dict, session_id: str, input_id: str, **overrides
+    ) -> RolloutFuture:
         """Invoke with async TPS rate limiting.
 
         The lock is held only during the timing check and released before the
@@ -374,7 +386,7 @@ class RolloutClient:
                 await asyncio.sleep(self._min_invoke_interval - elapsed)
             self._last_invoke_time = time.time()
 
-        full_payload = self._build_full_payload(payload, input_id)
+        full_payload = self._build_full_payload(payload, input_id, **overrides)
 
         # Invoke via boto3 in a thread (includes response parsing which reads streaming body)
         def _invoke_and_parse():
@@ -399,7 +411,7 @@ class RolloutClient:
             agent_runtime_arn=self.agent_runtime_arn,
         )
 
-    def invoke(self, payload: dict, session_id: str = None, input_id: str = None) -> RolloutFuture:
+    def invoke(self, payload: dict, session_id: str = None, input_id: str = None, **rollout_overrides) -> RolloutFuture:
         """
         Single invocation, returns Future for the result.
 
@@ -407,6 +419,9 @@ class RolloutClient:
             payload: The payload to send to the agent
             session_id: Optional session ID (default: auto-generated UUID)
             input_id: Optional input ID (default: auto-generated UUID)
+            **rollout_overrides: Per-invocation overrides merged into _rollout config
+                (e.g., base_url, model_id, temperature). These take precedence over
+                client-level defaults.
 
         Returns:
             RolloutFuture that can be awaited or polled for the result
@@ -414,18 +429,26 @@ class RolloutClient:
         Usage:
             future = client.invoke({"prompt": "...", "answer": "42"})
             result = future.result(timeout=60)
+
+            # With per-invocation overrides:
+            future = client.invoke(payload, base_url="http://other-server", temperature=0.9)
         """
         session_id = session_id or str(uuid.uuid4())
         input_id = input_id or str(uuid.uuid4())
-        return self._rate_limited_invoke(payload, session_id, input_id)
+        return self._rate_limited_invoke(payload, session_id, input_id, **rollout_overrides)
 
-    async def invoke_async(self, payload: dict, session_id: str = None, input_id: str = None) -> RolloutFuture:
+    async def invoke_async(
+        self, payload: dict, session_id: str = None, input_id: str = None, **rollout_overrides
+    ) -> RolloutFuture:
         """Async version of ``invoke()``. Returns a ``RolloutFuture``.
 
         Args:
             payload: The payload to send to the agent
             session_id: Optional session ID (default: auto-generated UUID)
             input_id: Optional input ID (default: auto-generated UUID)
+            **rollout_overrides: Per-invocation overrides merged into _rollout config
+                (e.g., base_url, model_id, temperature). These take precedence over
+                client-level defaults.
 
         Returns:
             RolloutFuture that can be awaited or polled for the result
@@ -435,10 +458,13 @@ class RolloutClient:
             future = await client.invoke_async({"prompt": "...", "answer": "42"})
             result = await future.result_async(timeout=60)
             # or simply: result = await future
+
+            # With per-invocation overrides:
+            future = await client.invoke_async(payload, base_url="http://other-server")
         """
         session_id = session_id or str(uuid.uuid4())
         input_id = input_id or str(uuid.uuid4())
-        return await self._async_rate_limited_invoke(payload, session_id, input_id)
+        return await self._async_rate_limited_invoke(payload, session_id, input_id, **rollout_overrides)
 
     def run_batch(
         self,
@@ -582,7 +608,7 @@ class BatchResult:
                     future._backoff_factor = self.backoff_factor
                     active_futures[future.result_key] = (idx, future)
                 except Exception as e:
-                    yield BatchItem(success=False, error=str(e), index=idx, elapsed=0.0)
+                    yield BatchItem(success=False, error=_format_exception(e), index=idx, elapsed=0.0)
 
             # Poll futures that are ready (per-future backoff) and check for timeouts
             completed_keys = []
@@ -603,7 +629,7 @@ class BatchResult:
                         result = future.result()
                         yield BatchItem(success=True, result=result, index=idx, elapsed=future.elapsed())
                     except Exception as e:
-                        yield BatchItem(success=False, error=str(e), index=idx, elapsed=future.elapsed())
+                        yield BatchItem(success=False, error=_format_exception(e), index=idx, elapsed=future.elapsed())
 
             # Remove completed from active
             for key in completed_keys:
@@ -687,7 +713,7 @@ class AsyncBatchResult:
                     future._backoff_factor = self.backoff_factor
                     active_futures[future.result_key] = (idx, future)
                 except Exception as e:
-                    yield BatchItem(success=False, error=str(e), index=idx, elapsed=time.time() - start)
+                    yield BatchItem(success=False, error=_format_exception(e), index=idx, elapsed=time.time() - start)
 
             # Poll active futures that are ready and check for timeouts
             completed_keys = []
@@ -707,7 +733,7 @@ class AsyncBatchResult:
                         result = await future.result_async()
                         yield BatchItem(success=True, result=result, index=idx, elapsed=future.elapsed())
                     except Exception as e:
-                        yield BatchItem(success=False, error=str(e), index=idx, elapsed=future.elapsed())
+                        yield BatchItem(success=False, error=_format_exception(e), index=idx, elapsed=future.elapsed())
 
             for key in completed_keys:
                 del active_futures[key]

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,377 @@
+"""Tests for async methods on RolloutFuture and RolloutClient."""
+
+import asyncio
+import json
+import time
+from concurrent.futures import CancelledError
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentcore_rl_toolkit.client import RolloutClient, RolloutFuture
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789:agent-runtime/my-runtime"
+FAKE_BUCKET = "my-bucket"
+FAKE_EXP = "exp-1"
+FAKE_RESULT_KEY = "exp-1/input-1/sess-1.json"
+FAKE_RESULT = {"rollout_data": [{"tokens": [1, 2, 3]}], "rewards": [1.0]}
+
+
+def _make_s3_client(found=False):
+    """Return a mock S3 client. ``found=True`` means head_object succeeds."""
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    if found:
+        client.head_object.return_value = {}
+    else:
+        error_response = {"Error": {"Code": "404", "Message": "Not Found"}}
+        client.head_object.side_effect = ClientError(error_response, "HeadObject")
+    body = MagicMock()
+    body.read.return_value = json.dumps(FAKE_RESULT).encode()
+    client.get_object.return_value = {"Body": body}
+    return client
+
+
+def _make_future(found=False, cancelled=False, **kwargs):
+    s3 = _make_s3_client(found=found)
+    future = RolloutFuture(
+        s3_client=s3,
+        s3_bucket=FAKE_BUCKET,
+        result_key=FAKE_RESULT_KEY,
+        initial_interval=0.01,
+        max_interval=0.05,
+        backoff_factor=1.5,
+        **kwargs,
+    )
+    if cancelled:
+        future._cancelled = True
+    return future
+
+
+def _make_client():
+    """Return a RolloutClient with mocked boto3 clients.
+
+    Each invoke_agent_runtime call returns a unique result_key so that
+    multiple futures don't collide in the active_futures dict.
+    """
+    _invoke_counter = {"n": 0}
+
+    with patch("agentcore_rl_toolkit.client.boto3") as mock_boto3:
+        acr_client = MagicMock()
+
+        def _fake_invoke(**kwargs):
+            _invoke_counter["n"] += 1
+            body = MagicMock()
+            body.read.return_value = json.dumps(
+                {
+                    "s3_bucket": FAKE_BUCKET,
+                    "result_key": f"{FAKE_EXP}/input-{_invoke_counter['n']}/sess.json",
+                    "status": "processing",
+                }
+            ).encode()
+            return {"response": body}
+
+        acr_client.invoke_agent_runtime.side_effect = _fake_invoke
+
+        s3_client = _make_s3_client(found=True)
+
+        def fake_client(service, **kwargs):
+            if service == "bedrock-agentcore":
+                return acr_client
+            return s3_client
+
+        mock_boto3.client.side_effect = fake_client
+        client = RolloutClient(
+            agent_runtime_arn=FAKE_ARN,
+            s3_bucket=FAKE_BUCKET,
+            exp_id=FAKE_EXP,
+        )
+    return client
+
+
+# ---------------------------------------------------------------------------
+# RolloutFuture async tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_done_async_returns_false_on_404():
+    future = _make_future(found=False)
+    assert await future.done_async() is False
+
+
+@pytest.mark.asyncio
+async def test_done_async_returns_true_when_found():
+    future = _make_future(found=True)
+    assert await future.done_async() is True
+
+
+@pytest.mark.asyncio
+async def test_done_async_returns_true_when_cancelled():
+    future = _make_future(found=False, cancelled=True)
+    assert await future.done_async() is True
+
+
+@pytest.mark.asyncio
+async def test_result_async_polls_until_ready():
+    """done_async returns False twice then True; result_async should succeed."""
+    from botocore.exceptions import ClientError
+
+    s3 = MagicMock()
+    error_response = {"Error": {"Code": "404", "Message": "Not Found"}}
+    s3.head_object.side_effect = [
+        ClientError(error_response, "HeadObject"),
+        ClientError(error_response, "HeadObject"),
+        {},  # found on third try
+    ]
+    body = MagicMock()
+    body.read.return_value = json.dumps(FAKE_RESULT).encode()
+    s3.get_object.return_value = {"Body": body}
+
+    future = RolloutFuture(
+        s3_client=s3,
+        s3_bucket=FAKE_BUCKET,
+        result_key=FAKE_RESULT_KEY,
+        initial_interval=0.01,
+        max_interval=0.05,
+        backoff_factor=1.0,
+    )
+    result = await future.result_async()
+    assert result == FAKE_RESULT
+
+
+@pytest.mark.asyncio
+async def test_result_async_raises_timeout():
+    """result_async(timeout=...) raises TimeoutError when result never appears."""
+    future = _make_future(found=False)
+    with pytest.raises(TimeoutError):
+        await future.result_async(timeout=0.05)
+
+
+@pytest.mark.asyncio
+async def test_result_async_raises_cancelled():
+    """result_async raises CancelledError when future was cancelled."""
+    future = _make_future(found=False, cancelled=True)
+    with pytest.raises(CancelledError):
+        await future.result_async()
+
+
+@pytest.mark.asyncio
+async def test_await_syntax():
+    """``await future`` should work via __await__."""
+    future = _make_future(found=True)
+    result = await future
+    assert result == FAKE_RESULT
+
+
+@pytest.mark.asyncio
+async def test_result_async_returns_cached():
+    """Second call returns cached result without polling again."""
+    future = _make_future(found=True)
+    r1 = await future.result_async()
+    # Reset mock to verify no further calls
+    future.s3_client.head_object.reset_mock()
+    future.s3_client.get_object.reset_mock()
+    r2 = await future.result_async()
+    assert r1 == r2
+    future.s3_client.head_object.assert_not_called()
+    future.s3_client.get_object.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# RolloutClient async tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invoke_async_returns_future():
+    client = _make_client()
+    future = await client.invoke_async({"prompt": "hello"})
+    assert isinstance(future, RolloutFuture)
+    assert future.result_key.startswith(FAKE_EXP + "/")
+
+
+@pytest.mark.asyncio
+async def test_invoke_async_generates_uuids():
+    """invoke_async with no session_id/input_id should auto-generate them."""
+    client = _make_client()
+    future = await client.invoke_async({"prompt": "hello"})
+    assert future.session_id is not None
+    assert future.input_id is not None
+
+
+@pytest.mark.asyncio
+async def test_invoke_async_custom_ids():
+    """invoke_async passes custom session_id and input_id through."""
+    client = _make_client()
+    future = await client.invoke_async({"prompt": "hello"}, session_id="s-1", input_id="i-1")
+    assert future.session_id == "s-1"
+    assert future.input_id == "i-1"
+
+
+@pytest.mark.asyncio
+async def test_async_rate_limiting_lock_released_before_http():
+    """Lock is released before the HTTP call so cold starts don't block others."""
+    client = _make_client()
+
+    # Track when the lock is acquired/released vs when the HTTP call happens
+    events = []
+
+    original_invoke = client.agentcore_client.invoke_agent_runtime
+
+    def slow_invoke(**kwargs):
+        events.append("http_start")
+        time.sleep(0.05)  # simulate cold start
+        events.append("http_end")
+        return original_invoke(**kwargs)
+
+    client.agentcore_client.invoke_agent_runtime = slow_invoke
+
+    # Fire two invocations concurrently
+    t1 = asyncio.create_task(client.invoke_async({"prompt": "a"}))
+    t2 = asyncio.create_task(client.invoke_async({"prompt": "b"}))
+    await asyncio.gather(t1, t2)
+
+    # Both HTTP calls should overlap (second http_start before first http_end)
+    # Due to thread pool, they run in parallel
+    assert len(events) == 4  # two http_start + two http_end
+
+
+# ---------------------------------------------------------------------------
+# AsyncBatchResult tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_batch_async_yields_all_items():
+    client = _make_client()
+    payloads = [{"prompt": f"q{i}"} for i in range(3)]
+    items = []
+    async for item in client.run_batch_async(payloads, max_concurrent_sessions=3):
+        items.append(item)
+    assert len(items) == 3
+    assert all(item.success for item in items)
+    indices = sorted(item.index for item in items)
+    assert indices == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_run_batch_async_handles_invoke_errors():
+    """If invoke fails for some payloads, they yield as error BatchItems."""
+    client = _make_client()
+
+    call_count = 0
+    original = client.agentcore_client.invoke_agent_runtime
+
+    def failing_invoke(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise RuntimeError("Connection refused")
+        return original(**kwargs)
+
+    client.agentcore_client.invoke_agent_runtime = failing_invoke
+
+    items = []
+    payloads = [{"prompt": "a"}, {"prompt": "b"}, {"prompt": "c"}]
+    async for item in client.run_batch_async(payloads, max_concurrent_sessions=3):
+        items.append(item)
+
+    assert len(items) == 3
+    errors = [i for i in items if not i.success]
+    assert len(errors) == 1
+    assert "Connection refused" in errors[0].error
+
+
+@pytest.mark.asyncio
+async def test_run_batch_async_timeout():
+    """Items that exceed timeout should yield as error BatchItems."""
+    from botocore.exceptions import ClientError
+
+    client = _make_client()
+
+    # Make S3 HEAD always return 404 so result never appears
+    error_response = {"Error": {"Code": "404", "Message": "Not Found"}}
+    client.s3_client.head_object.side_effect = ClientError(error_response, "HeadObject")
+
+    items = []
+    async for item in client.run_batch_async(
+        [{"prompt": "slow"}],
+        max_concurrent_sessions=1,
+        timeout=0.1,
+        initial_interval=0.01,
+    ):
+        items.append(item)
+
+    assert len(items) == 1
+    assert not items[0].success
+    assert "Timeout" in items[0].error
+
+
+@pytest.mark.asyncio
+async def test_run_batch_async_concurrent_submissions():
+    """Cold start on one request doesn't block submission of others."""
+    client = _make_client()
+
+    submission_times = []
+    original = client.agentcore_client.invoke_agent_runtime
+
+    def tracking_invoke(**kwargs):
+        submission_times.append(time.time())
+        return original(**kwargs)
+
+    client.agentcore_client.invoke_agent_runtime = tracking_invoke
+    # Set high TPS limit so rate limiting doesn't add delay
+    client._min_invoke_interval = 0.0
+
+    items = []
+    async for item in client.run_batch_async(
+        [{"prompt": f"q{i}"} for i in range(3)],
+        max_concurrent_sessions=3,
+    ):
+        items.append(item)
+
+    assert len(items) == 3
+    # All 3 submissions should happen nearly simultaneously
+    if len(submission_times) == 3:
+        span = submission_times[-1] - submission_times[0]
+        assert span < 1.0  # Should be well under 1 second
+
+
+# ---------------------------------------------------------------------------
+# Sync API regression
+# ---------------------------------------------------------------------------
+
+
+def test_sync_invoke_still_works():
+    """Verify sync invoke() is unaffected by async additions."""
+    client = _make_client()
+    future = client.invoke({"prompt": "hello"})
+    assert isinstance(future, RolloutFuture)
+    assert future.result_key.startswith(FAKE_EXP + "/")
+
+
+def test_sync_done_still_works():
+    """Verify sync done() is unaffected."""
+    future = _make_future(found=True)
+    assert future.done() is True
+
+
+def test_sync_result_still_works():
+    """Verify sync result() is unaffected."""
+    future = _make_future(found=True)
+    result = future.result()
+    assert result == FAKE_RESULT
+
+
+def test_sync_run_batch_still_works():
+    """Verify sync run_batch() is unaffected."""
+    client = _make_client()
+    items = list(client.run_batch([{"prompt": "a"}], max_concurrent_sessions=1))
+    assert len(items) == 1
+    assert items[0].success

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -375,3 +375,64 @@ def test_sync_run_batch_still_works():
     items = list(client.run_batch([{"prompt": "a"}], max_concurrent_sessions=1))
     assert len(items) == 1
     assert items[0].success
+
+
+# ---------------------------------------------------------------------------
+# Per-invocation overrides (async)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invoke_async_with_overrides():
+    """invoke_async merges per-invocation overrides into _rollout config."""
+    with patch("agentcore_rl_toolkit.client.boto3") as mock_boto3:
+        acr_client = MagicMock()
+
+        def _fake_invoke(**kwargs):
+            body = MagicMock()
+            body.read.return_value = json.dumps(
+                {"s3_bucket": FAKE_BUCKET, "result_key": FAKE_RESULT_KEY, "status": "processing"}
+            ).encode()
+            return {"response": body}
+
+        acr_client.invoke_agent_runtime.side_effect = _fake_invoke
+        s3_client = _make_s3_client(found=True)
+
+        mock_boto3.client.side_effect = lambda service, **kw: (
+            acr_client if service == "bedrock-agentcore" else s3_client
+        )
+        client = RolloutClient(
+            agent_runtime_arn=FAKE_ARN,
+            s3_bucket=FAKE_BUCKET,
+            exp_id=FAKE_EXP,
+            base_url="http://default:8000",
+        )
+
+        await client.invoke_async(
+            {"prompt": "hello"},
+            session_id="s-1",
+            input_id="i-1",
+            base_url="http://override:8000",
+            temperature=0.9,
+        )
+
+    payload = json.loads(acr_client.invoke_agent_runtime.call_args.kwargs["payload"])
+    assert payload["_rollout"]["base_url"] == "http://override:8000"
+    assert payload["_rollout"]["temperature"] == 0.9
+
+
+@pytest.mark.asyncio
+async def test_run_batch_async_error_contains_traceback():
+    """Async batch invoke errors should contain full traceback strings."""
+    client = _make_client()
+
+    client.agentcore_client.invoke_agent_runtime = MagicMock(side_effect=RuntimeError("Connection refused"))
+
+    items = []
+    async for item in client.run_batch_async([{"prompt": "a"}], max_concurrent_sessions=1):
+        items.append(item)
+
+    assert len(items) == 1
+    assert not items[0].success
+    assert "Traceback (most recent call last)" in items[0].error
+    assert "Connection refused" in items[0].error

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -705,3 +705,132 @@ class TestBatchResult:
             call_kwargs = mock_acr.stop_runtime_session.call_args.kwargs
             assert call_kwargs["agentRuntimeArn"] == "arn:aws:bedrock-agentcore:us-west-2:123:agent/test"
             assert "runtimeSessionId" in call_kwargs
+
+    def test_invoke_with_per_invocation_overrides(self):
+        """Test invoke() merges per-invocation overrides into _rollout config."""
+        with patch("agentcore_rl_toolkit.client.boto3") as mock_boto3:
+            mock_acr = MagicMock()
+            mock_s3 = MagicMock()
+            mock_boto3.client.side_effect = lambda service, **kwargs: (
+                mock_acr if service == "bedrock-agentcore" else mock_s3
+            )
+
+            mock_acr.invoke_agent_runtime.return_value = {
+                "response": mock_streaming_body({"status": "processing", "s3_bucket": "bucket", "result_key": "key"})
+            }
+
+            client = RolloutClient(
+                agent_runtime_arn="arn:aws:bedrock-agentcore:us-west-2:123:agent/test",
+                s3_bucket="test-bucket",
+                exp_id="exp-001",
+                base_url="http://default:8000",
+                model_id="default-model",
+            )
+
+            client.invoke(
+                {"prompt": "test"},
+                session_id="sess-1",
+                input_id="input-1",
+                base_url="http://override:8000",
+                temperature=0.5,
+            )
+
+            payload = json.loads(mock_acr.invoke_agent_runtime.call_args.kwargs["payload"])
+            assert payload["_rollout"]["base_url"] == "http://override:8000"
+            assert payload["_rollout"]["temperature"] == 0.5
+            assert payload["_rollout"]["model_id"] == "default-model"
+
+    def test_invoke_overrides_work_without_client_defaults(self):
+        """Test per-invocation overrides work even when client has no base_url/model_id."""
+        with patch("agentcore_rl_toolkit.client.boto3") as mock_boto3:
+            mock_acr = MagicMock()
+            mock_s3 = MagicMock()
+            mock_boto3.client.side_effect = lambda service, **kwargs: (
+                mock_acr if service == "bedrock-agentcore" else mock_s3
+            )
+
+            mock_acr.invoke_agent_runtime.return_value = {
+                "response": mock_streaming_body({"status": "processing", "s3_bucket": "bucket", "result_key": "key"})
+            }
+
+            client = RolloutClient(
+                agent_runtime_arn="arn:aws:bedrock-agentcore:us-west-2:123:agent/test",
+                s3_bucket="test-bucket",
+                exp_id="exp-001",
+                # No base_url or model_id
+            )
+
+            client.invoke(
+                {"prompt": "test"},
+                base_url="http://override:8000",
+                model_id="override-model",
+            )
+
+            payload = json.loads(mock_acr.invoke_agent_runtime.call_args.kwargs["payload"])
+            assert payload["_rollout"]["base_url"] == "http://override:8000"
+            assert payload["_rollout"]["model_id"] == "override-model"
+
+    def test_invoke_overrides_do_not_mutate_client(self):
+        """Test per-invocation overrides don't affect subsequent invocations."""
+        with patch("agentcore_rl_toolkit.client.boto3") as mock_boto3:
+            mock_acr = MagicMock()
+            mock_s3 = MagicMock()
+            mock_boto3.client.side_effect = lambda service, **kwargs: (
+                mock_acr if service == "bedrock-agentcore" else mock_s3
+            )
+
+            invoke_count = [0]
+
+            def mock_invoke(*args, **kwargs):
+                invoke_count[0] += 1
+                return {
+                    "response": mock_streaming_body(
+                        {"status": "processing", "s3_bucket": "bucket", "result_key": f"key{invoke_count[0]}.json"}
+                    )
+                }
+
+            mock_acr.invoke_agent_runtime.side_effect = mock_invoke
+
+            client = RolloutClient(
+                agent_runtime_arn="arn:aws:bedrock-agentcore:us-west-2:123:agent/test",
+                s3_bucket="test-bucket",
+                exp_id="exp-001",
+                base_url="http://default:8000",
+            )
+
+            # First call with override
+            client.invoke({"prompt": "test"}, base_url="http://override:8000")
+            # Second call without override
+            client.invoke({"prompt": "test"})
+
+            calls = mock_acr.invoke_agent_runtime.call_args_list
+            payload1 = json.loads(calls[0].kwargs["payload"])
+            payload2 = json.loads(calls[1].kwargs["payload"])
+
+            assert payload1["_rollout"]["base_url"] == "http://override:8000"
+            assert payload2["_rollout"]["base_url"] == "http://default:8000"
+
+    def test_batch_error_contains_traceback(self):
+        """Test that batch invoke errors contain full traceback strings."""
+        with patch("agentcore_rl_toolkit.client.boto3") as mock_boto3:
+            mock_acr = MagicMock()
+            mock_s3 = MagicMock()
+            mock_boto3.client.side_effect = lambda service, **kwargs: (
+                mock_acr if service == "bedrock-agentcore" else mock_s3
+            )
+
+            mock_acr.invoke_agent_runtime.side_effect = RuntimeError("ACR invocation failed")
+
+            client = RolloutClient(
+                agent_runtime_arn="arn:aws:bedrock-agentcore:us-west-2:123:agent/test",
+                s3_bucket="test-bucket",
+                exp_id="exp-001",
+                tps_limit=1000,
+            )
+
+            items = list(client.run_batch([{"prompt": "q1"}], max_concurrent_sessions=1))
+
+            assert len(items) == 1
+            assert items[0].success is False
+            assert "Traceback (most recent call last)" in items[0].error
+            assert "ACR invocation failed" in items[0].error

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "agentcore-rl-toolkit"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },
@@ -18,6 +18,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -28,6 +29,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 provides-extras = ["dev"]
@@ -75,6 +77,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758", size = 92210, upload-time = "2025-01-14T14:46:18.454Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/43/53afb8ba17218f19b77c7834128566c5bbb100a0ad9ba2e8e89d089d7079/autopep8-2.3.2-py2.py3-none-any.whl", hash = "sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128", size = 45807, upload-time = "2025-01-14T14:46:15.466Z" },
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
 ]
 
 [[package]]
@@ -1043,6 +1054,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
*Description of changes:*

Implements invoke_async, run_batch_async, result_async, done_async, and __await__ enable non-blocking usage in asyncio event loops for RolloutClient. Uses asyncio.to_thread for boto3 calls.

Also extracts shared eval helpers into eval_utils.py and adds evaluate_async.py example demonstrating both batch and individual async patterns.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
