### PR TITLE
feat(client): Automatically update async loop lock if async event loop has changed

### DIFF
--- a/src/agentcore_rl_toolkit/client.py
+++ b/src/agentcore_rl_toolkit/client.py
@@ -373,9 +373,15 @@ class RolloutClient:
         )
 
     def _get_async_lock(self) -> asyncio.Lock:
-        """Lazily create and return the async rate-limiting lock."""
-        if not hasattr(self, "_async_lock"):
+        """Lazily create and return the async rate-limiting lock.
+
+        Detects when the running event loop has changed (e.g., due to a new
+        ``asyncio.run()`` call) and recreates the lock for the current loop.
+        """
+        loop = asyncio.get_running_loop()
+        if not hasattr(self, "_async_lock") or self._async_lock_loop is not loop:
             self._async_lock = asyncio.Lock()
+            self._async_lock_loop = loop
         return self._async_lock
 
     async def _async_rate_limited_invoke(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 """Tests for RolloutClient, RolloutFuture, and BatchResult."""
 
+import asyncio
 import io
 import json
 import time
@@ -467,6 +468,26 @@ class TestRolloutClient:
             future = client.invoke({"prompt": "test"}, input_id="my-input")
 
             assert future.input_id == "my-input"
+
+    def test_get_async_lock_recreated_for_new_event_loop(self):
+        """Lock is recreated when _get_async_lock() is called from a different event loop."""
+        with patch("agentcore_rl_toolkit.client.boto3"):
+            client = RolloutClient(
+                agent_runtime_arn="arn:aws:bedrock-agentcore:us-west-2:123:agent/test",
+                s3_bucket="test-bucket",
+                exp_id="exp-001",
+            )
+
+        locks = []
+
+        async def capture_lock():
+            locks.append(client._get_async_lock())
+
+        asyncio.run(capture_lock())
+        asyncio.run(capture_lock())  # new event loop
+
+        assert len(locks) == 2
+        assert locks[0] is not locks[1]
 
     def test_run_batch_returns_batch_result(self):
         """Test run_batch() returns a BatchResult."""


### PR DESCRIPTION
Automatically update async loop lock if async event loop has changed. This is needed for RL training where every training step creates a new async event loop to block progress until all rollouts in the batch complete.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
