### PR TITLE
feat(slime): support arbitrary agent payload shapes in the training backend

### DIFF
--- a/src/agentcore_rl_toolkit/backends/slime/SETUP.md
+++ b/src/agentcore_rl_toolkit/backends/slime/SETUP.md
@@ -112,10 +112,21 @@ ds = load_dataset('openai/gsm8k', 'main', split='train')
 with open('/path/to/gsm8k_tiny.jsonl', 'w') as f:
     for i, row in enumerate(ds):
         if i >= 64: break
+        question = row['question']
         answer = row['answer'].split('####')[-1].strip()
-        f.write(json.dumps({'prompt': row['question'], 'label': answer}) + '\n')
+        # Top-level 'prompt' is read by slime (tokenization, length filter).
+        # 'metadata' is the agent payload verbatim — shape it however the agent expects.
+        f.write(json.dumps({
+            'prompt': question,
+            'metadata': {'prompt': question, 'answer': answer},
+        }) + '\n')
 "
 ```
+
+The agent-visible payload is exactly the contents of ``metadata``, so
+different agents can use different payload shapes (e.g. ``{'task_id': ...}``
+for AppWorld, ``{'repo_uri': ..., 'metadata_uri': ..., ...}`` for
+migration) without any slime-side changes.
 
 ### 3.3 Configure deployment settings
 

--- a/src/agentcore_rl_toolkit/backends/slime/examples/math_agent/train.sh
+++ b/src/agentcore_rl_toolkit/backends/slime/examples/math_agent/train.sh
@@ -80,7 +80,6 @@ ray job submit --address="http://127.0.0.1:8265" \
   --tensor-model-parallel-size ${TP_SIZE} \
   --rollout-num-gpus-per-engine ${ROLLOUT_GPUS_PER_ENGINE} \
   --input-key prompt \
-  --label-key label \
   --rollout-batch-size 32 \
   --n-samples-per-prompt 8 \
   --rollout-max-response-len 1024 \

--- a/src/agentcore_rl_toolkit/backends/slime/integration/rollout.py
+++ b/src/agentcore_rl_toolkit/backends/slime/integration/rollout.py
@@ -209,52 +209,20 @@ def _ensure_initialized(args: Namespace):
 
 
 def _sample_to_payload(sample) -> dict:
-    """Convert a slime Sample to an ART invocation payload.
+    """The agent payload is the JSONL row's ``metadata`` dict, verbatim.
 
-    Extracts all non-None public fields from the Sample into the payload.
-    The agent's @rollout_entrypoint receives this dict as `payload`.
+    slime's Dataset reads the JSONL row's ``metadata`` field into
+    ``Sample.metadata``; we hand that dict to the agent unchanged. The JSONL's
+    top-level ``prompt`` field is for slime (tokenization, length filtering);
+    the agent's payload shape is entirely defined by whatever the data author
+    put in ``metadata``. A shallow copy isolates the agent's view from
+    downstream mutations to ``Sample.metadata`` (e.g. ``task_metadata``
+    injection in ``_process_one_episode``).
     """
-    payload = {}
-
-    if hasattr(sample, "prompt") and sample.prompt:
-        payload["prompt"] = sample.prompt
-    if hasattr(sample, "label") and sample.label is not None:
-        payload["answer"] = sample.label
-    if hasattr(sample, "metadata") and sample.metadata:
-        payload["metadata"] = sample.metadata
-
-    if hasattr(sample, "to_dict"):
-        for key, value in sample.to_dict().items():
-            if (
-                key not in payload
-                and value is not None
-                and key
-                not in (
-                    "tokens",
-                    "rollout_log_probs",
-                    "loss_mask",
-                    "teacher_log_probs",
-                    "rollout_routed_experts",
-                    "multimodal_inputs",
-                    "multimodal_train_inputs",
-                    "group_index",
-                    "index",
-                    "status",
-                    "session_id",
-                    "spec_info",
-                    "prefix_cache_info",
-                    "response_length",
-                    "response",
-                    "weight_versions",
-                    "remove_sample",
-                    "non_generation_time",
-                    "generate_function_path",
-                    "train_metadata",
-                )
-            ):
-                payload[key] = value
-
-    return payload
+    metadata = getattr(sample, "metadata", None)
+    if isinstance(metadata, dict):
+        return dict(metadata)
+    return {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_slime_rollout_payload.py
+++ b/tests/test_slime_rollout_payload.py
@@ -1,0 +1,66 @@
+"""Tests for the slime backend's agent-payload conversion.
+
+``_sample_to_payload`` is the contract between slime's ``Sample`` object
+and the agent's ``@rollout_entrypoint`` payload. Post the data-contract
+change, the rule is: the agent receives ``Sample.metadata`` verbatim
+(shallow-copied). These tests pin that rule so the contract can't
+regress silently.
+"""
+
+from types import SimpleNamespace
+
+from agentcore_rl_toolkit.backends.slime.integration.rollout import _sample_to_payload
+
+
+def test_metadata_is_returned_verbatim():
+    sample = SimpleNamespace(metadata={"task_id": "t1", "prompt": "hi"})
+    assert _sample_to_payload(sample) == {"task_id": "t1", "prompt": "hi"}
+
+
+def test_empty_metadata_returns_empty_dict():
+    sample = SimpleNamespace(metadata={})
+    assert _sample_to_payload(sample) == {}
+
+
+def test_missing_metadata_attr_returns_empty_dict():
+    sample = SimpleNamespace()
+    assert _sample_to_payload(sample) == {}
+
+
+def test_none_metadata_returns_empty_dict():
+    sample = SimpleNamespace(metadata=None)
+    assert _sample_to_payload(sample) == {}
+
+
+def test_non_dict_metadata_returns_empty_dict():
+    sample = SimpleNamespace(metadata="not a dict")
+    assert _sample_to_payload(sample) == {}
+
+
+def test_returned_dict_is_a_shallow_copy():
+    """Mutations to the returned payload must not leak into Sample.metadata.
+
+    _process_one_episode mutates ``Sample.metadata`` (e.g. injects
+    ``task_metadata``) downstream; the agent's view must remain stable.
+    """
+    metadata = {"prompt": "hi", "answer": "42"}
+    sample = SimpleNamespace(metadata=metadata)
+
+    payload = _sample_to_payload(sample)
+    payload["injected"] = True
+
+    assert "injected" not in metadata
+
+
+def test_prompt_and_label_on_sample_are_ignored():
+    """Top-level sample.prompt / sample.label are no longer part of the payload.
+
+    They exist on ``Sample`` for slime's own use (tokenization, logging).
+    Post the data-contract change, only ``metadata`` reaches the agent.
+    """
+    sample = SimpleNamespace(
+        prompt="slime-side prompt",
+        label="slime-side label",
+        metadata={"foo": "bar"},
+    )
+    assert _sample_to_payload(sample) == {"foo": "bar"}

--- a/tests/test_slime_rollout_payload.py
+++ b/tests/test_slime_rollout_payload.py
@@ -1,10 +1,8 @@
 """Tests for the slime backend's agent-payload conversion.
 
 ``_sample_to_payload`` is the contract between slime's ``Sample`` object
-and the agent's ``@rollout_entrypoint`` payload. Post the data-contract
-change, the rule is: the agent receives ``Sample.metadata`` verbatim
-(shallow-copied). These tests pin that rule so the contract can't
-regress silently.
+and the agent's ``@rollout_entrypoint`` payload. The rule: the agent
+receives ``Sample.metadata`` verbatim (shallow-copied).
 """
 
 from types import SimpleNamespace
@@ -13,37 +11,26 @@ from agentcore_rl_toolkit.backends.slime.integration.rollout import _sample_to_p
 
 
 def test_metadata_is_returned_verbatim():
-    sample = SimpleNamespace(metadata={"task_id": "t1", "prompt": "hi"})
-    assert _sample_to_payload(sample) == {"task_id": "t1", "prompt": "hi"}
+    """Core contract: the agent payload is Sample.metadata as-is.
 
-
-def test_empty_metadata_returns_empty_dict():
-    sample = SimpleNamespace(metadata={})
-    assert _sample_to_payload(sample) == {}
-
-
-def test_missing_metadata_attr_returns_empty_dict():
-    sample = SimpleNamespace()
-    assert _sample_to_payload(sample) == {}
-
-
-def test_none_metadata_returns_empty_dict():
-    sample = SimpleNamespace(metadata=None)
-    assert _sample_to_payload(sample) == {}
-
-
-def test_non_dict_metadata_returns_empty_dict():
-    sample = SimpleNamespace(metadata="not a dict")
-    assert _sample_to_payload(sample) == {}
+    Fields on Sample outside metadata (prompt, label) are slime's own
+    concern and must not leak into the payload.
+    """
+    sample = SimpleNamespace(
+        prompt="slime-side prompt",
+        label="slime-side label",
+        metadata={"task_id": "t1", "answer": "42"},
+    )
+    assert _sample_to_payload(sample) == {"task_id": "t1", "answer": "42"}
 
 
 def test_returned_dict_is_a_shallow_copy():
-    """Mutations to the returned payload must not leak into Sample.metadata.
+    """Mutations to the payload must not leak back into Sample.metadata.
 
-    _process_one_episode mutates ``Sample.metadata`` (e.g. injects
-    ``task_metadata``) downstream; the agent's view must remain stable.
+    ``_process_one_episode`` later injects keys into ``Sample.metadata``
+    (e.g. ``task_metadata``); the agent's view must stay stable.
     """
-    metadata = {"prompt": "hi", "answer": "42"}
+    metadata = {"prompt": "hi"}
     sample = SimpleNamespace(metadata=metadata)
 
     payload = _sample_to_payload(sample)
@@ -52,15 +39,11 @@ def test_returned_dict_is_a_shallow_copy():
     assert "injected" not in metadata
 
 
-def test_prompt_and_label_on_sample_are_ignored():
-    """Top-level sample.prompt / sample.label are no longer part of the payload.
-
-    They exist on ``Sample`` for slime's own use (tokenization, logging).
-    Post the data-contract change, only ``metadata`` reaches the agent.
-    """
-    sample = SimpleNamespace(
-        prompt="slime-side prompt",
-        label="slime-side label",
-        metadata={"foo": "bar"},
-    )
-    assert _sample_to_payload(sample) == {"foo": "bar"}
+def test_missing_or_invalid_metadata_returns_empty_dict():
+    """Defensive fallback when metadata is absent or not a dict."""
+    for sample in [
+        SimpleNamespace(),  # attribute absent
+        SimpleNamespace(metadata=None),  # explicit None
+        SimpleNamespace(metadata="not a dict"),  # wrong type
+    ]:
+        assert _sample_to_payload(sample) == {}

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,9 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
+slime = [
+    { name = "rllm-model-gateway" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -31,8 +34,27 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "rllm-model-gateway", marker = "extra == 'slime'", specifier = ">=0.1.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "slime"]
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
 
 [[package]]
 name = "annotated-types"
@@ -335,6 +357,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -1219,6 +1257,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "rllm-model-gateway"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/45/6134fa839037a425a54c6e63abeb22afbd8902564eca3890d430fb87f87a/rllm_model_gateway-0.1.0.tar.gz", hash = "sha256:11be2368ca9c1b81ce2639d6451ab9054e90a55f5c46e70971d4cd6d7a335612", size = 40247, upload-time = "2026-03-12T04:35:06.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/73/4c88d3b6f369c6643d5efa6d80e3a69099d5cba00b7a82d7f0b2ed30cb78/rllm_model_gateway-0.1.0-py3-none-any.whl", hash = "sha256:3963661cac8f29e803a725f13abfe719f3e1b94bf2885b17ffc009eafb92e562", size = 26971, upload-time = "2026-03-12T04:35:05.52Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Goal

Let the slime training backend carry **any agent payload shape** from the JSONL dataset to the agent, so agents with different input schemas (GSM8K, AppWorld, migration, OfficeBench, future ones) can train through slime without bespoke integration changes.

Before this PR, \`_sample_to_payload\` hardcoded the GSM8K shape (\`prompt\` + \`answer\` top-level plus a nested \`metadata\` dict), which forced every other agent into workarounds. After this PR, the JSONL row's \`metadata\` dict **is** the agent payload verbatim — the data author owns the schema, the framework holds no opinion.

## User-facing effect

Each agent declares its payload shape by choosing what keys go in \`metadata\`:

| Agent | JSONL row shape | Agent reads |
|---|---|---|
| Math (GSM8K) | \`{prompt, metadata: {prompt, answer}}\` | \`payload["prompt"]\`, \`payload["answer"]\` |
| AppWorld | \`{prompt, metadata: {task_id}}\` | \`payload["task_id"]\` |
| Migration | \`{prompt, metadata: {repo_uri, metadata_uri, ...}}\` | \`InvocationRequest(**payload)\` |
| OfficeBench | \`{prompt, metadata: {task_uri, testbed_uri}}\` | \`InvocationRequest(**payload)\` |

The top-level \`prompt\` field stays — it drives slime's tokenizer / length filter. The agent-visible payload comes entirely from \`metadata\`.

## How

One-line replacement in \`backends/slime/integration/rollout.py::_sample_to_payload\`: return a shallow copy of \`Sample.metadata\`. All the old hardcoded-shape logic is deleted.

Plan: [\`docs/roadmap/committed/slime-data-contract.md\`](https://github.com/awslabs/agentcore-rl-toolkit/blob/docs/core-api-rename-roadmap/docs/roadmap/committed/slime-data-contract.md) (on the PR #59 branch).

## Breaking change

JSONLs in the old \`{prompt, label}\` shape produce empty agent payloads under the new rule. Regenerate with the updated SETUP.md data-prep snippet, which emits \`{prompt, metadata: {prompt, answer}}\`. The math agent's \`rl_app.py\` already reads \`payload["prompt"]\` / \`payload["answer"]\` and works without changes once the JSONL is regenerated.

## End-to-end smoke test

Ran \`bash train.sh\` with \`NUM_ROLLOUT=10\` on Qwen2.5-3B-Instruct + 64-row GSM8K (\`slimerl/slime:latest\` container, 8 × H100):

| Rollout | raw_reward |
|---|---|
| 0 | 0.271 |
| 1 | 0.308 |
| 2 | 0.346 |
| 3 | 0.540 |
| 4 | 0.441 |
| 5 | 0.633 |
| 6 | 0.552 |
| 7 | 0.597 |
| 8 | 0.458 |
| 9 | 0.556 |

Reward climbs from 0.27 → 0.63 over 10 rollouts — GRPO is learning under the new contract. All 10 train steps logged \`train/loss\`, \`train/grad_norm\`, and progressed \`train/step\` monotonically. No Tracebacks or FAILED session statuses (one transient ACR ThrottlingException was caught and retried; two atexit tracebacks from Ray teardown at job exit are cosmetic).

## Test plan

- [x] Unit tests (\`tests/test_slime_rollout_payload.py\`) pin the contract: metadata-in-is-payload-out, empty/missing/None/non-dict metadata → \`{}\`, returned dict is a shallow copy, \`sample.prompt\` / \`sample.label\` are ignored.
- [x] Existing test suite passes (79 tests).
- [x] End-to-end smoke test (10-rollout training on Qwen2.5-3B, rewards climb, loss moves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)