### PR TITLE
fix(packaging): move rllm git dependency to tool.uv.sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,11 @@ rllm = [
     #
     # NOTE: do not depend on rllm's own [agentcore] extra here — it pulls
     # in agentcore-rl-toolkit, which would create a circular dependency.
-    "rllm @ git+https://github.com/rllm-org/rllm.git",
+    #
+    # The git source is declared in [tool.uv.sources] below rather than inline
+    # here, because PyPI rejects direct-reference (git URL) dependencies in
+    # uploaded packages. uv reads the source when installing from the repo.
+    "rllm",
 ]
 verl = [
     "transformers>=5.5.3",
@@ -62,7 +66,7 @@ verl = [
     "vllm==0.21.0",
     "flash-attn==2.8.3",
     "qwen-vl-utils",
-    "rllm-model-gateway @ git+https://github.com/rllm-org/rllm.git#subdirectory=rllm-model-gateway",
+    "rllm-model-gateway>=0.1.0",
 ]
 
 [project.urls]
@@ -72,6 +76,14 @@ Homepage = "https://github.com/awslabs/agentcore-rl-toolkit"
 override-dependencies = [
     "numpy>=1.26.0",
 ]
+
+[tool.uv.sources]
+# rllm is not published to PyPI; install it from GitHub. The git source is
+# declared here rather than inline in [project.optional-dependencies] so the
+# published package metadata stays free of direct-reference (git URL)
+# dependencies, which PyPI rejects. uv reads this source when installing the
+# [rllm] extra from a checkout of this repo.
+rllm = { git = "https://github.com/rllm-org/rllm.git" }
 
 [tool.uv.extra-build-dependencies]
 flash-attn = [


### PR DESCRIPTION
## Problem

The v0.1.3 PyPI publish workflow [failed](https://github.com/awslabs/agentcore-rl-toolkit/actions/runs/27990369885/job/82841279609) at the `uv publish` step:

```
400 Bad Request: Can't have direct dependency:
rllm @ git+https://github.com/rllm-org/rllm.git ; extra == "rllm"
```

PyPI rejects direct-reference (git URL) dependencies in uploaded packages. Two extras carried git URLs:
- `[rllm]` → `rllm @ git+...` (rllm is **not** published to PyPI)
- `[verl]` → `rllm-model-gateway @ git+...#subdirectory=...` (this package **is** on PyPI)

`allow-direct-references = true` only lets hatchling *build* the wheel locally; it has no effect on PyPI's upload validation.

## Fix

- Declare the `rllm` git source in `[tool.uv.sources]` instead of inline in the `[rllm]` extra. The published wheel metadata becomes a plain `Requires-Dist: rllm; extra == 'rllm'`, while `uv pip install -e ".[rllm]"` still resolves rllm from GitHub for source installs.
- Switch the `verl` extra's `rllm-model-gateway` pin from the git+subdirectory URL to the PyPI spec `>=0.1.0` (already used by the `slime` extra).

## Verification

Built the wheel locally and inspected `METADATA` — no `git+` / direct-reference `Requires-Dist` lines remain:

```
Requires-Dist: rllm; extra == 'rllm'
Requires-Dist: rllm-model-gateway>=0.1.0; extra == 'verl'
```

## Notes

- `uv.lock` is intentionally not regenerated here — `main`'s lock is already stale and `uv lock` pulls in a large unrelated dependency cascade; that belongs in a separate PR.
- After merge, the existing `v0.1.3` release/tag (pointing at the pre-fix commit) must be deleted and recreated against `main` so a fresh, clean artifact is built and published.