### PR TITLE
fix(strands-migration-agent): return reward 0 when agent deletes its workspace

### DIFF
--- a/examples/strands_migration_agent/reward.py
+++ b/examples/strands_migration_agent/reward.py
@@ -30,6 +30,13 @@ class MigrationReward(RewardFunction):
         """
 
         reward = 0
+        # The agent occasionally `rm -rf`'s its own workspace (giving up after a failed
+        # build, then hallucinating a successful migration in its summary message).
+        # Score that as a normal failed migration instead of letting copytree raise.
+        if not os.path.isdir(repo_dir):
+            logger.warning("repo_dir missing — agent likely deleted it: %s", repo_dir)
+            return reward
+
         with tempfile.TemporaryDirectory() as temp_dir:
             # copy repo_dir to a temp dir for evaluation. Skip node_modules
             # (frontend-maven-plugin's npm tree contains symlinks like


### PR DESCRIPTION
*Description of changes:*

- Pre-flight `os.path.isdir(repo_dir)` check in `MigrationReward.__call__` before `shutil.copytree`.
- When the agent has `rm -rf`'d its own workspace (typically after giving up on a failed build and hallucinating success in its summary), score the rollout as a normal failed migration (reward=0) instead of letting copytree raise and surfacing as `status_code=500`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
