### PR TITLE
fix(client, migration-agent): add max_pool_connections to boto config, enable passing sampling parameters to evaluation script, polish migration agent example readme

### DIFF
--- a/examples/strands_migration_agent/README.md
+++ b/examples/strands_migration_agent/README.md
@@ -78,6 +78,8 @@ mvn --version
 
 ## Installation
 
+Set the repo root and migration agent paths — these variables are used throughout this document:
+
 ```bash
 export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
 export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
@@ -156,12 +158,9 @@ curl -X POST http://localhost:8080/invocations \
 
 ### Build & run locally
 
-Set the repo root path and migration agent path first, then build docker:
+Build the docker image:
 
 ```bash
-export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
-export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
-
 docker buildx build \
   --build-context toolkit=$TOOLKIT_ROOT \
   -t migration:dev --load \
@@ -169,11 +168,13 @@ docker buildx build \
   $MIGRATION_DIR
 ```
 
-Add AWS credentials to your `.env` file since Docker can't access your host's AWS credential chain:
+The agent inside the container needs AWS credentials to access S3 (for saving rollout results and downloading datasets). Since Docker containers can't access your host's AWS credential, you need to pass them explicitly via an `.env` file:
 
 ```bash
 cp $MIGRATION_DIR/.env.example $MIGRATION_DIR/.env
-# Edit .env and fill in your AWS credentials
+# Edit .env and add your AWS credentials.
+# If you have configured your AWS credential, you should be able to find
+# them at ~/.aws/credentials.
 # AWS_ACCESS_KEY_ID=your_access_key_id
 # AWS_SECRET_ACCESS_KEY=your_secret_access_key
 # AWS_REGION=us-west-2
@@ -192,15 +193,14 @@ docker run --network host --env-file $MIGRATION_DIR/.env migration:dev python -m
 You need to build docker and push it to AWS ECR for deploying agent, running evaluation or running RL training with AgentCore.
 
 ```bash
-export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
-export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
-
 cd $TOOLKIT_ROOT
 cp .env.example .env
 # Edit .env and fill in your AWS region, account ID, and ECR repo name before proceeding
 # AWS_REGION=us-west-2
 # AWS_ACCOUNT=your-aws-account-number
 # ECR_REPO_NAME=your-ecr-repo-name
+# The script uses the AWS CLI, which reads credentials from ~/.aws/credentials.
+# Make sure this is configured (e.g., run `aws configure`) before proceeding.
 
 ./scripts/build_docker_image_and_push_to_ecr.sh \
   --dockerfile=$MIGRATION_DIR/Dockerfile \
@@ -214,9 +214,6 @@ cp .env.example .env
 Create your `config.toml` file and fill in the `[agentcore]` section:
 
 ```bash
-export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
-export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
-
 cd $MIGRATION_DIR
 cp config.example.toml config.toml
 ```
@@ -269,9 +266,6 @@ sampling_params = {max_completion_tokens = 8192}
 ### Sync evaluation
 
 ```bash
-export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
-export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
-
 cd $MIGRATION_DIR
 
 # Run full evaluation
@@ -288,9 +282,6 @@ The async script supports two modes:
 - **individual**: Uses `invoke_async()` + `gather` for fine-grained control
 
 ```bash
-export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
-export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
-
 cd $MIGRATION_DIR
 
 # With custom concurrency and timeout

--- a/examples/strands_migration_agent/README.md
+++ b/examples/strands_migration_agent/README.md
@@ -79,13 +79,15 @@ mvn --version
 ## Installation
 
 ```bash
-cd examples/strands_migration_agent
+export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
+export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
+
+cd $MIGRATION_DIR
 
 uv venv --python 3.13
 source .venv/bin/activate
 uv pip install -e .
 uv pip install -e ../../ --force-reinstall --no-deps # install the parent repo
-
 ```
 
 ## Run locally
@@ -93,6 +95,8 @@ uv pip install -e ../../ --force-reinstall --no-deps # install the parent repo
 First, preprocess the MigrationBench dataset and upload to S3:
 
 ```bash
+cd $MIGRATION_DIR
+
 # Create S3 bucket if needed
 aws s3 mb s3://my-migration-bench-data
 
@@ -103,21 +107,32 @@ python preprocess.py --s3-bucket-name my-migration-bench-data
 python preprocess.py --s3-bucket-name my-migration-bench-data --max-repos-per-split 2 --skip-s3-sync
 ```
 
-After data preprocessing is done, you can start testing the agent
+After data preprocessing is done, you can start testing the agent. First, prepare the environment file so Strands runs in non-interactive server mode:
 
 ```bash
-# Start a local vLLM server
+cp .env.example .env
+```
+
+Then start the vLLM server, the app, and submit a request. Each command runs in its own terminal:
+
+```bash
+# Terminal 1: Start a local vLLM server
 vllm serve Qwen/Qwen3-Coder-30B-A3B-Instruct \
 -tp 8 \
 --port 4000 \
 --enable-auto-tool-choice \
 --tool-call-parser qwen3_coder \
 --max-model-len 262144
+```
 
-# Start the app server with hot reloading
+```bash
+# Terminal 2: Start the app server with hot reloading (from $MIGRATION_DIR)
+cd $MIGRATION_DIR
 uvicorn dev_app:app --port 8080 --reload --reload-dir ../..
+```
 
-# Submit request
+```bash
+# Terminal 3: Submit request
 curl -X POST http://localhost:8080/invocations \
   -H "Content-Type: application/json" \
   -d '{
@@ -135,21 +150,18 @@ curl -X POST http://localhost:8080/invocations \
         "sampling_params": {"max_completion_tokens": 8192}
     }
   }'
-
 ```
 
 ## Docker
 
 ### Build & run locally
 
-Set the repo root path first:
+Set the repo root path and migration agent path first, then build docker:
 
 ```bash
 export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
 export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
-```
 
-```bash
 docker buildx build \
   --build-context toolkit=$TOOLKIT_ROOT \
   -t migration:dev --load \
@@ -177,10 +189,18 @@ docker run --network host --env-file $MIGRATION_DIR/.env migration:dev python -m
 
 ### Build & push to ECR
 
+You need to build docker and push it to AWS ECR for deploying agent, running evaluation or running RL training with AgentCore.
+
 ```bash
-cd /path/to/your/agentcore-rl-toolkit/repo
+export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
+export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
+
+cd $TOOLKIT_ROOT
 cp .env.example .env
-# Edit .env and fill in your AWS credentials and ECR repo name before proceeding
+# Edit .env and fill in your AWS region, account ID, and ECR repo name before proceeding
+# AWS_REGION=us-west-2
+# AWS_ACCOUNT=your-aws-account-number
+# ECR_REPO_NAME=your-ecr-repo-name
 
 ./scripts/build_docker_image_and_push_to_ecr.sh \
   --dockerfile=$MIGRATION_DIR/Dockerfile \
@@ -194,7 +214,10 @@ cp .env.example .env
 Create your `config.toml` file and fill in the `[agentcore]` section:
 
 ```bash
-cd /path/to/your/agentcore-rl-toolkit/repo/examples/strands_migration_agent
+export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
+export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
+
+cd $MIGRATION_DIR
 cp config.example.toml config.toml
 ```
 
@@ -246,7 +269,10 @@ sampling_params = {max_completion_tokens = 8192}
 ### Sync evaluation
 
 ```bash
-cd /path/to/your/agentcore-rl-toolkit/repo/examples/strands_migration_agent
+export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
+export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
+
+cd $MIGRATION_DIR
 
 # Run full evaluation
 python evaluate.py --exp_id my_eval --max_concurrent 50 --timeout 1800
@@ -262,7 +288,10 @@ The async script supports two modes:
 - **individual**: Uses `invoke_async()` + `gather` for fine-grained control
 
 ```bash
-cd /path/to/your/agentcore-rl-toolkit/repo/examples/strands_migration_agent
+export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
+export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
+
+cd $MIGRATION_DIR
 
 # With custom concurrency and timeout
 python evaluate_async.py --mode batch --exp_id my_eval_async --max_concurrent 50 --timeout 1800

--- a/examples/strands_migration_agent/README.md
+++ b/examples/strands_migration_agent/README.md
@@ -141,42 +141,135 @@ curl -X POST http://localhost:8080/invocations \
 ## Docker
 
 ### Build & run locally
+
+Set the repo root path first:
+
 ```bash
-docker buildx build --build-context toolkit=../.. -t migration:dev --load -f Dockerfile .
+export TOOLKIT_ROOT=/path/to/your/agentcore-rl-toolkit/repo
+export MIGRATION_DIR=$TOOLKIT_ROOT/examples/strands_migration_agent
 ```
 
-Since Docker can't access your host's AWS credential chain, append these AWS credentials to your `.env` file.
+```bash
+docker buildx build \
+  --build-context toolkit=$TOOLKIT_ROOT \
+  -t migration:dev --load \
+  -f $MIGRATION_DIR/Dockerfile \
+  $MIGRATION_DIR
+```
+
+Add AWS credentials to your `.env` file since Docker can't access your host's AWS credential chain:
 
 ```bash
-AWS_ACCESS_KEY_ID=your_access_key_id
-AWS_SECRET_ACCESS_KEY=your_secret_access_key
-AWS_REGION=us-west-2
+cp $MIGRATION_DIR/.env.example $MIGRATION_DIR/.env
+# Edit .env and fill in your AWS credentials
+# AWS_ACCESS_KEY_ID=your_access_key_id
+# AWS_SECRET_ACCESS_KEY=your_secret_access_key
+# AWS_REGION=us-west-2
 ```
 
 Then start the server as follows, and send the request.
-
 ```bash
-docker run --network host --env-file .env migration:dev python -m dev_app
+# Run with host network so the agent can access the locally hosted vLLM server
+docker run --network host --env-file $MIGRATION_DIR/.env migration:dev python -m dev_app
+
+# Submit request (same curl as above)
 ```
 
 ### Build & push to ECR
 
 ```bash
+cd /path/to/your/agentcore-rl-toolkit/repo
+cp .env.example .env
+# Edit .env and fill in your AWS credentials and ECR repo name before proceeding
+
 ./scripts/build_docker_image_and_push_to_ecr.sh \
---dockerfile=examples/strands_migration_agent/Dockerfile \
---tag=dev \
---context=examples/strands_migration_agent \
---additional-context=toolkit=.
+  --dockerfile=$MIGRATION_DIR/Dockerfile \
+  --tag=dev \
+  --context=$MIGRATION_DIR \
+  --additional-context=toolkit=$TOOLKIT_ROOT
 ```
 
 ## Deploy
 
-Create your config.toml file and fill in the values.
+Create your `config.toml` file and fill in the `[agentcore]` section:
+
 ```bash
+cd /path/to/your/agentcore-rl-toolkit/repo/examples/strands_migration_agent
 cp config.example.toml config.toml
 ```
 
-Then run
+Edit `config.toml` with your deployment values:
+
+```toml
+[agentcore]
+region = "us-west-2"
+agent_name = "my_strands_migration_agent"
+image_uri = "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/example-agent:tag"  # ECR image URI from the push step
+execution_role_arn = "arn:aws:iam::ACCOUNT_ID:role/EXAMPLE_ROLE"
+
+# Network configuration (optional — omit for PUBLIC mode)
+network_mode = "VPC"
+subnets = ["subnet-xxxxxxxxxxxxxxxxx"]
+security_groups = ["sg-xxxxxxxxxxxxxxxxx"]
+```
+
+Then run:
+
 ```bash
 python deploy.py
 ```
+
+The deploy script will print the Amazon Resource Name (ARN) of your deployed agent in its output log. Copy this value — you will need it for evaluation.
+
+## Evaluate
+
+After deploying the agent to ACR, you can run batch evaluation against the MigrationBench dataset. The evaluation scripts use `RolloutClient` to submit requests to ACR and poll S3 for results.
+
+First, fill in the `agent_arn` and the `[eval]` section in your `config.toml`:
+
+- **`agent_arn`**: The ARN printed in the deploy step output log.
+- **`s3_input_bucket`**: The S3 path where `preprocess.py` uploaded the dataset. For example, if you ran `python preprocess.py --s3-bucket-name my-migration-bench-data`, the test split is at `my-migration-bench-data/tars/test/`.
+- **`s3_output_bucket`**: The S3 bucket where evaluation rollout results will be saved.
+
+```toml
+[agentcore]
+agent_arn = "arn:aws:bedrock-agentcore:REGION:ACCOUNT_ID:runtime/AGENT_ID"
+
+[eval]
+s3_input_bucket = "my-migration-bench-data/tars/test/"
+s3_output_bucket = "agentcore-rl"
+base_url = "http://INFERENCE_SERVER_IP:4000/v1"
+model_id = "Qwen/Qwen3-Coder-30B-A3B-Instruct"
+sampling_params = {max_completion_tokens = 8192}
+```
+
+### Sync evaluation
+
+```bash
+cd /path/to/your/agentcore-rl-toolkit/repo/examples/strands_migration_agent
+
+# Run full evaluation
+python evaluate.py --exp_id my_eval --max_concurrent 50 --timeout 1800
+
+# Quick test with a few repos
+python evaluate.py --exp_id my_eval_test --limit 5
+```
+
+### Async evaluation
+
+The async script supports two modes:
+- **batch** (default): Uses `run_batch_async()` with managed concurrency
+- **individual**: Uses `invoke_async()` + `gather` for fine-grained control
+
+```bash
+cd /path/to/your/agentcore-rl-toolkit/repo/examples/strands_migration_agent
+
+# With custom concurrency and timeout
+python evaluate_async.py --mode batch --exp_id my_eval_async --max_concurrent 50 --timeout 1800
+```
+
+Note that all arguments can also be passed via CLI to override `config.toml` values.
+
+Both `evaluate.py` (sync) and `evaluate_async.py` (async) can run multiple agent instances concurrently via `--max_concurrent`. The difference is that the sync script submits requests sequentially — a slow submission (e.g., ACR cold start) blocks the next one — while the async script dispatches submissions as concurrent tasks so cold starts don't block each other.
+
+Results are saved as JSONL files under `results/` (e.g., `results/my_eval.jsonl`).

--- a/examples/strands_migration_agent/config.example.toml
+++ b/examples/strands_migration_agent/config.example.toml
@@ -19,3 +19,4 @@ s3_input_bucket = "my-benchmark-bucket/path/to/inputs/"
 s3_output_bucket = "my-rollout-results-bucket"
 base_url = "http://INFERENCE_SERVER_IP:8000/v1"
 model_id = "my-model-id"
+sampling_params = {temperature = 0.0}

--- a/examples/strands_migration_agent/evaluate.py
+++ b/examples/strands_migration_agent/evaluate.py
@@ -1,6 +1,7 @@
 """Evaluation script for migration agent using RolloutClient.run_batch()."""
 
 import argparse
+import json
 import logging
 import time
 from pathlib import Path
@@ -73,6 +74,12 @@ def main():
         default=None,
         help="Limit number of repositories to evaluate (for testing)",
     )
+    parser.add_argument(
+        "--sampling_params",
+        type=str,
+        default=eval_config.get("sampling_params"),
+        help="Sampling parameters as JSON string (e.g. '{\"temperature\": 0.7}')",
+    )
 
     args = parser.parse_args()
 
@@ -112,6 +119,14 @@ def main():
 
     logger.info(f"Results will be written to: {result_path}")
 
+    # Parse sampling params
+    sampling_params = {}
+    if args.sampling_params:
+        if isinstance(args.sampling_params, str):
+            sampling_params = json.loads(args.sampling_params)
+        else:
+            sampling_params = dict(args.sampling_params)
+
     # Create client
     client = RolloutClient(
         agent_runtime_arn=args.agent_arn,
@@ -119,6 +134,8 @@ def main():
         exp_id=args.exp_id,
         base_url=args.base_url,
         model_id=args.model_id,
+        max_pool_connections=args.max_concurrent,
+        sampling_params=sampling_params,
     )
 
     # Run batch and stream results

--- a/examples/strands_migration_agent/evaluate_async.py
+++ b/examples/strands_migration_agent/evaluate_async.py
@@ -2,6 +2,7 @@
 
 import argparse
 import asyncio
+import json
 import logging
 import time
 from pathlib import Path
@@ -200,6 +201,12 @@ async def main():
         default=None,
         help="Limit number of repositories to evaluate (for testing)",
     )
+    parser.add_argument(
+        "--sampling_params",
+        type=str,
+        default=eval_config.get("sampling_params"),
+        help="Sampling parameters as JSON string (e.g. '{\"temperature\": 0.7}')",
+    )
 
     args = parser.parse_args()
 
@@ -240,13 +247,26 @@ async def main():
 
     logger.info(f"Results will be written to: {result_path}")
 
+    # Parse sampling params
+    sampling_params = {}
+    if args.sampling_params:
+        if isinstance(args.sampling_params, str):
+            sampling_params = json.loads(args.sampling_params)
+        else:
+            sampling_params = dict(args.sampling_params)
+
     # Create client
+    # In batch mode, concurrency is capped by max_concurrent.
+    # In individual mode, all payloads are submitted at once.
+    max_pool = args.max_concurrent if args.mode == "batch" else len(payloads)
     client = RolloutClient(
         agent_runtime_arn=args.agent_arn,
         s3_bucket=args.s3_output_bucket,
         exp_id=args.exp_id,
         base_url=args.base_url,
         model_id=args.model_id,
+        max_pool_connections=max_pool,
+        sampling_params=sampling_params,
     )
 
     # Run evaluation

--- a/src/agentcore_rl_toolkit/client.py
+++ b/src/agentcore_rl_toolkit/client.py
@@ -272,6 +272,7 @@ class RolloutClient:
         exp_id: str,
         max_retry_attempts: int = 5,
         tps_limit: int = 25,
+        max_pool_connections: int = 10,
         # Optional model inference config (for vLLM/SGLang servers)
         base_url: str = None,
         model_id: str = None,
@@ -287,6 +288,9 @@ class RolloutClient:
             exp_id: Experiment ID for organizing results
             max_retry_attempts: Max retries for transient errors (default: 5)
             tps_limit: ACR invocation rate limit (default: 25)
+            max_pool_connections: Max urllib3 connection pool size per boto3 client (default: 10).
+                Set to at least the max number of concurrent requests to avoid
+                "Connection pool is full, discarding connection" warnings.
             base_url: Optional vLLM/SGLang server URL
             model_id: Optional model ID for inference
             **extra_config: Additional config passed to _rollout (e.g., temperature, top_p)
@@ -303,7 +307,10 @@ class RolloutClient:
         self.region = self._parse_region_from_arn(agent_runtime_arn)
 
         # Configure boto3 with adaptive retry for 429/503
-        config = Config(retries={"max_attempts": max_retry_attempts, "mode": "adaptive"})
+        config = Config(
+            retries={"max_attempts": max_retry_attempts, "mode": "adaptive"},
+            max_pool_connections=max_pool_connections,
+        )
         self.agentcore_client = boto3.client("bedrock-agentcore", region_name=self.region, config=config)
         self.s3_client = boto3.client("s3", region_name=self.region, config=config)
 


### PR DESCRIPTION
- Avoid throwing "Connection pool is full, discarding connection" warnings by setting max_pool_connections in boto config.
- Enable passing sampling parameters in evaluation script.
- Polish migration agent example's readme.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
