### PR TITLE
fix(strands-migration-agent): handle empty assistant turn when logging model response

### DIFF
--- a/examples/strands_migration_agent/pyproject.toml
+++ b/examples/strands_migration_agent/pyproject.toml
@@ -19,5 +19,5 @@ dependencies = [
 py-modules = ["rl_app", "reward", "models", "utils"]
 
 [tool.uv.sources]
-migrationbench = { git = "https://github.com/amazon-science/MigrationBench.git", rev = "d764faaf0b77c7f17a8e82e05aebd8a5ff664662" }
+migrationbench = { git = "https://github.com/amazon-science/MigrationBench.git", rev = "19acd9eb3a402d825f200eb14cf01584eaa1f6e9" }
 java-migration-agent = { git = "https://github.com/amazon-science/JavaMigration.git", subdirectory = "java_migration_agent" }

--- a/examples/strands_migration_agent/rl_app.py
+++ b/examples/strands_migration_agent/rl_app.py
@@ -104,7 +104,13 @@ def invoke_agent(payload: dict):
 
     response = agent(user_input)
 
-    logger.info(f'Model response: {response.message["content"][0]["text"]}')
+    # Strands ends the loop on stop_reason=end_turn even when message.content is empty
+    # (model emits <|im_end|> as its only output token — rare but valid). Pick the first
+    # text block if any, otherwise fall back to a placeholder so logging doesn't crash.
+    content_blocks = response.message.get("content", [])
+    texts = [c["text"] for c in content_blocks if "text" in c]
+    response_text = texts[0] if texts else "(empty assistant turn)"
+    logger.info(f"Model response: {response_text}")
 
     reward = reward_fn(
         repo_dir=repo_path,


### PR DESCRIPTION
## Summary
- Observed in production rollouts: `response.message["content"][0]["text"]` crashes with `IndexError` when Strands ends the agent loop on `stop_reason=end_turn` with an empty `content` list (model emits only `<|im_end|>`). Pick the first text block if present, otherwise log a placeholder so the rollout can still return a reward.
- Bump `migrationbench` git pin to `19acd9eb` (rolled in here to avoid a trivial separate PR).

## Tests
- [x] Re-run training and hasn't observed similar error (sampling is deterministic, so hard to verify). 
- [x] Run a normal rollout and confirm the logged response text matches the first text block as before.
- [x] `uv sync` in `examples/strands_migration_agent` resolves the new `migrationbench` rev.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
