### PR TITLE
feat(example): add Strands Tau2-Bench agent example

### DIFF
--- a/examples/strands_taubench_agent/.bedrock_agentcore/strands_taubench_agent_rl_test/Dockerfile
+++ b/examples/strands_taubench_agent/.bedrock_agentcore/strands_taubench_agent_rl_test/Dockerfile
@@ -1,0 +1,48 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+WORKDIR /app
+
+# All environment variables in one layer
+ENV UV_SYSTEM_PYTHON=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_NO_PROGRESS=1 \
+    PYTHONUNBUFFERED=1 \
+    DOCKER_CONTAINER=1 \
+    AWS_REGION=us-west-2 \
+    AWS_DEFAULT_REGION=us-west-2
+
+# Manual add
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/sierra-research/tau2-bench.git /opt/tau2-bench && \
+    cd /opt/tau2-bench && git checkout 70e700c && \
+    uv pip install -e .
+
+COPY . .
+# Install from pyproject.toml directory
+RUN cd . && uv pip install .
+
+
+
+
+RUN uv pip install aws-opentelemetry-distro==0.12.2
+
+
+# Signal that this is running in Docker for host binding logic
+ENV DOCKER_CONTAINER=1
+
+# Create non-root user
+RUN useradd -m -u 1000 bedrock_agentcore
+USER bedrock_agentcore
+
+EXPOSE 9000
+EXPOSE 8000
+EXPOSE 8080
+
+# Copy entire project (respecting .dockerignore)
+COPY . .
+
+# Use the full module path
+
+CMD ["opentelemetry-instrument", "python", "-m", "rl_app"]

--- a/examples/strands_taubench_agent/.dockerignore
+++ b/examples/strands_taubench_agent/.dockerignore
@@ -1,0 +1,75 @@
+# Build artifacts
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Python cache
+__pycache__/
+__pycache__*
+*.py[cod]
+*$py.class
+*.so
+.Python
+
+# Virtual environments
+.venv/
+.env
+venv/
+env/
+ENV/
+
+# Node.js
+node_modules/
+
+# Testing
+.pytest_cache/
+.coverage
+.coverage*
+htmlcov/
+.tox/
+*.cover
+.hypothesis/
+.mypy_cache/
+.ruff_cache/
+
+# Development
+*.log
+*.bak
+*.swp
+*.swo
+*~
+.DS_Store
+
+# IDEs
+.vscode/
+.idea/
+
+# Version control
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+docs/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Project specific
+tests/
+
+# Bedrock AgentCore specific - keep config but exclude runtime files
+.bedrock_agentcore.yaml
+.dockerignore
+.bedrock_agentcore/
+
+# Keep wheelhouse for offline installations
+# wheelhouse/
+
+# Monorepo directories
+cdk/
+terraform/
+mcp/lambda/

--- a/examples/strands_taubench_agent/README.md
+++ b/examples/strands_taubench_agent/README.md
@@ -1,0 +1,275 @@
+# Strands Tau-Bench Agent
+
+RL-adapted [tau2-bench](https://github.com/sierra-research/tau2-bench) agent for
+training with Bedrock AgentCore Runtime (ACR). Supports the **airline**,
+**retail**, and **telecom** tau-bench domains from a single deployment.
+
+Each rollout is a multi-turn conversation between two models:
+
+- **Assistant** — the vLLM-served model being trained (a customer-service agent
+  that follows the domain policy and calls tau-bench tools).
+- **User simulator** — a Bedrock Claude model that plays the customer, driven by
+  the task's scenario.
+
+Tool calls execute against a fresh tau-bench environment (DB + tools); telecom
+additionally exposes user-side tools (device actions). The reward follows
+tau-bench's `reward_basis` (DB / COMMUNICATE / ENV_ASSERTION / ACTION) and is
+computed deterministically at the end of the rollout.
+
+## Architecture
+
+```
+Training Cluster (e.g. HyperPod)
+├── Training Engine (veRL / GRPO)
+├── vLLM Inference Server (serves the model being trained)
+│
+└──► ACR (Bedrock AgentCore Runtime)
+     ├── Agent Session 1  ──► vLLM       (assistant inference)
+     ├── Agent Session 2       + Bedrock (user simulator)
+     └── ...                   + tau-bench env (tools + DB)
+         │
+         └──► S3 (rollout data + rewards)
+```
+
+The assistant model is reached over HTTP via `base_url` (passed per-invocation
+in the `_rollout` payload). The user simulator calls Bedrock using the ACR
+container's execution-role credentials — see [IAM permissions](#5-set-up-iam-permissions).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `rl_app.py` | Entrypoint — multi-turn orchestrator with `@rollout_entrypoint` |
+| `reward.py` | `TauBenchReward` — DB / COMMUNICATE / ENV_ASSERTION / ACTION axes, dispatched per task by `reward_basis` |
+| `utils.py` | Strands tool wrapping, message-role conversion, thinking-token handling |
+| `constants.py` | System prompts, user-model config, orchestrator config, `DOMAINS_USER_TOOLS` |
+| `pyproject.toml` | Example dependencies (tau2-bench is installed separately via the Dockerfile) |
+| `test_local.py` | Smoke test — runs one task against a local server or a deployed ACR agent |
+| `tasks/` | Sample tau2-bench tasks, one per domain (airline / retail / telecom) |
+
+## Prerequisites
+
+- **AWS credentials** with access to Bedrock (user simulator), S3 (rollout
+  results), and AgentCore. Verify with `aws sts get-caller-identity`.
+- A **vLLM server** serving the model being trained.
+- An **S3 bucket** for rollout results.
+
+Two separate packages are involved — don't confuse them:
+
+| Package | What it gives you | Source |
+|---------|-------------------|--------|
+| `agentcore-rl-toolkit` (this repo) | The RL SDK (`AgentCoreRLApp`, `@rollout_entrypoint`, `vLLMModel`) **and this example** | `git clone` (below) |
+| `bedrock-agentcore-starter-toolkit` | AWS's `agentcore` CLI used to deploy to ACR | `pip install` (below) |
+
+## Installation
+
+```bash
+# 1. Clone this repo — it provides both the RL SDK source and this example folder
+git clone https://github.com/awslabs/agentcore-rl-toolkit.git
+cd agentcore-rl-toolkit/examples/strands_taubench_agent
+
+# 2. Install the agentcore CLI (a separate AWS tool, used in the deploy steps below)
+pip install bedrock-agentcore-starter-toolkit
+
+# 3. Create the example's environment and install its dependencies
+uv venv --python 3.13
+source .venv/bin/activate
+uv pip install -e .
+uv pip install -e ../../ --force-reinstall --no-deps  # install agentcore-rl-toolkit from local source
+```
+
+> tau2-bench is **not** a pip dependency — it is not on PyPI and its data files
+> require an editable install from the repo root, so it is not in `pyproject.toml`.
+> It is installed inside the container instead (see [step 2](#2-customize-the-dockerfile)).
+
+## Run RL App on ACR
+
+The common RL-training setup serves the model being trained from a local vLLM
+server and runs many parallel rollouts on ACR. The steps below deploy this
+agent to ACR.
+
+### 1. Configure the ACR agent
+
+```bash
+cd examples/strands_taubench_agent
+
+# Network details from your vLLM instance (so ACR can reach the server inside the VPC)
+SUBNET_ID="subnet-0123456789abcdefg"
+SECURITY_GROUP_ID="sg-0123456789abcdefg"
+
+agentcore configure --entrypoint rl_app.py \
+  --name strands_taubench_agent_rl_test \
+  --requirements-file pyproject.toml \
+  --deployment-type container \
+  --vpc --subnets $SUBNET_ID --security-groups $SECURITY_GROUP_ID \
+  --disable-memory \
+  --non-interactive
+```
+
+This writes config to `.bedrock_agentcore.yaml` and generates a Dockerfile at
+`.bedrock_agentcore/strands_taubench_agent_rl_test/Dockerfile`.
+
+> If your vLLM server is reachable at a public URL instead of inside a VPC, drop
+> the `--vpc --subnets --security-groups` flags to deploy to the public network.
+
+### 2. Customize the Dockerfile
+
+The auto-generated Dockerfile installs this example's dependencies but **not
+tau2-bench** (which isn't on PyPI). Add one section to clone and editable-install
+tau2-bench at a pinned commit, before the `COPY . .` line:
+
+```dockerfile
+# --- tau2-bench: editable install at a pinned commit ---
+# tau2-bench isn't on PyPI; its data/ dir must be reachable via the repo layout,
+# so an editable install is required.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/sierra-research/tau2-bench.git /opt/tau2-bench && \
+    cd /opt/tau2-bench && git checkout 70e700c && \
+    uv pip install -e .
+```
+
+> **Pin tau2-bench to the commit your tasks were authored against.** The reward
+> code is tightly coupled to a specific tau2 version: `_compute_db_reward`
+> compares DB hashes, `_compute_env_assertion_reward` runs tau2 assertion
+> functions, and tool schemas come from tau2's `openai_schema`. A different tau2
+> version (e.g. a future tau-3) can silently change rewards with no error. Pin it.
+
+The agent reads the stock tau2 DBs bundled at that commit. The reward stays
+correct because `_compute_db_reward` builds both the gold and predicted
+environments from the same `get_environment()` call, so both sides read the same
+DB — the hash comparison is internally consistent.
+
+### 3. Deploy to ACR
+
+```bash
+agentcore deploy --agent strands_taubench_agent_rl_test
+```
+
+This uploads the source, builds the (ARM64) image via CodeBuild, pushes it to
+ECR, and registers the agent runtime.
+
+Record two values from this step — both are in `.bedrock_agentcore.yaml` (and
+printed in the deploy logs):
+
+- **`agent_runtime_arn`** — the training engine needs it to invoke the agent.
+- **`execution_role`** — the IAM role the agent runs as, e.g.
+  `arn:aws:iam::123456789:role/AmazonBedrockAgentCoreSDKRuntime-us-west-2-abc123`.
+  You grant it S3 + Bedrock permissions in [step 5](#5-set-up-iam-permissions).
+
+### 4. Set up S3
+
+```bash
+aws s3 mb s3://agentcore-rl   # skip if the bucket already exists
+```
+
+Rollout results are written here as `s3://<bucket>/<exp_id>/<input_id>_<session_id>.json`.
+
+### 5. Set up IAM permissions
+
+Grant the ACR agent's execution role permission to write rollout results to S3:
+
+```bash
+# Find execution_role in .bedrock_agentcore.yaml, e.g.
+# arn:aws:iam::123456789:role/AmazonBedrockAgentCoreSDKRuntime-us-west-2-abc123
+# -> set ROLE_NAME to the part after "role/"
+ROLE_NAME="YOUR_ROLE_NAME_HERE"
+
+aws iam put-role-policy --role-name $ROLE_NAME \
+  --policy-name TauBenchRLAccess \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["s3:PutObject", "s3:GetObject"],
+        "Resource": "arn:aws:s3:::agentcore-rl/*"
+      }
+    ]
+  }'
+```
+
+> The user simulator calls Bedrock (defaults to `global.anthropic.claude-opus-4-6-v1`;
+> see `USER_MODEL_CONFIG` in `constants.py`). The auto-generated ACR execution
+> role normally already grants Bedrock invoke access — if user turns fail with
+> `AccessDeniedException`, add `bedrock:InvokeModel` permission to the role.
+
+### 6. Set up the vLLM server
+
+Serve the model being trained from a vLLM server reachable by ACR. For example:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-4B-Instruct-2507 \
+  --max-model-len 8192 --port 4000 \
+  --enable-auto-tool-choice --tool-call-parser hermes
+```
+
+The training engine (or your test) passes this server's address and model id to
+the agent per-invocation via the `_rollout` payload:
+
+```jsonc
+"_rollout": {
+  "base_url": "http://<vllm-host>:4000/v1",   // assistant inference endpoint
+  "model_id": "Qwen/Qwen3-4B-Instruct-2507",  // must match --served-model-name
+  "exp_id": "test",
+  "s3_bucket": "agentcore-rl",
+  "session_id": "session_123",
+  "input_id": "task_123"
+}
+```
+
+### 7. Test the agent
+
+`test_local.py` runs a single tau-bench task end-to-end. Three sample tasks ship
+in `tasks/` (one per domain) — each is a raw tau2-bench task with a single write
+action, sampled from the stock tau2 DBs so they work out of the box. The domain
+is read from the task file, so you only pass the task path and model config.
+
+**Local server** — run `rl_app.py` directly, before (or instead of) deploying.
+Because the agent runs in your own environment here, tau2-bench must be installed
+locally. With the `.venv` from [Installation](#installation) active, clone
+tau2-bench into this example folder and editable-install it at the pinned commit:
+
+```bash
+# from examples/strands_taubench_agent, with .venv active
+git clone https://github.com/sierra-research/tau2-bench.git
+cd tau2-bench && git checkout 70e700c && uv pip install -e .
+cd ..
+```
+
+Then run the server in one terminal and the test in another:
+
+```bash
+python rl_app.py &        # serves on localhost:8080
+python test_local.py --task tasks/airline_example.json \
+  --base-url http://localhost:4000/v1 \
+  --model-id Qwen/Qwen3-4B-Instruct-2507
+```
+
+**Deployed ACR agent** — add `--acr` and `--agent-name`. No local tau2-bench
+needed here; the agent runs inside the container, which already has it:
+
+```bash
+python test_local.py --task tasks/retail_example.json --acr \
+  --agent-name strands_taubench_agent_rl_test \
+  --base-url http://localhost:4000/v1 \
+  --model-id Qwen/Qwen3-4B-Instruct-2507 \
+  --s3-bucket agentcore-rl
+```
+
+The result (rollout data, reward, conversation, metadata) is written to
+`s3://<bucket>/test/task_123_session_123.json`. Swap `--task` to any of
+`tasks/{airline,retail,telecom}_example.json` to exercise a different domain —
+the same image serves all three.
+
+### 8. Redeployment
+
+After code changes, rebuild and re-register:
+
+```bash
+agentcore deploy --agent strands_taubench_agent_rl_test
+```
+
+The first invocation after a redeploy cold-starts (image pull + container init).

--- a/examples/strands_taubench_agent/README.md
+++ b/examples/strands_taubench_agent/README.md
@@ -68,14 +68,17 @@ Two separate packages are involved — don't confuse them:
 git clone https://github.com/awslabs/agentcore-rl-toolkit.git
 cd agentcore-rl-toolkit/examples/strands_taubench_agent
 
-# 2. Install the agentcore CLI (a separate AWS tool, used in the deploy steps below)
-pip install bedrock-agentcore-starter-toolkit
-
-# 3. Create the example's environment and install its dependencies
+# 2. Create and activate the example's environment
 uv venv --python 3.13
 source .venv/bin/activate
+
+# 3. Install dependencies into the venv:
+#    a) the example's own deps (pyproject.toml)
+#    b) agentcore-rl-toolkit from local source (so unreleased SDK changes are picked up)
+#    c) the agentcore CLI (separate AWS tool, used in the deploy steps below)
 uv pip install -e .
-uv pip install -e ../../ --force-reinstall --no-deps  # install agentcore-rl-toolkit from local source
+uv pip install -e ../../ --force-reinstall --no-deps
+uv pip install bedrock-agentcore-starter-toolkit
 ```
 
 > tau2-bench is **not** a pip dependency — it is not on PyPI and its data files

--- a/examples/strands_taubench_agent/constants.py
+++ b/examples/strands_taubench_agent/constants.py
@@ -1,0 +1,87 @@
+USER_MODEL_CONFIG = {
+    "bedrock": {
+        "model_id": "global.anthropic.claude-opus-4-6-v1",
+        "temperature": 1.0,
+        "max_tokens": 2048,
+        "thinking_enabled": False,
+        "thinking_budget": 1024,  # only used when thinking_enabled is True
+    },
+}
+
+ASSISTANT_MODEL_DEFAULTS = {
+    "max_tokens": 2048,
+    "extra_body": {
+        "chat_template_kwargs": {"enable_thinking": True},
+    },
+}
+
+ORCHESTRATOR_CONFIG = {
+    "max_turns": 50,
+    "strip_thinking_from_history": True,  # if true, assistant's thinking is stripped from
+    # conversation history (forces self-contained reasoning
+    # per turn, avoids context length blowup in RL rollouts)
+    "db_path": None,  # custom DB path (e.g., db_working.json with new records from task init)
+    # if None, uses the default DB bundled with tau-bench
+}
+
+
+DOMAINS_USER_TOOLS = ["telecom"]
+
+
+ASSISTANT_INSTRUCTION = """
+You are a customer service agent that helps the user according to the <policy> provided below.
+In each turn you can either:
+- Send a message to the user.
+- Make a tool call.
+You cannot do both at the same time. After tool call, you should send message to user to communicate information.
+
+Try to be helpful and always follow the policy. Always make sure you generate valid JSON only.
+
+""".strip()
+
+ASSISTANT_SYSTEM_PROMPT = """
+<instructions>
+{assistant_instruction}
+</instructions>
+<policy>
+{assistant_policy}
+</policy>
+""".strip()
+
+
+USER_SYSTEM_PROMPT = """
+{global_user_sim_guidelines}
+
+<scenario>
+{instructions}
+</scenario>
+""".strip()
+
+# Appended for stablizing user simulator
+USER_SYSTEM_PROMPT += """
+
+# Verification Checklist:
+[] I've taken actions that the assistant asked, e.g. if assistant asks me to reboot device,
+I literally call `reboot_device()` instead of saying "I'll do it later".
+[] I've faithfully complied with the task instructions given to me, on every constraint,
+without altering them.
+[] If I am going to change my mind about an item the assistant has just proposed an action on
+(e.g., assistant says "I will do A on item X" and I want B on that same item X instead), I MUST
+raise this BEFORE confirming. I say "wait, for item X please do B instead of A, because ..." and
+only confirm after the assistant updates the plan. I do NOT say "yes, proceed" and then ask to undo it
+ — once the assistant has acted on item X, that action cannot be reliably reverted.
+""".strip()
+
+
+# User termination commands
+OUT_OF_SCOPE = "###OUT-OF-SCOPE###"
+STOP = "###STOP###"
+TRANSFER = "###TRANSFER###"
+TERMINATION_KEYWORDS = [STOP, TRANSFER, OUT_OF_SCOPE]
+
+# Malformed tool call markers that models may leak into text
+MALFORMED_TOOL_CALL_TAGS = ["<tool_call>"]
+
+# Strands content-block keys
+TOOL_USE_KEY = "toolUse"
+TOOL_RESULT_KEY = "toolResult"

--- a/examples/strands_taubench_agent/pyproject.toml
+++ b/examples/strands_taubench_agent/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "strands-taubench-agent-example"
+version = "0.1.0"
+description = "Example: Strands Tau-Bench Agent using Bedrock AgentCore RL Toolkit"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "agentcore-rl-toolkit>=0.1.0",
+    "strands-agents[openai]>=1.18.0",
+]
+
+[tool.setuptools]
+py-modules = ["rl_app", "reward", "utils", "constants"]

--- a/examples/strands_taubench_agent/reward.py
+++ b/examples/strands_taubench_agent/reward.py
@@ -1,0 +1,277 @@
+import logging
+from typing import Any, Optional
+
+from tau2.data_model.tasks import EnvAssertion, EnvFunctionCall
+
+from agentcore_rl_toolkit import RewardFunction
+
+logger = logging.getLogger(__name__)
+
+
+class TauBenchReward(RewardFunction):
+    """
+    Computes tau-bench reward based on task's reward_basis.
+
+    Args:
+        get_environment_func: dict mapping domain name -> environment constructor callable
+    """
+
+    def __init__(self, get_environment_func: dict):
+        self.get_environment_func = get_environment_func
+
+    def __call__(
+        self, env: Any, task: dict, domain: str, messages: Optional[list[dict]] = None, **kwargs: Any
+    ) -> tuple[float, dict]:
+        """
+        Compute reward for a completed tau-bench rollout.
+
+        Args:
+            env: The post-rollout Environment (already mutated by agent's tool calls)
+            task: Task dict from the payload (raw JSON, not Pydantic)
+            domain: Domain name ("airline", "retail", "telecom")
+            messages: Global message list in Strands format (for COMMUNICATE and ACTION checking)
+
+        Returns:
+            tuple: (reward: float, reward_info: dict)
+                - reward: scalar in [0, 1] based on reward_basis
+                - reward_info: detailed breakdown with db_check, communicate_checks,
+                  env_assertion_checks, action_checks, reward_basis, reward_breakdown
+        """
+        eval_criteria = task.get("evaluation_criteria") or {}
+        reward_basis = eval_criteria.get("reward_basis")
+        # Default to DB only
+        if not reward_basis:
+            reward_basis = ["DB"]
+
+        reward = 1.0
+        reward_breakdown = {}
+        reward_info = {"reward_basis": reward_basis}
+
+        if "DB" in reward_basis:
+            db_reward, db_check = self._compute_db_reward(env, task, domain)
+            reward *= db_reward
+            reward_breakdown["DB"] = db_reward
+            reward_info["db_check"] = db_check
+
+        if "COMMUNICATE" in reward_basis:
+            comm_reward, comm_checks = self._compute_communicate_reward(eval_criteria, messages or [])
+            reward *= comm_reward
+            reward_breakdown["COMMUNICATE"] = comm_reward
+            reward_info["communicate_checks"] = comm_checks
+
+        if "ENV_ASSERTION" in reward_basis:
+            env_reward, env_checks = self._compute_env_assertion_reward(env, eval_criteria)
+            reward *= env_reward
+            reward_breakdown["ENV_ASSERTION"] = env_reward
+            reward_info["env_assertion_checks"] = env_checks
+
+        # ACTION axis: count toward reward when listed in reward_basis;
+        # otherwise still compute and surface as diagnostic-only.
+        action_checks = self._compute_action_checks(eval_criteria, messages or [])
+        reward_info["action_checks"] = action_checks
+        if "ACTION" in reward_basis:
+            action_reward = (
+                1.0
+                if action_checks and all(c["action_match"] for c in action_checks)
+                else (1.0 if not action_checks else 0.0)
+            )
+            reward *= action_reward
+            reward_breakdown["ACTION"] = action_reward
+            logger.info("ACTION reward: %s", action_reward)
+
+        reward_info["reward"] = reward
+        reward_info["reward_breakdown"] = reward_breakdown
+        return reward, reward_info
+
+    def _compute_db_reward(self, env: Any, task: dict, domain: str) -> tuple[float, dict]:
+        """
+        Compare DB hashes between predicted env (live) and gold env (fresh + golden actions).
+
+        The live `env` was mutated during the rollout via use_tool/sync_tools, so it already
+        represents the predicted environment state — no need to replay the trajectory.
+
+        Returns:
+            tuple: (reward: float, db_check: dict)
+        """
+        eval_criteria = task.get("evaluation_criteria") or {}
+        golden_actions = eval_criteria.get("actions") or []
+
+        # Build gold environment: init + golden actions
+        get_environment = self.get_environment_func[domain]
+        gold_env = get_environment()
+
+        # Replay initialization
+        initial_state = task.get("initial_state") or {}
+        for action in initial_state.get("initialization_actions") or []:
+            gold_env.run_env_function_call(EnvFunctionCall(**action))
+
+        # Run golden actions
+        for action in golden_actions:
+            try:
+                gold_env.make_tool_call(
+                    tool_name=action["name"],
+                    requestor=action.get("requestor", "assistant"),
+                    **action.get("arguments", {}),
+                )
+            except Exception as e:
+                logger.warning("Gold action %s failed: %s", action["name"], e)
+
+        # Compare agent DB hashes
+        gold_agent_hash = gold_env.get_db_hash()
+        pred_agent_hash = env.get_db_hash()
+        agent_match = gold_agent_hash == pred_agent_hash
+
+        # Compare user DB hashes (only telecom has user_tools; others return None)
+        gold_user_hash = gold_env.get_user_db_hash()
+        pred_user_hash = env.get_user_db_hash()
+        if gold_user_hash is not None and pred_user_hash is not None:
+            user_match = gold_user_hash == pred_user_hash
+        else:
+            user_match = True
+
+        db_reward = 1.0 if (agent_match and user_match) else 0.0
+        db_check = {
+            "db_match": agent_match and user_match,
+            "db_reward": db_reward,
+            "agent_db_match": agent_match,
+            "user_db_match": user_match,
+        }
+        logger.info("DB reward: %s (agent_match=%s, user_match=%s)", db_reward, agent_match, user_match)
+        return db_reward, db_check
+
+    def _compute_communicate_reward(self, eval_criteria: dict, messages: list[dict]) -> tuple[float, list[dict]]:
+        """
+        Check if agent communicated required info strings to the user.
+
+        Matches tau-bench's evaluator_communicate.py: case-insensitive substring check
+        with commas stripped from agent text.
+
+        Returns:
+            tuple: (reward: float, checks: list[dict])
+        """
+        communicate_info = eval_criteria.get("communicate_info") or []
+        if not communicate_info:
+            return 1.0, []
+
+        # Collect all assistant text blocks from the conversation
+        assistant_texts = []
+        for m in messages:
+            if m.get("role") == "assistant" or m.get("from") == "assistant":
+                for block in m.get("content", []):
+                    if "text" in block:
+                        assistant_texts.append(block["text"].lower().replace(",", ""))
+
+        checks = []
+        all_met = True
+        for info_str in communicate_info:
+            found = any(info_str.lower() in text for text in assistant_texts)
+            checks.append({"info": info_str, "met": found})
+            if not found:
+                all_met = False
+                logger.warning("COMMUNICATE failed: '%s' not found in assistant responses", info_str)
+
+        comm_reward = 1.0 if all_met else 0.0
+        passed = sum(1 for c in checks if c["met"])
+        logger.info("COMMUNICATE reward: %s (%d/%d passed)", comm_reward, passed, len(checks))
+        return comm_reward, checks
+
+    def _compute_env_assertion_reward(self, env: Any, eval_criteria: dict) -> tuple[float, list[dict]]:
+        """
+        Run env_assertions on the post-rollout environment.
+        Reward is the product of all assertion results (all-or-nothing per assertion).
+
+        Returns:
+            tuple: (reward: float, checks: list[dict])
+        """
+        env_assertions = eval_criteria.get("env_assertions") or []
+        if not env_assertions:
+            return 1.0, []
+
+        checks = []
+        reward = 1.0
+        for assertion_dict in env_assertions:
+            assertion = EnvAssertion(**assertion_dict)
+            success = env.run_env_assertion(assertion, raise_assertion_error=False)
+            checks.append(
+                {
+                    "func_name": assertion.func_name,
+                    "arguments": assertion.arguments,
+                    "met": success,
+                }
+            )
+            if not success:
+                reward *= 0.0
+                logger.warning("ENV_ASSERTION failed: %s(%s)", assertion.func_name, assertion.arguments)
+
+        passed = sum(1 for c in checks if c["met"])
+        logger.info("ENV_ASSERTION reward: %s (%d/%d passed)", reward, passed, len(checks))
+        return reward, checks
+
+    def _compute_action_checks(self, eval_criteria: dict, messages: list[dict]) -> list[dict]:
+        """
+        Check if agent made the expected tool calls (ACTION matching).
+        Not used for reward — saved as diagnostics only.
+
+        Returns:
+            list[dict]: One entry per golden action with action details and match result.
+        """
+        golden_actions = eval_criteria.get("actions") or []
+        if not golden_actions:
+            return []
+
+        # Extract tool calls from Strands-format messages, keyed by requestor.
+        # Telecom user-side tools (e.g. toggle_airplane_mode) are emitted by the
+        # user simulator and tagged from="user"; assistant-side tools are tagged
+        # from="assistant". A golden action's `requestor` selects the matching pool.
+        pred_tool_calls_by_requestor = {"assistant": [], "user": []}
+        for m in messages:
+            requestor = m.get("from")
+            if requestor not in pred_tool_calls_by_requestor:
+                continue
+            for block in m.get("content", []):
+                if "toolUse" in block:
+                    tu = block["toolUse"]
+                    pred_tool_calls_by_requestor[requestor].append(
+                        {
+                            "name": tu["name"],
+                            "arguments": tu.get("input", {}),
+                        }
+                    )
+
+        checks = []
+        for gold_action in golden_actions:
+            gold_name = gold_action["name"]
+            gold_args = gold_action.get("arguments", {})
+            compare_args = gold_action.get("compare_args")
+            gold_requestor = gold_action.get("requestor", "assistant")
+            candidate_pool = pred_tool_calls_by_requestor.get(gold_requestor, [])
+
+            found = False
+            for pred in candidate_pool:
+                if pred["name"] != gold_name:
+                    continue
+                # Filter arguments by compare_args (None = check all pred args)
+                if compare_args is None:
+                    cmp_keys = pred["arguments"].keys()
+                else:
+                    cmp_keys = compare_args
+                if len(cmp_keys) == 0:
+                    found = True
+                    break
+                pred_filtered = {k: v for k, v in pred["arguments"].items() if k in cmp_keys}
+                gold_filtered = {k: v for k, v in gold_args.items() if k in cmp_keys}
+                if pred_filtered == gold_filtered:
+                    found = True
+                    break
+
+            checks.append(
+                {
+                    "action": gold_action,
+                    "action_match": found,
+                    "action_reward": 1.0 if found else 0.0,
+                }
+            )
+
+        passed = sum(1 for c in checks if c["action_match"])
+        logger.info("ACTION checks (diagnostic): %d/%d matched", passed, len(checks))
+        return checks

--- a/examples/strands_taubench_agent/rl_app.py
+++ b/examples/strands_taubench_agent/rl_app.py
@@ -1,0 +1,329 @@
+import copy
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from constants import (
+    ASSISTANT_INSTRUCTION,
+    ASSISTANT_MODEL_DEFAULTS,
+    ASSISTANT_SYSTEM_PROMPT,
+    DOMAINS_USER_TOOLS,
+    MALFORMED_TOOL_CALL_TAGS,
+    ORCHESTRATOR_CONFIG,
+    TERMINATION_KEYWORDS,
+    USER_MODEL_CONFIG,
+    USER_SYSTEM_PROMPT,
+)
+from reward import TauBenchReward
+from strands import Agent
+from strands.agent.conversation_manager import NullConversationManager
+from strands.models import BedrockModel
+from tau2.data_model.tasks import EnvFunctionCall
+from tau2.domains.airline.environment import get_environment as airline_env
+from tau2.domains.retail.environment import get_environment as retail_env
+from tau2.domains.telecom.environment import get_environment_workflow_policy as telecom_env
+from tau2.user.user_simulator import get_global_user_sim_guidelines
+from utils import extract_text, log_turn, make_strands_tool, to_real_world_roles
+
+from agentcore_rl_toolkit import AgentCoreRLApp
+from agentcore_rl_toolkit.frameworks.strands.vllm_model import vLLMModel
+
+GET_ENVIRONMENT_FUNC = {
+    "airline": airline_env,
+    "retail": retail_env,
+    "telecom": telecom_env,
+}
+
+logger = logging.getLogger(__name__)
+
+app = AgentCoreRLApp()
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RolloutContext:
+    """Everything assembled from the payload that the rollout needs."""
+
+    base_url: str
+    model_id: str
+    params: dict
+    task: dict
+    domain: str
+    assistant_model: Any
+    user_model: Any
+    env: Any
+    assistant_tools: list
+    user_tools: list
+    assistant_system_prompt: str
+    user_system_prompt: str
+
+
+def _setup_rollout(payload: dict) -> RolloutContext:
+    """Assemble everything a rollout needs from the request payload.
+
+    Parses model/task config, instantiates the assistant (vLLM) and user
+    (Bedrock) models, builds a fresh environment and replays its initialization
+    actions, wraps tau-bench tools as Strands tools, and renders system prompts.
+
+    Args:
+        payload: The rollout request, with a "_rollout" block (base_url, model_id,
+            optional sampling_params) and a "_task" block (domain, user_scenario,
+            initial_state, evaluation_criteria, ...).
+
+    Returns:
+        A populated ``RolloutContext``.
+    """
+    base_url = payload["_rollout"]["base_url"]
+    model_id = payload["_rollout"]["model_id"]
+    # Copy so we don't mutate the caller's payload while applying defaults.
+    params = copy.deepcopy(payload["_rollout"].get("sampling_params", {}))
+    for k, v in ASSISTANT_MODEL_DEFAULTS.items():
+        if k == "extra_body":
+            params.setdefault("extra_body", {})
+            for ek, ev in v.items():
+                params["extra_body"].setdefault(ek, ev)
+        else:
+            params.setdefault(k, v)
+
+    task = payload["_task"]
+    domain = task["domain"]
+
+    # Assistant model (RL-trained, served via vLLM)
+    assistant_model = vLLMModel(
+        client_args={"api_key": "EMPTY", "base_url": base_url},
+        model_id=model_id,
+        params=params,
+    )
+
+    # User simulator model (Bedrock)
+    _user_cfg = USER_MODEL_CONFIG["bedrock"]
+    user_model = BedrockModel(
+        model_id=_user_cfg["model_id"],
+        temperature=_user_cfg["temperature"],
+        max_tokens=_user_cfg["max_tokens"],
+        additional_request_fields={
+            "thinking": (
+                {"type": "enabled", "budget_tokens": _user_cfg.get("thinking_budget", 1024)}
+                if _user_cfg["thinking_enabled"]
+                else {"type": "disabled"}
+            )
+        },
+    )
+
+    # Fresh environment + initialize state
+    env = GET_ENVIRONMENT_FUNC[domain]()
+    initial_state = task.get("initial_state") or {}
+    for action in initial_state.get("initialization_actions") or []:
+        env.run_env_function_call(EnvFunctionCall(**action))
+
+    # Wrap tau-bench tools as Strands tools
+    assistant_tools = [make_strands_tool(env, t.name, t, "assistant") for t in env.get_tools()]
+    user_tools = (
+        [make_strands_tool(env, t.name, t, "user") for t in env.get_user_tools()]
+        if domain in DOMAINS_USER_TOOLS
+        else []
+    )
+
+    # System prompts
+    assistant_system_prompt = ASSISTANT_SYSTEM_PROMPT.format(
+        assistant_instruction=ASSISTANT_INSTRUCTION,
+        assistant_policy=env.get_policy(),
+    )
+    user_system_prompt = USER_SYSTEM_PROMPT.format(
+        global_user_sim_guidelines=get_global_user_sim_guidelines(use_tools=(domain in DOMAINS_USER_TOOLS)),
+        instructions=json.dumps(task["user_scenario"]),
+    )
+
+    return RolloutContext(
+        base_url=base_url,
+        model_id=model_id,
+        params=params,
+        task=task,
+        domain=domain,
+        assistant_model=assistant_model,
+        user_model=user_model,
+        env=env,
+        assistant_tools=assistant_tools,
+        user_tools=user_tools,
+        assistant_system_prompt=assistant_system_prompt,
+        user_system_prompt=user_system_prompt,
+    )
+
+
+def _run_agent_turn(
+    turn: int, role: str, global_messages: list[dict], model: Any, tools: list, system_prompt: str
+) -> Any:
+    """Run one ReAct turn for the given agent and record its output.
+
+    Builds an ``Agent`` from ``role``'s perspective of the shared history, runs a
+    single turn, then tags every newly produced message with ``from=role`` and
+    appends it to ``global_messages`` (mutated in place).
+
+    Args:
+        turn: Zero-based turn index (for logging).
+        role: Which agent acts this turn — "user" or "assistant".
+        global_messages: The shared conversation history; appended to in place.
+        model: The Strands model backing this agent.
+        tools: Tools available to this agent.
+        system_prompt: System prompt for this agent.
+
+    Returns:
+        The Strands ``AgentResult`` for the turn (its ``.message`` holds the reply).
+    """
+    messages = log_turn(turn, role, global_messages, ORCHESTRATOR_CONFIG)
+    agent = Agent(
+        model=model,
+        tools=tools,
+        system_prompt=system_prompt,
+        messages=messages,
+        conversation_manager=NullConversationManager(),  # avoid context moving window of 40 turns
+    )
+    logger.debug("%s MESSAGE RAW:\n%s", role.upper(), json.dumps(agent.messages, indent=4))
+    prev_len = len(agent.messages)
+    response = agent()
+    for m in agent.messages[prev_len:]:
+        m["from"] = role
+        global_messages.append(m)
+    return response
+
+
+def _run_conversation(ctx: RolloutContext) -> tuple[list[dict], Optional[float], Optional[str]]:
+    """Drive the multi-turn user/assistant conversation to completion.
+
+    Alternates user and assistant turns until the user emits a termination
+    keyword, the assistant leaks a malformed tool-call tag, or ``max_turns`` is
+    reached.
+
+    Args:
+        ctx: The rollout context holding both models, tools, and system prompts.
+
+    Returns:
+        A tuple ``(global_messages, force_reward, terminated_reason)``:
+          - global_messages: the full shared history (tagged with "from").
+          - force_reward: a forced reward (e.g. 0.0 on malformed tool call), or
+            None when the reward should be computed normally.
+          - terminated_reason: why the loop ended (termination keyword,
+            "malformed_tool_call"), or None if it ran to max_turns.
+
+    Raises:
+        Exception: propagates any error from the assistant agent so the caller
+            can save a partial rollout with reward 0.
+    """
+    global_messages = [{"role": "assistant", "content": [{"text": "Hello! How can I help you?"}], "from": "assistant"}]
+    force_reward = None
+    terminated_reason = None
+
+    for turn in range(ORCHESTRATOR_CONFIG.get("max_turns", 50)):
+        # --- User turn ---
+        user_response = _run_agent_turn(
+            turn, "user", global_messages, ctx.user_model, ctx.user_tools, ctx.user_system_prompt
+        )
+        user_text = extract_text(user_response.message)
+        hit = next((kw for kw in TERMINATION_KEYWORDS if kw in user_text), None)
+        if hit:
+            terminated_reason = hit
+            logger.info("Terminated at turn %d: %s", turn, hit)
+            break
+
+        # --- Assistant turn ---
+        try:
+            _run_agent_turn(
+                turn,
+                "assistant",
+                global_messages,
+                ctx.assistant_model,
+                ctx.assistant_tools,
+                ctx.assistant_system_prompt,
+            )
+        except Exception as e:
+            logger.warning("Agent failed (%s), partial rollout, reward=0", e)
+            raise
+
+        # Check for malformed tool-call tags leaking into the assistant's text
+        combined_text = extract_text(global_messages[-1]).strip()
+        leaked_tag = next((tag for tag in MALFORMED_TOOL_CALL_TAGS if tag in combined_text), None)
+        if leaked_tag:
+            terminated_reason = "malformed_tool_call"
+            force_reward = 0.0
+            logger.warning("Terminated at turn %d: malformed %s leaked into text, forcing reward=0", turn, leaked_tag)
+            break
+
+    return global_messages, force_reward, terminated_reason
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+@app.rollout_entrypoint
+def invoke_agent(payload: dict) -> dict:
+    """Run one tau2-bench rollout and return its results.
+
+    Sets up the rollout, drives the user/assistant conversation, computes the
+    reward, and returns rollout data, reward, conversation, and metadata. Used
+    as the ``@rollout_entrypoint``, which automatically runs this in the
+    background, saves the returned dict to S3, and records errors for the client.
+
+    Args:
+        payload: The rollout request (see ``_setup_rollout`` for the schema).
+
+    Returns:
+        A JSON-serializable dict with keys: "rollout_data", "rewards",
+        "reward_info", "messages", and "meta". On assistant failure, a minimal
+        ``{"rollout_data", "rewards": 0.0}`` partial result.
+    """
+    ctx = _setup_rollout(payload)
+    logger.info("Starting rollout: domain=%s, model=%s", ctx.domain, ctx.model_id)
+
+    # Run conversation — if the rollout throws, return partial rollout with reward=0
+    try:
+        global_messages, force_reward, terminated_reason = _run_conversation(ctx)
+    except Exception:
+        logger.exception("Rollout failed before completion")
+        rollout_data = ctx.assistant_model.get_token_data()
+        return {"rollout_data": rollout_data, "rewards": 0.0}
+
+    # Compute reward
+    rollout_data = ctx.assistant_model.get_token_data()
+    if force_reward is not None:
+        rewards = force_reward
+        reward_info = {"forced": True, "terminated_reason": terminated_reason}
+    else:
+        reward_fn = TauBenchReward(GET_ENVIRONMENT_FUNC)
+        rewards, reward_info = reward_fn(env=ctx.env, task=ctx.task, domain=ctx.domain, messages=global_messages)
+    logger.info(
+        "Rollout complete: %d messages, %d steps, reward=%.4f, terminated_reason=%s",
+        len(global_messages),
+        len(rollout_data),
+        rewards,
+        terminated_reason,
+    )
+
+    return {
+        "rollout_data": rollout_data,
+        "rewards": rewards,
+        "reward_info": reward_info,
+        "messages": to_real_world_roles(global_messages),
+        "meta": {
+            "assistant_model": {
+                "base_url": ctx.base_url,
+                "model_id": ctx.model_id,
+                "params": ctx.params,
+            },
+            "user_model": {
+                "source": "bedrock",
+                **USER_MODEL_CONFIG["bedrock"],
+            },
+            "terminated_reason": terminated_reason,
+        },
+    }
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/strands_taubench_agent/rl_app.py
+++ b/examples/strands_taubench_agent/rl_app.py
@@ -19,6 +19,7 @@ from reward import TauBenchReward
 from strands import Agent
 from strands.agent.conversation_manager import NullConversationManager
 from strands.models import BedrockModel
+from strands.models.openai import OpenAIModel
 from tau2.data_model.tasks import EnvFunctionCall
 from tau2.domains.airline.environment import get_environment as airline_env
 from tau2.domains.retail.environment import get_environment as retail_env
@@ -27,7 +28,6 @@ from tau2.user.user_simulator import get_global_user_sim_guidelines
 from utils import extract_text, log_turn, make_strands_tool, to_real_world_roles
 
 from agentcore_rl_toolkit import AgentCoreRLApp
-from agentcore_rl_toolkit.frameworks.strands.vllm_model import vLLMModel
 
 GET_ENVIRONMENT_FUNC = {
     "airline": airline_env,
@@ -94,7 +94,7 @@ def _setup_rollout(payload: dict) -> RolloutContext:
     domain = task["domain"]
 
     # Assistant model (RL-trained, served via vLLM)
-    assistant_model = vLLMModel(
+    assistant_model = OpenAIModel(
         client_args={"api_key": "EMPTY", "base_url": base_url},
         model_id=model_id,
         params=params,
@@ -266,31 +266,33 @@ def invoke_agent(payload: dict) -> dict:
     """Run one tau2-bench rollout and return its results.
 
     Sets up the rollout, drives the user/assistant conversation, computes the
-    reward, and returns rollout data, reward, conversation, and metadata. Used
-    as the ``@rollout_entrypoint``, which automatically runs this in the
-    background, saves the returned dict to S3, and records errors for the client.
+    reward, and returns the reward, conversation, and metadata. Used as the
+    ``@rollout_entrypoint``, which automatically runs this in the background,
+    saves the returned dict to S3, and records errors for the client.
+
+    Token IDs are captured server-side by the rllm-model-gateway HTTP proxy
+    (no client-side token collection in agent code).
 
     Args:
         payload: The rollout request (see ``_setup_rollout`` for the schema).
 
     Returns:
-        A JSON-serializable dict with keys: "rollout_data", "rewards",
-        "reward_info", "messages", and "meta". On assistant failure, a minimal
-        ``{"rollout_data", "rewards": 0.0}`` partial result.
+        A JSON-serializable dict with keys: "rewards", "reward_info",
+        "messages", and "meta". On assistant failure, a minimal
+        ``{"rewards": 0.0}`` partial result.
     """
     ctx = _setup_rollout(payload)
     logger.info("Starting rollout: domain=%s, model=%s", ctx.domain, ctx.model_id)
 
-    # Run conversation — if the rollout throws, return partial rollout with reward=0
+    # Run conversation — if the rollout throws, return reward=0
+    # (token IDs are captured server-side by the rllm-model-gateway, not collected here)
     try:
         global_messages, force_reward, terminated_reason = _run_conversation(ctx)
     except Exception:
         logger.exception("Rollout failed before completion")
-        rollout_data = ctx.assistant_model.get_token_data()
-        return {"rollout_data": rollout_data, "rewards": 0.0}
+        return {"rewards": 0.0}
 
     # Compute reward
-    rollout_data = ctx.assistant_model.get_token_data()
     if force_reward is not None:
         rewards = force_reward
         reward_info = {"forced": True, "terminated_reason": terminated_reason}
@@ -298,15 +300,13 @@ def invoke_agent(payload: dict) -> dict:
         reward_fn = TauBenchReward(GET_ENVIRONMENT_FUNC)
         rewards, reward_info = reward_fn(env=ctx.env, task=ctx.task, domain=ctx.domain, messages=global_messages)
     logger.info(
-        "Rollout complete: %d messages, %d steps, reward=%.4f, terminated_reason=%s",
+        "Rollout complete: %d messages, reward=%.4f, terminated_reason=%s",
         len(global_messages),
-        len(rollout_data),
         rewards,
         terminated_reason,
     )
 
     return {
-        "rollout_data": rollout_data,
         "rewards": rewards,
         "reward_info": reward_info,
         "messages": to_real_world_roles(global_messages),

--- a/examples/strands_taubench_agent/tasks/airline_example.json
+++ b/examples/strands_taubench_agent/tasks/airline_example.json
@@ -1,0 +1,40 @@
+{
+  "id": "19",
+  "description": {
+    "purpose": "Testing that Agent follows the policy that basic economy flights cannot be modified.\n\nInstructions should lead to a flight cancellation.",
+    "relevant_policies": null,
+    "notes": null
+  },
+  "user_scenario": {
+    "persona": null,
+    "instructions": {
+      "task_instructions": "You do not accept JFK, only EWR. \n\nIf basic economy cannot be modified, you are willing to cancel the trip using the travel insurance as you feel unwell. You will book the flight again yourself later.\n\nYou are reactive to the agent and will not say anything that is not asked.",
+      "domain": "airline",
+      "reason_for_call": "You will have a crazy half-day trip to Texas.\n\nIt is in your reservations but you don't remember the reservation id.\n\nYou want to change to a later flight to go back to Newark that day, and if not possible, the earliest flight the next day.\n\nYour current return flight departs 3pm (on the 28th).",
+      "known_info": "Your name is Olivia Gonzalez.\n\nYour user id is olivia_gonzalez_2305.\n\nYou currently reside in Newark.",
+      "unknown_info": null
+    }
+  },
+  "initial_state": null,
+  "evaluation_criteria": {
+    "actions": [
+      {
+        "action_id": "19_0",
+        "name": "cancel_reservation",
+        "arguments": {
+          "reservation_id": "Z7GOZK"
+        },
+        "info": null
+      }
+    ],
+    "communicate_info": [],
+    "nl_assertions": [
+      "Agent cancels reservation Z7GOZK"
+    ],
+    "reward_basis": [
+      "DB",
+      "COMMUNICATE"
+    ]
+  },
+  "annotations": null
+}

--- a/examples/strands_taubench_agent/tasks/retail_example.json
+++ b/examples/strands_taubench_agent/tasks/retail_example.json
@@ -1,0 +1,40 @@
+{
+  "id": "73",
+  "description": {
+    "purpose": null,
+    "relevant_policies": null,
+    "notes": null
+  },
+  "user_scenario": {
+    "persona": null,
+    "instructions": {
+      "task_instructions": "You are polite, flexible, creative.",
+      "domain": "retail",
+      "reason_for_call": "You want to return everything you just bought except the coffee machine.",
+      "known_info": "You name is Fatima Wilson and your email is fatima.wilson5721@example.com.",
+      "unknown_info": null
+    }
+  },
+  "initial_state": null,
+  "evaluation_criteria": {
+    "actions": [
+      {
+        "action_id": "73_0",
+        "name": "return_delivered_order_items",
+        "arguments": {
+          "order_id": "#W5272531",
+          "item_ids": [
+            "7228247242",
+            "2698416822",
+            "8098621301",
+            "3320557165"
+          ],
+          "payment_method_id": "credit_card_6824399"
+        },
+        "info": null
+      }
+    ],
+    "communicate_info": [],
+    "nl_assertions": null
+  }
+}

--- a/examples/strands_taubench_agent/tasks/telecom_example.json
+++ b/examples/strands_taubench_agent/tasks/telecom_example.json
@@ -1,0 +1,75 @@
+{
+  "id": "[service_issue]airplane_mode_on[PERSONA:None]",
+  "description": {
+    "purpose": "Test resolution path: No Service/Connection Issues.",
+    "relevant_policies": null,
+    "notes": null
+  },
+  "user_scenario": {
+    "persona": null,
+    "instructions": {
+      "domain": "telecom",
+      "reason_for_call": "Your phone has been showing 'No Service' for the past few hours.",
+      "known_info": "You are John Smith with phone number 555-123-2002.",
+      "unknown_info": null,
+      "task_instructions": "If the agent suggests actions that don't immediately fix the issue, follow their guidance but express mild frustration after the first unsuccessful attempt. You will consider the issue resolved when the status bar shows that you have signal. Always check the status bar if the agent asks you for status information. If the agent asks you to pay a bill, you accept. If the tool call does not return updated status information, you might need to perform another tool call to get the updated status. \nWhenever the agent asks you about your device, always ground your responses on the results of tool calls. \nFor example: If the agent asks what the status bar shows, always ground your response on the results of the `get_status_bar` tool call. If the agent asks if you are able to send an MMS message, always ground your response on the results of the `can_send_mms` tool call.\nNever make up the results of tool calls, always ground your responses on the results of tool calls.\nIf you are unsure about whether an action is necessary, always ask the agent for clarification.\n"
+    }
+  },
+  "ticket": "The user is experiencing issues with their phone service. They are unable to make or receive calls, and the status bar shows 'No Service'. Customer name: John Smith, phone number: 555-123-2002. They gave permission to pay all their overdue bills. They will consider the issue resolved when the status bar shows that they have signal.",
+  "initial_state": {
+    "initialization_data": null,
+    "initialization_actions": [
+      {
+        "env_type": "user",
+        "func_name": "set_user_info",
+        "arguments": {
+          "name": "John Smith",
+          "phone_number": "555-123-2002"
+        }
+      },
+      {
+        "env_type": "user",
+        "func_name": "turn_airplane_mode_on",
+        "arguments": {}
+      }
+    ],
+    "message_history": null
+  },
+  "evaluation_criteria": {
+    "actions": [
+      {
+        "action_id": "toggle_airplane_mode_0",
+        "requestor": "user",
+        "name": "toggle_airplane_mode",
+        "arguments": {},
+        "info": null,
+        "compare_args": null
+      }
+    ],
+    "env_assertions": [
+      {
+        "env_type": "user",
+        "func_name": "assert_service_status",
+        "arguments": {
+          "expected_status": "connected"
+        },
+        "assert_value": true,
+        "message": "Service status is not as expected"
+      },
+      {
+        "env_type": "assistant",
+        "func_name": "assert_no_overdue_bill",
+        "arguments": {
+          "overdue_bill_id": "B1234321"
+        },
+        "assert_value": true,
+        "message": "Overdue bill is not as expected"
+      }
+    ],
+    "communicate_info": null,
+    "nl_assertions": null,
+    "reward_basis": [
+      "ENV_ASSERTION"
+    ]
+  }
+}

--- a/examples/strands_taubench_agent/test_local.py
+++ b/examples/strands_taubench_agent/test_local.py
@@ -1,0 +1,91 @@
+import argparse
+import json
+import subprocess
+from urllib.parse import urlparse, urlunparse
+
+import requests
+
+
+def build_payload(task_file: str, base_url: str, model_id: str, s3_bucket: str) -> dict:
+    """Build the ACR invocation payload from a raw tau2-bench task file."""
+    with open(task_file) as f:
+        task = json.load(f)
+
+    domain = task["user_scenario"]["instructions"]["domain"]
+    return {
+        "_task": {
+            "domain": domain,
+            "user_scenario": task["user_scenario"],
+            "initial_state": task.get("initial_state"),
+            "evaluation_criteria": task.get("evaluation_criteria"),
+        },
+        "_rollout": {
+            "exp_id": "test",
+            "s3_bucket": s3_bucket,
+            "session_id": "session_123",
+            "input_id": "task_123",
+            "base_url": base_url,
+            "model_id": model_id,
+            "sampling_params": {
+                "max_tokens": 4096,
+                "extra_body": {
+                    "chat_template_kwargs": {"enable_thinking": True},
+                },
+            },
+        },
+    }
+
+
+def run_local(payload: dict) -> None:
+    """POST to a local rl_app.py server (localhost:8080)."""
+    resp = requests.post("http://localhost:8080/invocations", json=payload)
+    print(resp.status_code)
+    print(json.dumps(resp.json(), indent=2))
+
+
+def run_acr(payload: dict, agent_name: str) -> None:
+    """Invoke a deployed ACR agent via the agentcore CLI.
+
+    The host part of base_url is rewritten to the cluster's primary IP so the
+    deployed container can reach the vLLM server. Port and path are preserved.
+    """
+    cluster_ip = subprocess.check_output("hostname -I | awk '{print $1}'", shell=True, text=True).strip()
+    parsed = urlparse(payload["_rollout"]["base_url"])
+    new_netloc = f"{cluster_ip}:{parsed.port}" if parsed.port else cluster_ip
+    payload["_rollout"]["base_url"] = urlunparse(parsed._replace(netloc=new_netloc))
+
+    result = subprocess.run(
+        ["agentcore", "invoke", "--agent", agent_name, json.dumps(payload)],
+        capture_output=True,
+        text=True,
+    )
+    print(result.stdout)
+    if result.stderr:
+        print(result.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--task", required=True, help="Path to a tau2-bench task JSON (e.g. tasks/retail_example.json)")
+    parser.add_argument(
+        "--base-url", required=True, help="vLLM server URL for the assistant model (e.g. http://localhost:4000/v1)"
+    )
+    parser.add_argument(
+        "--model-id", required=True, help="Assistant model id (must match the vLLM --served-model-name)"
+    )
+    parser.add_argument(
+        "--s3-bucket", default="agentcore-rl", help="S3 bucket for rollout results (default: agentcore-rl)"
+    )
+    parser.add_argument("--acr", action="store_true", help="Invoke the deployed ACR agent instead of a local server")
+    parser.add_argument("--agent-name", default="strands_taubench_agent_rl", help="ACR agent name (used with --acr)")
+    args = parser.parse_args()
+
+    payload = build_payload(args.task, args.base_url, args.model_id, args.s3_bucket)
+    if args.acr:
+        run_acr(payload, args.agent_name)
+    else:
+        run_local(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/strands_taubench_agent/utils.py
+++ b/examples/strands_taubench_agent/utils.py
@@ -1,0 +1,267 @@
+import copy
+import json
+import logging
+from typing import Any
+
+from constants import TOOL_RESULT_KEY, TOOL_USE_KEY
+
+logger = logging.getLogger(__name__)
+
+# Type aliases for the Strands dict shapes handled throughout this module.
+ContentBlock = dict[str, Any]
+Message = dict[str, Any]
+
+
+def make_strands_tool(env: Any, tool_name: str, tau_tool: Any, requestor: str = "assistant") -> Any:
+    """Wrap a tau-bench tool as a Strands-compatible tool.
+
+    Tau-bench tools interact closely with the database (environment state).
+    This builds a Strands ``PythonAgentTool`` whose ``tool_spec`` carries the
+    full parameter schema from tau-bench's ``openai_schema``, and whose handler
+    routes calls to the environment and returns a Strands ``ToolResult`` dict
+    (PythonAgentTool does not auto-wrap the result the way the ``@tool``
+    decorator does).
+
+    Args:
+        env: The tau-bench Environment that executes the tool and holds DB state.
+        tool_name: Name of the tool to invoke on the environment.
+        tau_tool: The tau-bench tool object exposing ``openai_schema`` and ``short_desc``.
+        requestor: "assistant" or "user" — selects which toolkit the call routes
+            to (``env.use_tool`` vs ``env.use_user_tool``).
+
+    Returns:
+        A ``PythonAgentTool`` ready to be passed to a Strands ``Agent``.
+    """
+    from strands.tools.tools import PythonAgentTool
+
+    # Convert tau-bench openai_schema to Strands tool_spec
+    func_schema = tau_tool.openai_schema["function"]
+    tool_spec = {
+        "name": func_schema["name"],
+        "description": func_schema.get("description", tau_tool.short_desc),
+        "inputSchema": {"json": func_schema.get("parameters", {})},
+    }
+
+    def tool_func(tool_use: dict, **kwargs: Any) -> dict:
+        # PythonAgentTool passes tool_use as first arg: {"toolUseId": ..., "name": ..., "input": {...}}
+        tool_input = tool_use.get("input", {})
+        tool_use_id = str(tool_use.get("toolUseId", ""))
+        try:
+            if requestor == "user":
+                result = env.use_user_tool(tool_name, **tool_input)
+            else:
+                result = env.use_tool(tool_name, **tool_input)
+            env.sync_tools()
+            result_str = env.to_json_str(result)
+            return {
+                "toolUseId": tool_use_id,
+                "status": "success",
+                "content": [{"text": result_str}],
+            }
+        except Exception as e:
+            logger.error("Tool error: %s: %s", tool_name, e)
+            return {
+                "toolUseId": tool_use_id,
+                "status": "error",
+                "content": [{"text": f"Error: {e}"}],
+            }
+
+    return PythonAgentTool(tool_name, tool_spec, tool_func)
+
+
+def _has_tool_use(message: Message) -> bool:
+    """Check whether a message contains any toolUse content block.
+
+    Args:
+        message: A Strands message.
+
+    Returns:
+        True if at least one content block is a tool call.
+    """
+    return any(TOOL_USE_KEY in block for block in message.get("content", []))
+
+
+def _has_tool_result(message: Message) -> bool:
+    """Check whether a message contains any toolResult content block.
+
+    Args:
+        message: A Strands message.
+
+    Returns:
+        True if at least one content block is a tool result.
+    """
+    return any(TOOL_RESULT_KEY in block for block in message.get("content", []))
+
+
+def extract_text(message: Message) -> str:
+    """Concatenate all text blocks of a message.
+
+    Thinking (reasoningContent) and tool (toolUse/toolResult) blocks are skipped,
+    so this returns only the model's user-facing text.
+
+    Args:
+        message: A Strands message.
+
+    Returns:
+        The message's text blocks joined by spaces (empty string if none).
+    """
+    return " ".join(
+        block["text"] for block in message.get("content", []) if isinstance(block, dict) and "text" in block
+    )
+
+
+def _strip_thinking(content: list[ContentBlock]) -> list[ContentBlock]:
+    """Remove thinking from a content-block list.
+
+    Handles both Bedrock format (``reasoningContent`` blocks, dropped entirely)
+    and vLLM format (``<think>...</think>`` embedded in a text block, where only
+    the text after ``</think>`` is kept).
+
+    Args:
+        content: The content blocks of a single message.
+
+    Returns:
+        A new list of content blocks with thinking removed.
+    """
+    result: list[ContentBlock] = []
+    for block in content:
+        if "reasoningContent" in block:
+            continue
+        if "text" in block and "</think>" in block["text"]:
+            text_after = block["text"].split("</think>", 1)[1].strip()
+            if text_after:
+                result.append({"text": text_after})
+        else:
+            result.append(block)
+    return result
+
+
+def convert_message_role(messages: list[Message], to_role: str, strip_thinking: bool = False) -> list[Message]:
+    """Re-project the shared conversation history into one agent's perspective.
+
+    Shared messages are in Strands/Bedrock format, tagged with "from" for origin.
+    Each agent is always "assistant" in its own Strands perspective, so the other
+    agent's turns must be re-cast as "user" input.
+
+    For the target agent:
+      - Messages without "from" (e.g. system): passed through as-is.
+      - Own messages (from == to_role): kept, optionally with thinking stripped, "from" stripped.
+      - Other agent's text (no toolUse/toolResult): included as "user" input, thinking stripped.
+      - Other agent's tool calls and tool results: excluded.
+      - Any other (unexpected) origin: dropped.
+
+    Args:
+        messages: The shared conversation history (each tagged with "from").
+        to_role: Whose perspective to build for — "user" or "assistant".
+        strip_thinking: If True, strip thinking from own messages in history.
+            Used for both agents to force self-contained reasoning per turn and
+            avoid context blowup when thinking is enabled on self-hosted inference
+            servers.
+
+    Returns:
+        A new message list in the target agent's Strands perspective.
+    """
+    other_role = "assistant" if to_role == "user" else "user"
+    filtered: list[Message] = []
+    for m in messages:
+        if "from" not in m:
+            # System / untagged message — pass through as-is.
+            filtered.append(copy.deepcopy(m))
+            continue
+        origin = m["from"]
+        if origin == to_role:
+            # Own message — preserve tool calls/results, optionally strip thinking. "from" stripped.
+            new_m = copy.deepcopy(m)
+            new_m.pop("from", None)
+            if strip_thinking:
+                new_m["content"] = _strip_thinking(new_m["content"])
+            filtered.append(new_m)
+        elif origin == other_role:
+            # Other agent — drop its tool calls/results, include only its text as "user" input.
+            if _has_tool_use(m) or _has_tool_result(m):
+                continue
+            clean_content = _strip_thinking(m["content"])
+            if clean_content:
+                filtered.append({"role": "user", "content": clean_content})
+        # else: tagged with an unexpected origin — dropped (matches original behavior)
+    return filtered
+
+
+def _convert_think_tags_to_reasoning_blocks(content_blocks: list[ContentBlock]) -> list[ContentBlock]:
+    """Convert inline ``<think>...</think>`` text into separate reasoningContent blocks.
+
+    vLLM embeds thinking in text content with ``<think>...</think>`` tags.
+    This extracts them into ``reasoningContent`` blocks to match Bedrock's format.
+
+    Args:
+        content_blocks: The content blocks of a single message.
+
+    Returns:
+        A new list of content blocks where any inline thinking has been split
+        into a dedicated reasoningContent block followed by the remaining text.
+    """
+    new_blocks: list[ContentBlock] = []
+    for block in content_blocks:
+        if "text" in block and "</think>" in block["text"]:
+            parts = block["text"].split("</think>", 1)
+            thinking = parts[0].replace("<think>", "").strip()
+            text = parts[1].strip() if len(parts) > 1 else ""
+            if thinking:
+                new_blocks.append({"reasoningContent": {"reasoningText": {"text": thinking}}})
+            if text:
+                new_blocks.append({"text": text})
+        else:
+            new_blocks.append(block)
+    return new_blocks
+
+
+def log_turn(turn: int, role: str, global_messages: list[Message], orchestrator_config: dict) -> list[Message]:
+    """Log a turn header and return the messages converted for the given role.
+
+    Args:
+        turn: Zero-based turn index, used in the log line.
+        role: Whose turn it is — "user" or "assistant".
+        global_messages: The shared conversation history.
+        orchestrator_config: Orchestrator settings; the "strip_thinking_from_history"
+            flag controls whether thinking is stripped from own messages.
+
+    Returns:
+        The history converted to ``role``'s Strands perspective (see
+        ``convert_message_role``).
+    """
+    logger.info("TURN %d — %s", turn, role.upper())
+    msgs = convert_message_role(
+        global_messages,
+        to_role=role,
+        strip_thinking=orchestrator_config.get("strip_thinking_from_history", False),
+    )
+    logger.debug("[%s-turn %d] full messages:\n%s", role, turn, json.dumps(msgs, indent=2, default=str))
+    return msgs
+
+
+def to_real_world_roles(global_messages: list[Message]) -> list[Message]:
+    """Normalize the shared history for saving as the final trajectory.
+
+    Sets each message's ``role`` to its real-world identity (the "from" value)
+    while keeping "from" for downstream analysis, and splits inline
+    ``<think>...</think>`` tags into reasoningContent blocks.
+
+    Only the assistant is vLLM-backed (its text carries inline ``<think>`` tags),
+    so splitting is applied to assistant messages only. The user simulator is
+    Bedrock-backed and already returns reasoningContent natively.
+
+    Args:
+        global_messages: The shared conversation history.
+
+    Returns:
+        A new message list with real-world roles and normalized reasoning blocks.
+    """
+    result: list[Message] = []
+    for m in global_messages:
+        new_m = copy.deepcopy(m)
+        if "from" in new_m:
+            new_m["role"] = new_m["from"]
+        if new_m.get("from") == "assistant":
+            new_m["content"] = _convert_think_tags_to_reasoning_blocks(new_m["content"])
+        result.append(new_m)
+    return result


### PR DESCRIPTION
*Description of changes:*
Adds a tau2-bench RL agent example supporting airline, retail, and telecom domains with deterministic DB / COMMUNICATE / ENV_ASSERTION / ACTION rewards. The agent runs a multi-turn conversation between a vLLM-served assistant (the model being trained) and a Bedrock-backed user simulator, with tool calls executed against fresh tau2-bench environments.

## Includes:
- rl_app.py with multi-agent orchestration
- reward.py implementing four tau-bench reward axes
- utils.py with Strands tool wrapping and message-role conversion
- 3 sample tasks (one per domain) sourced from tau2-bench
- test_local.py smoke test (local server or deployed ACR agent)
- Dockerfile with pinned tau2-bench commit
- README walking developers through deployment end-to-end

## Test plan
- [x] All Python files compile (`python3 -m py_compile`)
- [x] Local smoke test against `rl_app.py` server with airline task — produces full trajectory and reward
- [x] Deployed ACR agent smoke test
- [x] Run all three sample tasks (airline / retail / telecom) end-to-end




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
