### PR TITLE
chore(migration-agent): pin migrationbench to upstream-fix commit

### DIFF
--- a/examples/strands_migration_agent/pyproject.toml
+++ b/examples/strands_migration_agent/pyproject.toml
@@ -19,5 +19,5 @@ dependencies = [
 py-modules = ["rl_app", "reward", "models", "utils"]
 
 [tool.uv.sources]
-migrationbench = { git = "https://github.com/amazon-science/MigrationBench.git" }
+migrationbench = { git = "https://github.com/amazon-science/MigrationBench.git", rev = "d764faaf0b77c7f17a8e82e05aebd8a5ff664662" }
 java-migration-agent = { git = "https://github.com/amazon-science/JavaMigration.git", subdirectory = "java_migration_agent" }


### PR DESCRIPTION
*Description of changes:*

Pin `migrationbench` to commit `d764faa` so the example uses the fixed `same_repo_test_files` return shape from [MigrationBench#18](https://github.com/amazon-science/MigrationBench/pull/18).

Without this pin, the dependency tracks `main` and the reward function's`@Test`-equivalence check could silently regress if upstream introduces return-shape changes. Pinning makes evaluation results reproducible across machines and over time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
