### PR TITLE
feat(migration-agent): enable user to tune max_pool_connections

### DIFF
--- a/examples/strands_migration_agent/README.md
+++ b/examples/strands_migration_agent/README.md
@@ -292,4 +292,12 @@ Note that all arguments can also be passed via CLI to override `config.toml` val
 
 Both `evaluate.py` (sync) and `evaluate_async.py` (async) can run multiple agent instances concurrently via `--max_concurrent`. The difference is that the sync script submits requests sequentially — a slow submission (e.g., ACR cold start) blocks the next one — while the async script dispatches submissions as concurrent tasks so cold starts don't block each other.
 
+#### Connection pool sizing
+
+Both scripts accept `--max_pool_connections` (default: 10) to control the urllib3 connection pool size for boto3 clients. If this value is smaller than `--max_concurrent`, you may see urllib3 warnings like `"Connection pool is full, discarding connection"`. This is **not an error** — requests still succeed, but excess connections are created and discarded instead of being reused from the pool, adding minor TCP/TLS handshake overhead. If you want to eliminate these warnings, you can set `--max_pool_connections` to match `--max_concurrent`:
+
+```bash
+python evaluate.py --exp_id my_eval --max_concurrent 50 --max_pool_connections 50
+```
+
 Results are saved as JSONL files under `results/` (e.g., `results/my_eval.jsonl`).

--- a/examples/strands_migration_agent/evaluate.py
+++ b/examples/strands_migration_agent/evaluate.py
@@ -75,6 +75,16 @@ def main():
         help="Limit number of repositories to evaluate (for testing)",
     )
     parser.add_argument(
+        "--max_pool_connections",
+        type=int,
+        default=10,
+        help="Max urllib3 connection pool size for boto3 clients (default: 10). "
+        "If this value is smaller than --max_concurrent, you may see urllib3 warnings "
+        "'Connection pool is full, discarding connection'. This is not an error — "
+        "requests still succeed, but excess connections are created and discarded "
+        "instead of being reused from the pool, adding minor TCP/TLS overhead. ",
+    )
+    parser.add_argument(
         "--sampling_params",
         type=str,
         default=eval_config.get("sampling_params"),
@@ -134,7 +144,7 @@ def main():
         exp_id=args.exp_id,
         base_url=args.base_url,
         model_id=args.model_id,
-        max_pool_connections=args.max_concurrent,
+        max_pool_connections=args.max_pool_connections,
         sampling_params=sampling_params,
     )
 

--- a/examples/strands_migration_agent/evaluate_async.py
+++ b/examples/strands_migration_agent/evaluate_async.py
@@ -202,6 +202,16 @@ async def main():
         help="Limit number of repositories to evaluate (for testing)",
     )
     parser.add_argument(
+        "--max_pool_connections",
+        type=int,
+        default=10,
+        help="Max urllib3 connection pool size for boto3 clients (default: 10). "
+        "If this value is smaller than --max_concurrent, you may see urllib3 warnings "
+        "'Connection pool is full, discarding connection'. This is not an error — "
+        "requests still succeed, but excess connections are created and discarded "
+        "instead of being reused from the pool, adding minor TCP/TLS overhead. ",
+    )
+    parser.add_argument(
         "--sampling_params",
         type=str,
         default=eval_config.get("sampling_params"),
@@ -256,16 +266,13 @@ async def main():
             sampling_params = dict(args.sampling_params)
 
     # Create client
-    # In batch mode, concurrency is capped by max_concurrent.
-    # In individual mode, all payloads are submitted at once.
-    max_pool = args.max_concurrent if args.mode == "batch" else len(payloads)
     client = RolloutClient(
         agent_runtime_arn=args.agent_arn,
         s3_bucket=args.s3_output_bucket,
         exp_id=args.exp_id,
         base_url=args.base_url,
         model_id=args.model_id,
-        max_pool_connections=max_pool,
+        max_pool_connections=args.max_pool_connections,
         sampling_params=sampling_params,
     )
 


### PR DESCRIPTION
max_pool_connections is not auto inferred in evaluation script, but user could set it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
