### PR TITLE
fix(example): standardize OfficeBench app naming and correct known issues

### DIFF
--- a/examples/strands_officebench_agent/Dockerfile
+++ b/examples/strands_officebench_agent/Dockerfile
@@ -52,4 +52,4 @@ EXPOSE 9000
 EXPOSE 8000
 EXPOSE 8080
 
-CMD ["opentelemetry-instrument", "python", "-m", "dev_app"]
+CMD ["opentelemetry-instrument", "python", "-m", "rl_app"]

--- a/examples/strands_officebench_agent/README.md
+++ b/examples/strands_officebench_agent/README.md
@@ -226,16 +226,14 @@ strands_officebench_agent/
 
 ## Known Issues
 
-### OfficeBench data issues (4 tasks)
+### OfficeBench data issues (2 tasks)
 
 These tasks have bugs in the ground truth and will always fail regardless of agent capability:
 
 | Task | Issue |
 |------|-------|
-| `1-10/3` | `evaluate_excel_cell_value` expects `201000` but source has `2000000` |
-| `1-14/2` | Filename typo: `salery.xlsx` should be `salary.xlsx` |
-| `1-15/1` | Keywords not in source file `sample_syllabus.docx` |
-| `1-15/2` | Keywords not in source file `project_report.docx` |
+| `1-10/3` | `evaluate_excel_cell_value` expects `201000` but correct answer is `2001000` (2000000 + 1000) |
+| `1-14/2` | Filename typo: eval references `salery.xlsx` but actual file is `salary.xlsx` |
 
 ### Local testing limitations
 

--- a/examples/strands_officebench_agent/README.md
+++ b/examples/strands_officebench_agent/README.md
@@ -207,7 +207,7 @@ OFFICEBENCH_DIR=/path/to/OfficeBench python run_local_eval.py --exp_id local_tes
 
 ```
 strands_officebench_agent/
-├── dev_app.py          # AgentCoreRLApp with @rollout_entrypoint (runs in ACR)
+├── rl_app.py           # AgentCoreRLApp with @rollout_entrypoint (runs in ACR)
 ├── tools.py            # 20 Strands @tool wrappers for OfficeBench apps
 ├── reward.py           # OfficeBenchReward with 9 evaluation functions
 ├── models.py           # Pydantic request models

--- a/examples/strands_officebench_agent/preprocess.py
+++ b/examples/strands_officebench_agent/preprocess.py
@@ -1,7 +1,7 @@
 """Package OfficeBench tasks for S3 consumption.
 
 Uploads task configs and testbed data to S3 in a format
-that dev_app.py can consume during ACR invocations.
+that rl_app.py can consume during ACR invocations.
 
 Each task directory can contain multiple subtasks (0.json, 1.json, ...),
 and all subtasks share the same testbed. Each subtask is uploaded as a

--- a/examples/strands_officebench_agent/pyproject.toml
+++ b/examples/strands_officebench_agent/pyproject.toml
@@ -24,4 +24,4 @@ dependencies = [
 ]
 
 [tool.setuptools]
-py-modules = ["dev_app", "reward", "models", "utils", "tools"]
+py-modules = ["rl_app", "reward", "models", "utils", "tools"]

--- a/examples/strands_officebench_agent/rl_app.py
+++ b/examples/strands_officebench_agent/rl_app.py
@@ -5,7 +5,6 @@ from dotenv import load_dotenv
 from models import InvocationRequest
 from reward import OfficeBenchReward
 from strands import Agent
-from strands.agent.conversation_manager import NullConversationManager
 from strands.models import BedrockModel
 from strands_tools import shell
 from tools import ALL_TOOLS
@@ -86,7 +85,6 @@ def invoke_agent(payload: dict):
         model=model,
         tools=[shell, *ALL_TOOLS],
         system_prompt=system_prompt,
-        conversation_manager=NullConversationManager(),
     )
 
     # Run agent on the task

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "agentcore-rl-toolkit"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },


### PR DESCRIPTION
## Summary

  Align OfficeBench example with upstream changes from PR #39:

  - Renamed `dev_app.py` → `rl_app.py` for consistency with migration agent naming convention
  - Removed `NullConversationManager` (default conversation manager works for single-invocation rollouts)
  - Updated all references in Dockerfile, pyproject.toml, README, and preprocess.py
  - Corrected known issues list in README: reduced from 4 to 2 confirmed ground truth bugs (the other 2 were false
  positives where the agent is expected to modify the file)

  ## Changes

  - `dev_app.py` → `rl_app.py`: file rename + removed `NullConversationManager` import/usage
  - `Dockerfile`: CMD updated to `rl_app`
  - `pyproject.toml`: py-modules updated to `rl_app`
  - `preprocess.py`: stale comment reference updated
  - `README.md`: file structure updated, known issues corrected from 4 to 2

  ## Verified

  - Reward format already compatible (`rewards == 1.0`, not list indexing)
  - No functional changes to agent logic, tools, reward evaluation, or benchmark scripts
  - Ruff lint + format pass
