### PR TITLE
Fix missing aws region issue when using code artifact.

### DIFF
--- a/examples/strands_migration_agent/utils.py
+++ b/examples/strands_migration_agent/utils.py
@@ -15,9 +15,10 @@ def configure_codeartifact_token():
     domain = os.environ.get("CODEARTIFACT_DOMAIN")
     owner = os.environ.get("CODEARTIFACT_OWNER")
     repo = os.environ.get("CODEARTIFACT_REPO")
+    region = os.environ.get("AWS_REGION", "us-west-2")
     if not domain or not owner or not repo:
         return
-    ca = boto3.client("codeartifact")
+    ca = boto3.client("codeartifact", region_name=region)
     token = ca.get_authorization_token(domain=domain, domainOwner=owner)["authorizationToken"]
     url = ca.get_repository_endpoint(domain=domain, domainOwner=owner, repository=repo, format="maven")[
         "repositoryEndpoint"


### PR DESCRIPTION
*Issue #, if available:*
`ca = boto3.client("codeartifact")` requires an aws region. The current implementation will raise exception:
```
      raise NoRegionError()                                                                                                                                                                                                                                                                    
  botocore.exceptions.NoRegionError: You must specify a region.
```
*Description of changes:*
Get AWS_REGION from dotenv and pass into boto3.client("codeartifact", region_name=region)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
