### PR TITLE
fix(vllm): Use streaming mode of OpenAIModel parent in vLLMModel

### DIFF
--- a/src/agentcore_rl_toolkit/frameworks/strands/vllm_model.py
+++ b/src/agentcore_rl_toolkit/frameworks/strands/vllm_model.py
@@ -41,8 +41,8 @@ class vLLMModel(OpenAIModel):
         **kwargs: Any,
     ) -> dict[str, Any]:
         request = super().format_request(messages, tool_specs, system_prompt, tool_choice, **kwargs)
-        request["stream"] = False
-        request.pop("stream_options", None)
+        # Parent already sets stream=True and stream_options={"include_usage": True}.
+        # Add vLLM-specific extra_body to return token IDs in each streaming chunk.
         existing_extra = request.get("extra_body", {})
         existing_extra["return_token_ids"] = True
         request["extra_body"] = existing_extra
@@ -58,6 +58,16 @@ class vLLMModel(OpenAIModel):
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:
+        """Stream chat completions from vLLM, collecting token data for RL training.
+
+        Follows the same streaming event protocol as the parent OpenAIModel.stream(),
+        but additionally accumulates prompt_token_ids, response token_ids, and logprobs
+        from each chunk (vLLM extensions via return_token_ids=True).
+
+        Uses streaming mode so that vLLM can detect client disconnects (e.g., when an
+        ACR container is killed on timeout) and abort in-flight generation, freeing
+        GPU slots immediately instead of running orphaned requests to completion.
+        """
         request = self.format_request(messages, tool_specs, system_prompt, tool_choice, **kwargs)
 
         async with self._get_client() as client:
@@ -70,38 +80,97 @@ class vLLMModel(OpenAIModel):
             except openai.RateLimitError as e:
                 raise ModelThrottledException(str(e)) from e
 
-            # Store token data
-            choice = response.choices[0]
-            logprobs = []
-            if choice.logprobs and choice.logprobs.content:
-                logprobs = [lp.logprob for lp in choice.logprobs.content]
+            # Accumulators for RL token data (collected from vLLM-specific chunk fields)
+            prompt_ids: list[int] = []
+            response_ids: list[int] = []
+            response_logprobs: list[float] = []
 
-            self._token_data.append(
-                {
-                    "prompt_ids": getattr(response, "prompt_token_ids", []) or [],
-                    "response_ids": getattr(choice, "token_ids", []) or [],
-                    "response_logprobs": logprobs,
-                }
-            )
-
-            # Yield synthetic stream events for Strands compatibility
             yield self.format_chunk({"chunk_type": "message_start"})
+            tool_calls: dict[int, list[Any]] = {}
+            data_type = None
+            finish_reason = None
+            event = None
 
-            message = choice.message
-            if message.content:
-                yield self.format_chunk({"chunk_type": "content_start", "data_type": "text"})
-                yield self.format_chunk({"chunk_type": "content_delta", "data_type": "text", "data": message.content})
-                yield self.format_chunk({"chunk_type": "content_stop", "data_type": "text"})
+            async for event in response:
+                raw = event.model_dump()
 
-            for tool_call in message.tool_calls or []:
-                yield self.format_chunk({"chunk_type": "content_start", "data_type": "tool", "data": tool_call})
-                yield self.format_chunk({"chunk_type": "content_delta", "data_type": "tool", "data": tool_call})
+                # Collect prompt_token_ids from response-level field (first chunk that has it)
+                if not prompt_ids and "prompt_token_ids" in raw:
+                    prompt_ids = raw["prompt_token_ids"] or []
+
+                if not getattr(event, "choices", None):
+                    continue
+                choice = event.choices[0]
+                choice_raw = raw["choices"][0] if raw.get("choices") else {}
+
+                # Collect per-token response IDs (vLLM extension)
+                token_ids = choice_raw.get("token_ids") or choice_raw.get("delta", {}).get("token_ids")
+                if token_ids:
+                    if isinstance(token_ids, list):
+                        response_ids.extend(token_ids)
+                    else:
+                        response_ids.append(token_ids)
+
+                # Collect per-token logprobs
+                if choice.logprobs and choice.logprobs.content:
+                    for lp in choice.logprobs.content:
+                        response_logprobs.append(lp.logprob)
+
+                # Yield stream events (mirrors parent OpenAIModel.stream() protocol)
+                if hasattr(choice.delta, "reasoning_content") and choice.delta.reasoning_content:
+                    chunks, data_type = self._stream_switch_content("reasoning_content", data_type)
+                    for chunk in chunks:
+                        yield chunk
+                    yield self.format_chunk(
+                        {
+                            "chunk_type": "content_delta",
+                            "data_type": data_type,
+                            "data": choice.delta.reasoning_content,
+                        }
+                    )
+
+                if choice.delta.content:
+                    chunks, data_type = self._stream_switch_content("text", data_type)
+                    for chunk in chunks:
+                        yield chunk
+                    yield self.format_chunk(
+                        {"chunk_type": "content_delta", "data_type": "text", "data": choice.delta.content}
+                    )
+
+                for tool_call in choice.delta.tool_calls or []:
+                    tool_calls.setdefault(tool_call.index, []).append(tool_call)
+
+                if choice.finish_reason:
+                    finish_reason = choice.finish_reason
+                    if data_type:
+                        yield self.format_chunk({"chunk_type": "content_stop", "data_type": data_type})
+                    break
+
+            for tool_deltas in tool_calls.values():
+                yield self.format_chunk({"chunk_type": "content_start", "data_type": "tool", "data": tool_deltas[0]})
+                for tool_delta in tool_deltas:
+                    yield self.format_chunk({"chunk_type": "content_delta", "data_type": "tool", "data": tool_delta})
                 yield self.format_chunk({"chunk_type": "content_stop", "data_type": "tool"})
 
-            yield self.format_chunk({"chunk_type": "message_stop", "data": choice.finish_reason})
+            yield self.format_chunk({"chunk_type": "message_stop", "data": finish_reason or "end_turn"})
 
-            if response.usage:
-                yield self.format_chunk({"chunk_type": "metadata", "data": response.usage})
+            # Consume remaining chunks for usage metadata
+            async for event in response:
+                raw = event.model_dump()
+                if not prompt_ids and "prompt_token_ids" in raw:
+                    prompt_ids = raw["prompt_token_ids"] or []
+
+            if event and hasattr(event, "usage") and event.usage:
+                yield self.format_chunk({"chunk_type": "metadata", "data": event.usage})
+
+            # Store collected token data for RL training
+            self._token_data.append(
+                {
+                    "prompt_ids": prompt_ids,
+                    "response_ids": response_ids,
+                    "response_logprobs": response_logprobs,
+                }
+            )
 
     def get_token_data(self) -> list[dict[str, Any]]:
         return self._token_data


### PR DESCRIPTION
Use streaming mode of OpenAIModel parent in vLLMModel so that vLLM can detect client disconnects and abort orphaned requests. This reduces vLLM server workload and timeout errors when doing batch evaluation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
