### PR TITLE
fix(strands-migration-agent): bound mvn pre-warm, harden copytree, skip redundant mvn dependency:resolve retry

### DIFF
--- a/examples/strands_migration_agent/reward.py
+++ b/examples/strands_migration_agent/reward.py
@@ -31,9 +31,18 @@ class MigrationReward(RewardFunction):
 
         reward = 0
         with tempfile.TemporaryDirectory() as temp_dir:
-            # copy repo_dir to a temp dir for evaluation
+            # copy repo_dir to a temp dir for evaluation. Skip node_modules
+            # (frontend-maven-plugin's npm tree contains symlinks like
+            # `node_modules/.bin/in-install` that break copytree) and tolerate
+            # other dangling symlinks left by build artifacts.
             temp_repo_dir = os.path.join(temp_dir, os.path.basename(repo_dir))
-            shutil.copytree(repo_dir, temp_repo_dir)
+            shutil.copytree(
+                repo_dir,
+                temp_repo_dir,
+                symlinks=True,
+                ignore_dangling_symlinks=True,
+                ignore=shutil.ignore_patterns("node_modules"),
+            )
 
             if self.eval_build_success(repo_dir=temp_repo_dir, require_maximal_migration=require_maximal_migration):
                 logger.info("build succeeded!")
@@ -61,8 +70,21 @@ class MigrationReward(RewardFunction):
         maven_command: str = maven_utils.MVN_CLEAN_VERIFY,
         require_maximal_migration: bool = False,
     ):
+        # MVN_DEPENDENCY_RESOLVE_MAX_ATTEMPTS=0 disables the upstream `mvn dependency:resolve`
+        # pre-flight retry loop (default 10x). That retry treats `Downloading from` log lines as
+        # progress, which never breaks early on multi-module SNAPSHOT repos like
+        # apache/hbase-operator-tools — every attempt fails identically on inter-module SNAPSHOT
+        # resolution but keeps redownloading other plugins, costing ~5min per reward eval.
+        # `mvn clean verify` runs full reactor-aware resolution itself, so the pre-flight is redundant.
         build_success = (
-            (maven_utils.do_run_maven_command(maven_command.format(root_dir=repo_dir), check=False).return_code == 0)
+            (
+                maven_utils.do_run_maven_command(
+                    maven_command.format(root_dir=repo_dir),
+                    check=False,
+                    MVN_DEPENDENCY_RESOLVE_MAX_ATTEMPTS=0,
+                ).return_code
+                == 0
+            )
             and (
                 (require_compiled_java_major_version is None)
                 or (utils.get_compiled_java_major_versions(repo_dir) == {require_compiled_java_major_version})
@@ -73,7 +95,11 @@ class MigrationReward(RewardFunction):
 
     @staticmethod
     def eval_test_equivalence(repo_dir: str, original_num_tests: int, original_commit_id: str):
-        mvn_tests = maven_utils.do_run_maven_command(maven_utils.MVN_NUM_TESTS.format(root_dir=repo_dir), check=False)
+        mvn_tests = maven_utils.do_run_maven_command(
+            maven_utils.MVN_NUM_TESTS.format(root_dir=repo_dir),
+            check=False,
+            MVN_DEPENDENCY_RESOLVE_MAX_ATTEMPTS=0,
+        )
         num_tests = hash_utils.get_num_test_cases(repo_dir, mvn_tests.stdout)
 
         num_tests_match = num_tests is not None and num_tests >= original_num_tests

--- a/examples/strands_migration_agent/utils.py
+++ b/examples/strands_migration_agent/utils.py
@@ -79,15 +79,21 @@ def setup_repo_environment(repo_path: str, apply_static_update: bool = False):
     # fetching Node.js) that `dependency:go-offline` would miss.
     # The build will likely fail (repo is still Java 8), but that's fine —
     # the goal is to cache downloads so the agent's later `mvn clean verify` is quieter.
-    result = subprocess.run(
-        ["mvn", "clean", "verify"],
-        cwd=repo_path,
-        capture_output=True,
-    )
-    if result.returncode == 0:
-        logger.info("Pre-warm build succeeded")
-    else:
-        logger.info("Pre-warm build failed (expected — repo not yet migrated)")
+    # Bound the wall-clock at 300s to match `migration_bench.common.maven_utils.MVN_TIMEOUT_SECONDS`
+    # — some repos hang indefinitely on integration tests or embedded servers during pre-warm.
+    try:
+        result = subprocess.run(
+            ["mvn", "clean", "verify"],
+            cwd=repo_path,
+            capture_output=True,
+            timeout=300,
+        )
+        if result.returncode == 0:
+            logger.info("Pre-warm build succeeded")
+        else:
+            logger.info("Pre-warm build failed (expected — repo not yet migrated)")
+    except subprocess.TimeoutExpired:
+        logger.warning("Pre-warm build timed out after 300s — continuing without warmed cache")
 
     # ensure git works
     subprocess.run(


### PR DESCRIPTION
*Description of changes:*

### Summary

Three fixes for deterministic failures observed during MigrationBench RL training against repos from
[`AmazonScience/migration-bench-java-full`](https://huggingface.co/datasets/AmazonScience/migration-bench-java-full) and `migration-bench-java-selected`. Companion upstream PR for the AST crash: [amazon-science/MigrationBench#19](https://github.com/amazon-science/MigrationBench/pull/19).

### Changes

**`utils.py` — bound `mvn clean verify` pre-warm at 300s.** Some repos hang indefinitely on integration tests / embedded servers during pre-warm, killing the rollout before the agent ever runs. Now wrapped in `try/except subprocess.TimeoutExpired` with `timeout=300` (matches upstream `MVN_TIMEOUT_SECONDS`). Fixes `apache/hbase-operator-tools`, `DataFabricRus/scylla-rdf` (train); `Erudika/para`, `diennea/blazingcache` (val). Note, however, these repos could still end up failing because `mvn clean verify` will be still be called down the road, but with the 300s cap we can at least see clearly from logs what blocked the agent. 

**`reward.py` — harden `shutil.copytree`.** The reward snapshot used a bare `copytree`, which aborts on dangling symlinks (npm `node_modules/.bin/*`, Maven `target/classes/*.config`). Now uses `symlinks=True, ignore_dangling_symlinks=True, ignore=ignore_patterns("node_modules")`. Fixes `bbende/project-starter`, `junkdog/ecs-matrix` (train); `pzinsta/pizzeria` (val).

**`reward.py` — skip redundant `mvn dependency:resolve` pre-flight.** `maven_utils.do_run_maven_command` retries `dependency:resolve` up to 10x while it sees `Downloading from` lines. On multi-module SNAPSHOT repos every attempt
fails identically but the heuristic keeps retrying. Both calls in `MigrationReward` now pass `MVN_DEPENDENCY_RESOLVE_MAX_ATTEMPTS=0`. `mvn clean verify` does its own resolution. Saves ~5 min per reward eval on hbase-shaped repos.

### Before / after

| Repo | Mode pre-fix | Pre-fix outcome | Post-fix reward | Elapsed |
|---|---|---|---:|---:|
| `thomasmueller/tinyStats` | parse_file enum crash | `ValueError`, rollout errored | **1.0** | 130s |
| `bbende/project-starter` | copytree on `node_modules` | `shutil.Error`, rollout errored | **0.5** | 300s |
| `junkdog/ecs-matrix` | copytree on dangling symlinks | `shutil.Error`, rollout errored | 0 (real Java 17 incompat) | 76s |
| `apache/hbase-operator-tools` | mvn pre-warm hang | rollout dropped, num_steps=0 | 0 (legit build fail) | 3598s |

Pre-fix all four would have raised exceptions or hung indefinitely. Post-fix all four flow through the reward function and produce numeric rewards.

Validated end-to-end against a local vLLM-served Qwen3-Coder-30B via sequential tests over the repos.

### Follow-up Action Items

- After amazon-science/MigrationBench#19 lands: bump`pyproject.toml:22` `migrationbench` `rev`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
