### PR TITLE
feat(slime): multi-turn trace merging, validation at an input dataset and gateway config fix in custom rollout function

### DIFF
--- a/src/agentcore_rl_toolkit/backends/slime/examples/math_agent/config.yaml.example
+++ b/src/agentcore_rl_toolkit/backends/slime/examples/math_agent/config.yaml.example
@@ -16,9 +16,14 @@ exp_id: "gsm8k-grpo-train"
 gateway_port: 9090                  # rllm-model-gateway port
 acr_timeout: 900                    # per-session ACR invocation timeout (s)
 model_id: "default"                 # OpenAI model id served to the agent
-acr_tps_limit: 25                   # ACR service TPS quota
+acr_tps_limit: 5                   # ACR service TPS quota
 max_concurrent: 100                 # max concurrent ACR sessions
-max_pool_connections: 256           # boto3 connection pool size
+
+# Number of network connections the AWS client keeps open (and reuses) to talk
+# to ACR/S3. This is NOT max_concurrent: it caps reused connections, not how many
+# sessions run at once. Too small value causes "Connection pool is full" warnings,
+# they are NOT errors. Setting a too large value wastes resources (idle open sockets).
+max_pool_connections: 10
 reward_postprocessing: "grpo"       # "grpo" or "identity"
 
 # Set gateway_cumulative_token_mode to true will turn on model gateway's

--- a/src/agentcore_rl_toolkit/backends/slime/examples/math_agent/config.yaml.example
+++ b/src/agentcore_rl_toolkit/backends/slime/examples/math_agent/config.yaml.example
@@ -25,11 +25,17 @@ reward_postprocessing: "grpo"       # "grpo" or "identity"
 # cumulative token mode. It constructs a per-session cumulative input token
 # sequence and forwards it to sglang servers if the message history is cumulative.
 cumulative_token_mode: false
-# Model gateway's cumulative token mode uses renderers package to construct
-# cross-message-turn bridge tokens, that needs setting model family name
-# (e.g. "qwen3", "glm-5"). If it is "auto" and actor_rollout_ref.model.path
-# is a huggingface model id, renderers will auto infers model family name.
-# But you must set model family name explicitly if actor_rollout_ref.model.path
-# is a local model path. Check supported model families in MODEL_RENDERER_MAP of
+
+# renderer_family is only used when cumulative_token_mode is true — the renderers
+# package needs the model family name (e.g. "qwen3", "glm-5") to build the
+# cross-turn bridge tokens.
+#
+# "auto" resolves the family only by EXACT match of the served model name against
+# renderers' MODEL_RENDERER_MAP, which works when slime's --hf-checkpoint is a
+# canonical HuggingFace id (e.g. "Qwen/Qwen3-4B-Instruct-2507"). --hf-checkpoint
+# is usually a LOCAL PATH, which never matches, so "auto" falls back to a renderer
+# with no bridge and the gateway errors out at startup. => With cumulative mode on
+# and a local checkpoint path, you MUST set renderer_family explicitly.
+# Supported families are the keys of MODEL_RENDERER_MAP:
 # https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py
 renderer_family: "auto"

--- a/src/agentcore_rl_toolkit/backends/slime/examples/math_agent/config.yaml.example
+++ b/src/agentcore_rl_toolkit/backends/slime/examples/math_agent/config.yaml.example
@@ -17,5 +17,19 @@ gateway_port: 9090                  # rllm-model-gateway port
 acr_timeout: 900                    # per-session ACR invocation timeout (s)
 model_id: "default"                 # OpenAI model id served to the agent
 acr_tps_limit: 25                   # ACR service TPS quota
-max_concurrent: 100                 # max concurrent ACR sessions (eval batching)
+max_concurrent: 100                 # max concurrent ACR sessions
+max_pool_connections: 256           # boto3 connection pool size
 reward_postprocessing: "grpo"       # "grpo" or "identity"
+
+# Set gateway_cumulative_token_mode to true will turn on model gateway's
+# cumulative token mode. It constructs a per-session cumulative input token
+# sequence and forwards it to sglang servers if the message history is cumulative.
+cumulative_token_mode: false
+# Model gateway's cumulative token mode uses renderers package to construct
+# cross-message-turn bridge tokens, that needs setting model family name
+# (e.g. "qwen3", "glm-5"). If it is "auto" and actor_rollout_ref.model.path
+# is a huggingface model id, renderers will auto infers model family name.
+# But you must set model family name explicitly if actor_rollout_ref.model.path
+# is a local model path. Check supported model families in MODEL_RENDERER_MAP of
+# https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py
+renderer_family: "auto"

--- a/src/agentcore_rl_toolkit/backends/slime/examples/math_agent/train.sh
+++ b/src/agentcore_rl_toolkit/backends/slime/examples/math_agent/train.sh
@@ -1,73 +1,98 @@
 #!/bin/bash
-# Train strands_math_agent with slime GRPO using ACR-based rollouts.
+# Train the strands math agent with slime GRPO using ACR-based rollouts.
 #
 # The agent (examples/strands_math_agent/rl_app.py) must be deployed to ACR first.
 # This script runs slime training with our custom rollout function that submits
-# tasks to ACR, collects traces via rllm-model-gateway, and feeds per-turn
-# Samples into Megatron for GRPO training.
-#
-# Default smoke-test target is Qwen2.5-3B-Instruct (large enough to produce
-# non-trivial GSM8K rewards on the first rollout step, small enough to fit
-# on 8×H100 without offload acrobatics). Hyperparameters follow slime's
-# Qwen2.5-0.5B GSM8K production config (scripts/run-qwen2.5-0.5B-reproducibility.sh)
-# and are inlined in the `python3 train.py` command below.
+# tasks to ACR, collects per-turn token ids + logprobs via rllm-model-gateway
+# (use_sglang mode, driven by the integration), and feeds Samples into Megatron
+# for GRPO training.
 #
 # Configuration:
 #   config.yaml      — ACR deployment + toolkit tunables
 #                      (cp from config.yaml.example; gitignored)
-#   .wandb.env       — WANDB_API_KEY, WANDB_ENTITY (optional)
-#   env vars below   — paths, model type, cluster config (override via env)
+#   .wandb.env       — WANDB_API_KEY, WANDB_ENTITY, WANDB_PROJECT (optional)
+#   env vars below   — paths, model type, cluster + CUDA config (override via env)
 #
 # Usage: bash train.sh
 set -euo pipefail
 
-# === Paths (edit these) ===
-SLIME_DIR="${SLIME_DIR:?Set SLIME_DIR (path to slime repo)}"
-MEGATRON_DIR="${MEGATRON_DIR:?Set MEGATRON_DIR (path to patched Megatron-LM)}"
-MODEL_DIR="${MODEL_DIR:?Set MODEL_DIR (path to HF model checkpoint)}"
-DATA_PATH="${DATA_PATH:?Set DATA_PATH (path to training JSONL)}"
-CONFIG="${CONFIG:-$(dirname $0)/config.yaml}"
+# === Paths (set these via env) ===
+SLIME_DIR="${SLIME_DIR:?Set SLIME_DIR (path to the slime repo)}"
+MODEL_DIR="${MODEL_DIR:?Set MODEL_DIR (path to the HF model checkpoint)}"
+TRAIN_DATA_PATH="${TRAIN_DATA_PATH:?Set TRAIN_DATA_PATH (path to the training JSONL)}"
+VAL_DATA_PATH="${VAL_DATA_PATH:?Set VAL_DATA_PATH (path to the validation JSONL)}"
+CONFIG="${CONFIG:-$(dirname "$0")/config.yaml}"
 
-# Model architecture (change for different models)
-MODEL_TYPE="${MODEL_TYPE:-qwen2.5-3B}"
+# Set your cuda path
+CUDA_HOME=/usr/local/cuda-13.0
 
-# Cluster / run config (override via env — 3B smoke-test defaults)
+# Model architecture args sourced from $SLIME_DIR/scripts/models/${MODEL_TYPE}.sh
+MODEL_TYPE="${MODEL_TYPE:?Set MODEL_TYPE (slime model-arch name, e.g. qwen3-4B)}"
+
+# Checkpoint output dir (cleared at start; comment the rm to resume).
+CKPTS_DIR="${CKPTS_DIR:-exp_agentcore_grpo}"
+rm -rf "${CKPTS_DIR}"
+
+# Sequence / batching budget
+MAX_CONTEXT_LENGTH="${MAX_CONTEXT_LENGTH:-14336}"
+MAX_RESPONSE_LENGTH="${MAX_RESPONSE_LENGTH:-2048}"
+MAX_TOKENS_PER_GPU="${MAX_TOKENS_PER_GPU:-14336}"
+
+# Cluster / run config
 NUM_GPUS="${NUM_GPUS:-8}"
-TP_SIZE="${TP_SIZE:-2}"                                 # tensor model parallel size (TP=2 keeps 3B activations under the SGLang-mem-fraction=0.7 budget)
+TP_SIZE="${TP_SIZE:-2}"                                 # tensor model parallel size
 ROLLOUT_GPUS_PER_ENGINE="${ROLLOUT_GPUS_PER_ENGINE:-2}" # GPUs per SGLang engine
-NUM_ROLLOUT="${NUM_ROLLOUT:-1}"                         # total training iterations (smoke-test default)
+NUM_ROLLOUT="${NUM_ROLLOUT:-1}"                         # total rollout steps (smoke-test default)
+SGLANG_TOOL_CALL_PARSER="${SGLANG_TOOL_CALL_PARSER:-qwen}"  # must match the served model
 
-# Load wandb credentials (optional)
-[ -f "$(dirname $0)/.wandb.env" ] && source "$(dirname $0)/.wandb.env"
+# Load wandb credentials (optional). Define WANDB_API_KEY (and optionally
+# WANDB_ENTITY / WANDB_PROJECT) in .wandb.env — do NOT commit real keys.
+[ -f "$(dirname "$0")/.wandb.env" ] && source "$(dirname "$0")/.wandb.env"
 
 # === Setup ===
 pkill -9 sglang 2>/dev/null || true
 ray stop --force 2>/dev/null || true
 sleep 3
 
+# torch_memory_saver fixup for CUDA 13 envs: slime/ray/actor_group.py looks for
+# the cu12-named preload .so, but a cu13 build ships *_cu13.abi3.so. Symlink the
+# cu13 binary to the cu12 name so slime finds it. No-op on cu12 envs (the cu12
+# .so already exists) and idempotent — only the filename is bridged, not contents.
+TMS_SP="$(python -c 'import os, torch_memory_saver; print(os.path.dirname(os.path.dirname(torch_memory_saver.__file__)))' 2>/dev/null || true)"
+if [ -n "$TMS_SP" ] \
+   && [ ! -e "$TMS_SP/torch_memory_saver_hook_mode_preload_cu12.abi3.so" ] \
+   && [ -e "$TMS_SP/torch_memory_saver_hook_mode_preload_cu13.abi3.so" ]; then
+  ln -s "$TMS_SP/torch_memory_saver_hook_mode_preload_cu13.abi3.so" \
+        "$TMS_SP/torch_memory_saver_hook_mode_preload_cu12.abi3.so"
+  echo "[setup] linked tms cu13 .so -> cu12 name for slime compatibility"
+fi
+
+export CUDA_HOME
+export PATH="${CUDA_HOME}/bin:${PATH}"
+NVIDIA_LIBS=$(python -c "import sysconfig, os, glob; base=os.path.join(sysconfig.get_path('purelib'), 'nvidia'); print(':'.join(sorted(glob.glob(os.path.join(base, '*', 'lib')))))")
+LD_LIBRARY_PATH="$(echo "${LD_LIBRARY_PATH:-}" | tr ':' '\n' | grep -vE '^/usr/local/cuda(-[0-9.]+)?/' | paste -sd ':' -)"
+export LD_LIBRARY_PATH="${NVIDIA_LIBS}:${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}"
+
 export PYTHONUNBUFFERED=1
 ray start --head --num-gpus ${NUM_GPUS} --disable-usage-stats
 
-# Source model architecture args
+# Source model architecture args (populates MODEL_ARGS)
 source ${SLIME_DIR}/scripts/models/${MODEL_TYPE}.sh
 
 # === Launch training ===
 export no_proxy=127.0.0.1
 
-# Env vars forwarded to every Ray worker. Wandb keys injected only when set.
-# (ACR ARN + bucket flow through config.yaml, not env.)
-RUNTIME_ENV_JSON=$(python3 -c '
-import json, os, sys
-env = {
-    "PYTHONPATH": sys.argv[1],           # megatron.training is not editable-installed
-    "CUDA_DEVICE_MAX_CONNECTIONS": "1",  # required for Megatron TP comm/compute overlap
-}
-for key in ("WANDB_API_KEY", "WANDB_ENTITY"):
-    val = os.environ.get(key)
-    if val:
-        env[key] = val
-print(json.dumps({"env_vars": env}))
-' "${MEGATRON_DIR}")
+# Env vars forwarded to every Ray worker. (ACR ARN + bucket flow through
+# config.yaml, not env.) WANDB_API_KEY is appended only when set, so an unset key
+# doesn't inject an empty value into the worker env.
+RUNTIME_ENV_JSON="{\"env_vars\": {\"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\", \"CUDA_HOME\": \"${CUDA_HOME}\", \"LD_LIBRARY_PATH\": \"${LD_LIBRARY_PATH}\"${WANDB_API_KEY:+, \"WANDB_API_KEY\": \"${WANDB_API_KEY}\"}}}"
+
+# slime creates the Megatron train actors with their OWN runtime_env.env_vars
+# (slime/ray/actor_group.py), which does NOT carry CUDA_HOME / LD_LIBRARY_PATH —
+# so a train worker would fall back to the cluster CUDA and TransformerEngine
+# could hit "Multiple libcudart libraries found". --train-env-vars is merged into
+# that actor env, so pass the pinned CUDA paths through it too.
+TRAIN_ENV_VARS_JSON="{\"CUDA_HOME\": \"${CUDA_HOME}\", \"LD_LIBRARY_PATH\": \"${LD_LIBRARY_PATH}\"}"
 
 ray job submit --address="http://127.0.0.1:8265" \
   --runtime-env-json="${RUNTIME_ENV_JSON}" \
@@ -75,15 +100,22 @@ ray job submit --address="http://127.0.0.1:8265" \
   "${MODEL_ARGS[@]}" \
   --hf-checkpoint ${MODEL_DIR} \
   --ref-load ${MODEL_DIR} \
-  --prompt-data ${DATA_PATH} \
+  --prompt-data ${TRAIN_DATA_PATH} \
   --num-rollout ${NUM_ROLLOUT} \
   --tensor-model-parallel-size ${TP_SIZE} \
   --rollout-num-gpus-per-engine ${ROLLOUT_GPUS_PER_ENGINE} \
   --input-key prompt \
-  --rollout-batch-size 32 \
-  --n-samples-per-prompt 8 \
-  --rollout-max-response-len 1024 \
+  --rollout-batch-size 64 \
+  --n-samples-per-prompt 4 \
+  --num-steps-per-rollout 1 \
+  --rollout-max-response-len ${MAX_RESPONSE_LENGTH} \
   --rollout-temperature 1.0 \
+  --eval-interval 10 \
+  --eval-prompt-data gsm8k ${VAL_DATA_PATH} \
+  --eval-input-key prompt \
+  --n-samples-per-eval-prompt 1 \
+  --eval-temperature 0.0 \
+  --eval-max-response-len ${MAX_RESPONSE_LENGTH} \
   --advantage-estimator grpo \
   --use-kl-loss \
   --kl-loss-type low_var_kl \
@@ -91,30 +123,31 @@ ray job submit --address="http://127.0.0.1:8265" \
   --eps-clip-high 0.28 \
   --lr 1e-6 \
   --lr-decay-style constant \
-  --weight-decay 0.1 \
-  --adam-beta2 0.98 \
   --optimizer-cpu-offload \
   --overlap-cpu-optimizer-d2h-h2d \
   --use-precision-aware-optimizer \
   --sequence-parallel \
-  --sglang-mem-fraction-static 0.7 \
+  --sglang-mem-fraction-static 0.6 \
   --sglang-cuda-graph-max-bs 32 \
-  --sglang-tool-call-parser qwen25 \
-  --attention-dropout 0.0 \
-  --hidden-dropout 0.0 \
+  --sglang-context-length ${MAX_CONTEXT_LENGTH} \
+  --sglang-tool-call-parser ${SGLANG_TOOL_CALL_PARSER} \
+  --sglang-log-level warning \
+  --sglang-log-level-http warning \
   --accumulate-allreduce-grads-in-fp32 \
   --attention-softmax-in-fp32 \
   --attention-backend flash \
   --actor-num-gpus-per-node ${NUM_GPUS} \
   --colocate \
+  --train-env-vars "${TRAIN_ENV_VARS_JSON}" \
   --megatron-to-hf-mode bridge \
   --rollout-function-path \
       agentcore_rl_toolkit.backends.slime.integration.rollout.generate_rollout \
   --custom-reward-post-process-path \
       agentcore_rl_toolkit.backends.slime.integration.rewards.normalize_episode_rewards \
   --custom-config-path ${CONFIG} \
-  --use-dynamic-global-batch-size \
   --use-dynamic-batch-size \
-  --max-tokens-per-gpu 9216 \
-  ${WANDB_API_KEY:+--use-wandb --wandb-project ${WANDB_PROJECT:-slime-art} --wandb-group gsm8k-grpo}
-  # To enable checkpointing, add: --save /path/to/ckpt --save-interval 10 [--save-hf]
+  --max-tokens-per-gpu ${MAX_TOKENS_PER_GPU} \
+  --save ${CKPTS_DIR} \
+  --save-interval 100 \
+  --save-hf ${CKPTS_DIR}/hf/{rollout_id} \
+  ${WANDB_API_KEY:+--use-wandb --wandb-project ${WANDB_PROJECT:-slime-art} --wandb-group gsm8k-slime-grpo}

--- a/src/agentcore_rl_toolkit/backends/slime/integration/gateway.py
+++ b/src/agentcore_rl_toolkit/backends/slime/integration/gateway.py
@@ -28,6 +28,28 @@ class GatewayConfig:
     add_logprobs: bool = True
     add_return_token_ids: bool = True
     strip_vllm_fields: bool = False
+    # Cumulative token mode: gateway rewrites turn N>1 to /v1/completions with a
+    # pre-tokenized, prefix-extending prompt (drift-free multi-turn). Requires
+    # `model` (tokenizer source) and a `renderer_family` the model supports.
+    cumulative_token_mode: bool = False
+    renderer_family: str = "auto"
+    # Served model checkpoint (path or HF id). The gateway loads its tokenizer to
+    # render each turn's prompt to token ids for SGLang /generate and to decode
+    # completion ids for parsing; in cumulative mode it also resolves the renderer.
+    # Always required for the slime backend (use_sglang is always on); sourced from
+    # slime's --hf-checkpoint at the call site.
+    model: str | None = None
+    # SGLang tool-call / reasoning parser names for parsing /generate output text
+    # (same parsers SGLang's /v1/chat/completions uses). Required for tool-using
+    # agents in use_sglang mode; without the tool parser, tool calls come back as
+    # plain assistant text.
+    sglang_tool_call_parser: str | None = None
+    sglang_reasoning_parser: str | None = None
+    # Log level for the gateway subprocess (passed as --log-level). Also controls
+    # uvicorn access logs and httpx request logs, which are very chatty at INFO
+    # (one line per /v1/chat/completions and /generate call). Default WARNING so
+    # the training stdout is dominated by our own batch/metric logs.
+    log_level: str = "warning"
 
 
 class SlimeGatewayManager:
@@ -67,11 +89,37 @@ class SlimeGatewayManager:
             cmd.extend(["--host", cfg.host])
         if cfg.db_path:
             cmd.extend(["--db-path", cfg.db_path])
+        if cfg.log_level:
+            cmd.extend(["--log-level", cfg.log_level])
+
+        if not cfg.model:
+            raise ValueError(
+                "GatewayConfig.model is required for the slime backend, "
+                "the gateway needs the served checkpoint to load its tokenizer. "
+                "Pass it through --hf-checkpoint of slime's training script."
+            )
+        cmd.append("--use-sglang")
+        cmd.extend(["--model", cfg.model])
+        # SGLang output parsers (tool calls / reasoning). The same parser names
+        # slime passes to its SGLang server, so the gateway parses /generate output
+        # identically. Without the tool parser, tool calls come back as plain text.
+        if cfg.sglang_tool_call_parser:
+            cmd.extend(["--sglang-tool-call-parser", cfg.sglang_tool_call_parser])
+        if cfg.sglang_reasoning_parser:
+            cmd.extend(["--sglang-reasoning-parser", cfg.sglang_reasoning_parser])
+        # Cumulative mode adds the cross-turn bridge; it needs --renderer-family
+        # for a local checkpoint path (renderers can auto-infer it only for HF ids).
+        if cfg.cumulative_token_mode:
+            cmd.append("--cumulative-token-mode")
+            if cfg.renderer_family and cfg.renderer_family != "auto":
+                cmd.extend(["--renderer-family", cfg.renderer_family])
         # Note: add_logprobs, add_return_token_ids, strip_vllm_fields are
         # gateway config options set via GatewayClient after startup, not CLI args.
 
         self._process = subprocess.Popen(cmd)
-        self._wait_for_health(timeout=30)
+        # Tokenizer (always) + renderer (cumulative) load can take longer than a
+        # plain proxy start, so allow a generous health window.
+        self._wait_for_health(timeout=120)
 
         base = f"http://{cfg.host or 'localhost'}:{cfg.port}"
         self._client = GatewayClient(base)

--- a/src/agentcore_rl_toolkit/backends/slime/integration/rollout.py
+++ b/src/agentcore_rl_toolkit/backends/slime/integration/rollout.py
@@ -25,10 +25,12 @@ Usage:
         model_id: "default"              # OpenAI model id served to the agent
         acr_tps_limit: 25                # ACR service TPS quota
         max_concurrent: 100              # max concurrent ACR sessions (eval)
+        max_pool_connections: 100        # boto3 conn-pool size (>= max_concurrent)
         reward_postprocessing: "grpo"    # "grpo" or "identity"
 """
 
 import asyncio
+import copy
 import json
 import logging
 import os
@@ -46,6 +48,10 @@ _TRACE_LOG_PATH = Path(os.environ.get("TRACE_LOG", "trace_log.jsonl"))
 _gateway = None
 _client = None
 _config = None
+
+# Cache of eval datasets keyed by EvalDatasetConfig.cache_key, so repeated
+# evaluations don't re-read + re-tokenize the same JSONL every rollout.
+_eval_datasets: dict = {}
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +76,13 @@ class SlimeArtConfig:
     model_id: str = "default"
     acr_tps_limit: int = 25
     max_concurrent: int = 100
+    max_pool_connections: int = 10
     reward_postprocessing: str = "grpo"
+    cumulative_token_mode: bool = False
+    renderer_family: str = "auto"
+    sglang_tool_call_parser: str | None = None
+    sglang_reasoning_parser: str | None = None
+    gateway_log_level: str = "warning"
 
     @classmethod
     def from_args(cls, args: Namespace) -> "SlimeArtConfig":
@@ -82,6 +94,11 @@ class SlimeArtConfig:
                 return val
             return os.environ.get(env, default)
 
+        def _as_bool(val) -> bool:
+            if isinstance(val, bool):
+                return val
+            return str(val).strip().lower() in ("1", "true", "yes", "on")
+
         return cls(
             agent_runtime_arn=_get("agent_runtime_arn", "ACR_AGENT_RUNTIME_ARN", cls.agent_runtime_arn),
             s3_bucket=_get("s3_bucket", "ACR_S3_BUCKET", cls.s3_bucket),
@@ -91,7 +108,21 @@ class SlimeArtConfig:
             model_id=_get("model_id", "MODEL_ID", cls.model_id),
             acr_tps_limit=int(_get("acr_tps_limit", "ACR_TPS_LIMIT", cls.acr_tps_limit)),
             max_concurrent=int(_get("max_concurrent", "MAX_CONCURRENT", cls.max_concurrent)),
+            max_pool_connections=int(_get("max_pool_connections", "MAX_POOL_CONNECTIONS", cls.max_pool_connections)),
             reward_postprocessing=_get("reward_postprocessing", "REWARD_POSTPROCESSING", cls.reward_postprocessing),
+            cumulative_token_mode=_as_bool(
+                _get("cumulative_token_mode", "CUMULATIVE_TOKEN_MODE", cls.cumulative_token_mode)
+            ),
+            renderer_family=_get("renderer_family", "RENDERER_FAMILY", cls.renderer_family),
+            # Read slime's own SGLang server args (args.sglang_tool_call_parser /
+            # args.sglang_reasoning_parser) so the gateway parses identically.
+            sglang_tool_call_parser=_get(
+                "sglang_tool_call_parser", "SGLANG_TOOL_CALL_PARSER", cls.sglang_tool_call_parser
+            ),
+            sglang_reasoning_parser=_get(
+                "sglang_reasoning_parser", "SGLANG_REASONING_PARSER", cls.sglang_reasoning_parser
+            ),
+            gateway_log_level=_get("gateway_log_level", "GATEWAY_LOG_LEVEL", cls.gateway_log_level),
         )
 
 
@@ -183,11 +214,23 @@ def _ensure_initialized(args: Namespace):
 
     if _gateway is None:
         sglang_url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}"
+        # The slime backend always drives the gateway in use_sglang mode (enforced
+        # unconditionally in SlimeGatewayManager.start): the served engine is SGLang
+        # behind sgl-router, whose token ids + logprobs are only exposed via the
+        # native /generate API — the OpenAI endpoints would capture no token ids.
+        # `model` (= slime's --hf-checkpoint) is the tokenizer the gateway renders
+        # prompts to token ids with, and is required.
         _gateway = SlimeGatewayManager(
             GatewayConfig(
                 port=cfg.gateway_port,
                 host=args.sglang_router_ip,  # Bind to routable IP so VPC agents can reach it
                 strip_vllm_fields=False,
+                cumulative_token_mode=cfg.cumulative_token_mode,
+                renderer_family=cfg.renderer_family,
+                model=getattr(args, "hf_checkpoint", None),
+                sglang_tool_call_parser=cfg.sglang_tool_call_parser,
+                sglang_reasoning_parser=cfg.sglang_reasoning_parser,
+                log_level=cfg.gateway_log_level,
             )
         )
         _gateway.start(sglang_url)
@@ -198,6 +241,7 @@ def _ensure_initialized(args: Namespace):
             s3_bucket=cfg.s3_bucket,
             exp_id=cfg.exp_id,
             tps_limit=cfg.acr_tps_limit,
+            max_pool_connections=cfg.max_pool_connections,
         )
 
     return _gateway, _client, cfg
@@ -245,7 +289,7 @@ async def _process_one_episode(
     normalize_episode_rewards() can group all turns from all episodes
     of the same task together for GRPO normalization.
     """
-    from .traces import episode_traces_to_samples, extract_reward
+    from .traces import extract_reward, merge_traces_to_samples
 
     session_id = str(uuid.uuid4())
     try:
@@ -268,19 +312,22 @@ async def _process_one_episode(
         result = await future.result_async(timeout=cfg.acr_timeout)
         traces = await asyncio.to_thread(gateway.get_traces, session_id)
         episode_reward = extract_reward(result)
-        logger.info(
-            "Session %s: status=%s, traces=%d, reward=%s",
-            session_id[:8],
-            result.get("status_code"),
-            len(traces),
-            episode_reward,
-        )
         _log_traces(session_id, traces, episode_reward, task_index)
 
         if not traces:
-            return [_make_noop_sample(group_index=task_index, session_id=session_id, status_name="FAILED")]
+            noop = _make_noop_sample(group_index=task_index, session_id=session_id, status_name="FAILED")
+            noop.metadata["episode_error"] = "no traces returned"
+            logger.info("Episode failed (session=%s): %s", session_id, noop.metadata["episode_error"])
+            return [noop]
 
-        samples = episode_traces_to_samples(
+        # Always merge: fold the trajectory into one Sample per contiguous
+        # prefix-extending segment (GPU-efficient, drift-free). This is correct
+        # regardless of transport (use_sglang) or prompt construction
+        # (cumulative_token_mode): when turns share a byte-exact prefix they merge
+        # into one sequence; when a turn breaks the prefix (e.g. non-cumulative
+        # full re-render, or agent context surgery) merge_traces_to_samples splits
+        # at that point, degrading to per-turn/per-segment Samples.
+        samples = merge_traces_to_samples(
             traces=traces,
             episode_reward=episode_reward,
             group_index=task_index,
@@ -297,8 +344,12 @@ async def _process_one_episode(
         return samples
 
     except Exception as e:
-        logger.error("Episode failed (session=%s): %s", session_id, e)
-        return [_make_noop_sample(group_index=task_index, session_id=session_id, status_name="FAILED")]
+        # Record the failure on the sample (the per-batch summary counts these)
+        # and log it at INFO so a failing episode is visible.
+        noop = _make_noop_sample(group_index=task_index, session_id=session_id, status_name="FAILED")
+        noop.metadata["episode_error"] = str(e) or type(e).__name__
+        logger.info("Episode failed (session=%s): %s", session_id, noop.metadata["episode_error"])
+        return [noop]
     finally:
         await asyncio.to_thread(gateway.delete_session, session_id)
 
@@ -321,31 +372,74 @@ def generate_rollout(
     _, RolloutFnTrainOutput, RolloutFnEvalOutput = _import_slime_types()
     gateway, client, cfg = _ensure_initialized(args)
 
-    batch_size = (
-        args.rollout_batch_size if not evaluation else getattr(args, "eval_batch_size", args.rollout_batch_size)
-    )
-    sample_groups = data_source.get_samples(batch_size)
+    # ---- Step 1: resolve the prompt groups to run, each paired with the
+    # sampling params it should use ----
+    # Training samples one batch of GRPO-grouped prompts from the live
+    # data_source, all sharing the rollout params. Eval reads held-out datasets
+    # (args.eval_datasets, built by slime from --eval-prompt-data /
+    # --eval-config), each carrying its own already-resolved params (e.g.
+    # greedy via --eval-temperature 0); eval rewards are independent, so each
+    # (prompt, sample) is its own size-1 group.
+    if evaluation:
+        groups = []  # list of (prompt_group, sampling_params)
+        for dataset_cfg in getattr(args, "eval_datasets", None) or []:
+            params = {
+                "temperature": dataset_cfg.temperature,
+                "top_p": dataset_cfg.top_p,
+                "top_k": dataset_cfg.top_k,
+                "max_new_tokens": dataset_cfg.max_response_len,
+            }
+            dataset = _get_eval_dataset(args, dataset_cfg)
+            for prompt in dataset.samples:
+                for _ in range(dataset_cfg.n_samples_per_eval_prompt or 1):
+                    groups.append(([copy.deepcopy(prompt)], params))
+    else:
+        params = {
+            "temperature": args.rollout_temperature,
+            "top_p": args.rollout_top_p,
+            "top_k": args.rollout_top_k,
+            "max_new_tokens": args.rollout_max_response_len,
+        }
+        groups = [(group, params) for group in data_source.get_samples(args.rollout_batch_size)]
 
-    sampling_params = {
-        "temperature": args.rollout_temperature,
-        "top_p": args.rollout_top_p,
-        "top_k": args.rollout_top_k,
-        "max_new_tokens": args.rollout_max_response_len,
-    }
-
+    # ---- Step 2 (shared): run every group as parallel ACR episodes ----
+    # Each sample in a group becomes one episode tagged with the group index
+    # (GRPO grouping in training, a unique id in eval); turns are flattened
+    # back per group. All groups (and all episodes within them) are scheduled
+    # concurrently, but a shared semaphore caps the number of episodes that are
+    # actually in flight at once (cfg.max_concurrent). Without this cap, a large
+    # batch (e.g. a full 1319-prompt eval set) launches every episode at once —
+    # the 25-TPS client limiter only paces session *starts*, not the live count —
+    # which saturates the gateway/router + S3 result polling (episodes then miss
+    # acr_timeout and fail) and over-pressures the colocated SGLang KV cache
+    # (token-pool exhaustion crash). asyncio.gather preserves argument order, so
+    # the returned list stays group-ordered (list[list[Sample]]), keeping the
+    # GRPO group_index tags and slime's nesting-depth contract intact. (Ordering
+    # is non-semantic anyway: grouping is by explicit group_index/session_id, not
+    # list position — see rewards.normalize_episode_rewards.)
     sample_counter = iter(range(10**9))
 
     async def _run():
-        all_groups = []
-        for task_index, task_episodes in enumerate(sample_groups):
-            episode_tasks = [
-                _process_one_episode(s, gateway, client, cfg, sampling_params, task_index, sample_counter)
-                for s in task_episodes
-            ]
-            episode_results = await asyncio.gather(*episode_tasks)
-            flat = [s for result in episode_results for s in result]
-            all_groups.append(flat)
-        return all_groups
+        # Bound concurrent in-flight episodes across ALL groups. Created inside
+        # the running loop (asyncio.Semaphore binds to the active event loop).
+        sem = asyncio.Semaphore(max(1, cfg.max_concurrent))
+
+        async def _episode(s, group_index, sampling_params):
+            async with sem:
+                return await _process_one_episode(s, gateway, client, cfg, sampling_params, group_index, sample_counter)
+
+        async def _run_group(group_index, group, sampling_params):
+            results = await asyncio.gather(*(_episode(s, group_index, sampling_params) for s in group))
+            return [s for r in results for s in r]
+
+        return list(
+            await asyncio.gather(
+                *(
+                    _run_group(group_index, group, sampling_params)
+                    for group_index, (group, sampling_params) in enumerate(groups)
+                )
+            )
+        )
 
     try:
         loop = asyncio.get_event_loop()
@@ -354,30 +448,73 @@ def generate_rollout(
         asyncio.set_event_loop(loop)
     results = loop.run_until_complete(_run())
 
+    # ---- Step 3: per-batch summary (replaces per-session logging) ----
+    # num_episodes is the input-prompt count; num_sequences is the Sample
+    # count after merge (multi-turn episodes fold toward one sequence each in
+    # cumulative mode, stay one-per-turn otherwise).
+    num_episodes = sum(len(group) for group, _ in groups)
+    num_sequences = sum(len(g) for g in results)
+    failed = sum(1 for g in results for s in g if (s.metadata or {}).get("episode_error"))
+    succeeded = num_episodes - failed
+    phase = "Eval" if evaluation else "Rollout"
+    logger.info(
+        "%s %d batch: episodes=%d (succeeded=%d failed=%d) sequences=%d",
+        phase,
+        rollout_id,
+        num_episodes,
+        succeeded,
+        failed,
+        num_sequences,
+    )
+
+    # ---- Step 4: shape the backend-specific output ----
     if evaluation:
-        return _build_eval_output(results, RolloutFnEvalOutput)
+        # Episode reward is broadcast to every turn-Sample; take the first.
+        rewards = [float(g[0].reward) if g and isinstance(g[0].reward, (int, float)) else 0.0 for g in results]
+        n = max(len(rewards), 1)
+        accuracy = sum(1 for r in rewards if r > 0) / n
+        avg_reward = sum(rewards) / n
+        return RolloutFnEvalOutput(
+            data={"eval": {"rewards": rewards}},
+            metrics={
+                "eval/accuracy": accuracy,
+                "eval/avg_reward": avg_reward,
+                "eval/n_samples": len(rewards),
+            },
+        )
 
-    # Pad to dp_size multiple so no real samples are trimmed
+    # Training: pad to a dp_size multiple so no real samples are trimmed.
     dp_size = args.actor_num_nodes * args.actor_num_gpus_per_node // args.tensor_model_parallel_size
-    flat_count = sum(len(g) for g in results)
-    remainder = flat_count % dp_size
+    remainder = sum(len(g) for g in results) % dp_size
     if remainder > 0:
-        pad_count = dp_size - remainder
-        results[-1].extend([_make_noop_sample(group_index=-1) for _ in range(pad_count)])
-
+        results[-1].extend([_make_noop_sample(group_index=-1) for _ in range(dp_size - remainder)])
     return RolloutFnTrainOutput(samples=results)
 
 
-def _build_eval_output(results, RolloutFnEvalOutput):
-    """Convert grouped samples into slime eval output format."""
-    all_rewards = []
-    for group in results:
-        for sample in group:
-            r = sample.reward if sample.reward is not None else 0.0
-            all_rewards.append(float(r) if isinstance(r, (int, float)) else 0.0)
+def _get_eval_dataset(args, dataset_cfg):
+    """Load + cache a held-out eval dataset described by an EvalDatasetConfig.
 
-    accuracy = sum(1 for r in all_rewards if r > 0) / max(len(all_rewards), 1)
-    return RolloutFnEvalOutput(
-        data={"eval": {"rewards": all_rewards}},
-        metrics={"eval/accuracy": accuracy, "eval/n_samples": len(all_rewards)},
-    )
+    Reads the JSONL itself (independent of the training data_source) using
+    slime's Dataset so the prompt/metadata parsing matches the training path.
+    """
+    from slime.utils.data import Dataset
+    from slime.utils.processing_utils import load_processor, load_tokenizer
+
+    key = dataset_cfg.cache_key + (args.hf_checkpoint, args.apply_chat_template)
+    if key not in _eval_datasets:
+        tokenizer = load_tokenizer(args.hf_checkpoint, trust_remote_code=True)
+        processor = load_processor(args.hf_checkpoint, trust_remote_code=True)
+        _eval_datasets[key] = Dataset(
+            path=dataset_cfg.path,
+            tokenizer=tokenizer,
+            processor=processor,
+            max_length=args.eval_max_prompt_len,
+            prompt_key=dataset_cfg.input_key,
+            label_key=dataset_cfg.label_key,
+            metadata_key=dataset_cfg.metadata_key,
+            multimodal_keys=args.multimodal_keys,
+            tool_key=dataset_cfg.tool_key,
+            apply_chat_template=args.apply_chat_template,
+            apply_chat_template_kwargs=args.apply_chat_template_kwargs,
+        )
+    return _eval_datasets[key]

--- a/src/agentcore_rl_toolkit/backends/slime/integration/traces.py
+++ b/src/agentcore_rl_toolkit/backends/slime/integration/traces.py
@@ -119,6 +119,167 @@ def episode_traces_to_samples(
     return samples
 
 
+def _is_prefix_extension(prev_full: list[int], next_prompt: list[int]) -> bool:
+    """True if ``next_prompt`` begins byte-for-byte with ``prev_full``.
+
+    ``prev_full`` = previous turn's ``prompt_token_ids + completion_token_ids``.
+    The gateway's cumulative token mode guarantees this for adjacent turns of a
+    session (see rllm_model_gateway.token_accumulator). When it doesn't hold — the
+    gateway re-rendered the message list (non-cumulative mode), the agent did
+    context manipulation (truncation, summary injection), or the accumulator reset
+    — the two turns are NOT mergeable into one contiguous sequence.
+    """
+    if len(next_prompt) < len(prev_full):
+        return False
+    # Compare only the prefix region; next_prompt may be longer (bridge tokens).
+    return next_prompt[: len(prev_full)] == prev_full
+
+
+def _segment_to_sample(
+    segment: list,
+    reward: float,
+    group_index: int,
+    sample_index: int,
+    session_id: str,
+    segment_index: int,
+):
+    """Merge one contiguous (prefix-extending) run of traces into a single Sample.
+
+    Layout of the merged token stream, given traces ``t_0 .. t_{k-1}`` where each
+    ``t_i.prompt`` starts with ``t_{i-1}.prompt + t_{i-1}.completion``::
+
+        [ t_0.prompt | t_0.completion | bridge_1 | t_1.completion | bridge_2 | ... ]
+          \\___prompt__/ \\____________________ response ____________________________/
+
+    ``bridge_i`` = the new tokens turn ``i`` added before its own generation
+    (end-of-prev-assistant + new user/tool messages + next gen header). These are
+    NOT sampled by the policy, so they get ``loss_mask = 0`` and ``logprob = 0``;
+    only the completion spans are trainable (``loss_mask = 1``). This yields ONE
+    training sequence per trajectory of length ``≈ final_prompt + Σ completions``
+    instead of re-encoding the growing prefix once per turn.
+    """
+    Sample = _import_sample()
+
+    t0 = segment[0]
+    prompt_ids = list(t0.prompt_token_ids or [])
+    if not prompt_ids:
+        prompt_ids = [0]
+
+    # response stream = everything after the initial prompt, with per-token mask.
+    response_ids: list[int] = []
+    loss_mask: list[int] = []
+    logprobs: list[float] = []
+
+    prev_full = prompt_ids + list(t0.completion_token_ids or [])
+    for i, trace in enumerate(segment):
+        comp = list(trace.completion_token_ids or [])
+        lp = list(trace.logprobs or [])
+        if i > 0:
+            # Bridge = new prompt tokens beyond the previous turn's full sequence.
+            cur_prompt = list(trace.prompt_token_ids or [])
+            bridge = cur_prompt[len(prev_full) :]
+            response_ids.extend(bridge)
+            loss_mask.extend([0] * len(bridge))
+            logprobs.extend([0.0] * len(bridge))
+            prev_full = cur_prompt + comp
+        # Completion tokens are the trainable, policy-sampled span.
+        if not comp:
+            comp = [0]
+            lp = [0.0]
+        # Align logprobs to completion length.
+        if len(lp) > len(comp):
+            lp = lp[: len(comp)]
+        elif len(lp) < len(comp):
+            lp = lp + [0.0] * (len(comp) - len(lp))
+        response_ids.extend(comp)
+        loss_mask.extend([1] * len(comp))
+        logprobs.extend(lp)
+
+    if not response_ids:
+        response_ids = [0]
+        loss_mask = [0]
+        logprobs = [0.0]
+
+    sample = Sample()
+    sample.tokens = prompt_ids + response_ids
+    sample.response_length = len(response_ids)
+    sample.loss_mask = loss_mask
+    sample.rollout_log_probs = logprobs
+    sample.reward = reward
+    sample.group_index = group_index
+    sample.index = sample_index
+    sample.session_id = session_id
+    sample.metadata = {
+        "task_index": group_index,
+        "gateway_session_id": session_id,
+        "segment_index": segment_index,
+        "num_turns": len(segment),
+    }
+
+    # TRUNCATED if the final turn hit the length cap, else COMPLETED.
+    finish = getattr(segment[-1], "finish_reason", "stop")
+    sample.status = Sample.Status.TRUNCATED if finish == "length" else Sample.Status.COMPLETED
+    return sample
+
+
+def merge_traces_to_samples(
+    traces: list,
+    episode_reward: float,
+    group_index: int,
+    session_id: str,
+    sample_counter,
+) -> list:
+    """Merge an episode's traces into per-trajectory Samples by prefix extension.
+
+    Adjacent turns are merged into one Sample when they satisfy the
+    prefix-extension invariant (each turn's prompt begins byte-for-byte with the
+    previous turn's prompt+completion); see :func:`_segment_to_sample`.
+
+    Whenever the invariant breaks between two turns (non-cumulative re-render,
+    agent context manipulation, or a gateway accumulator reset), the trajectory is
+    split at that point and each contiguous run becomes its own Sample. All Samples
+    share the same ``session_id`` so :func:`rewards.normalize_episode_rewards`
+    still treats the whole session as one episode in the GRPO group.
+
+    Returns:
+        List of slime Samples (one per contiguous prefix-extending segment).
+    """
+    if not traces:
+        return []
+
+    # Split traces into contiguous prefix-extending segments.
+    segments: list[list] = [[traces[0]]]
+    prev_full = list(traces[0].prompt_token_ids or []) + list(traces[0].completion_token_ids or [])
+    for trace in traces[1:]:
+        cur_prompt = list(trace.prompt_token_ids or [])
+        if _is_prefix_extension(prev_full, cur_prompt):
+            segments[-1].append(trace)
+        else:
+            logger.warning(
+                "Session %s: prefix-extension broke at turn (prev_full=%d, cur_prompt=%d); "
+                "splitting trajectory into a new segment. Merged token savings reduced.",
+                session_id[:8],
+                len(prev_full),
+                len(cur_prompt),
+            )
+            segments.append([trace])
+        prev_full = cur_prompt + list(trace.completion_token_ids or [])
+
+    samples = []
+    for segment_index, segment in enumerate(segments):
+        samples.append(
+            _segment_to_sample(
+                segment=segment,
+                reward=episode_reward,
+                group_index=group_index,
+                sample_index=next(sample_counter),
+                session_id=session_id,
+                segment_index=segment_index,
+            )
+        )
+    return samples
+
+
 def extract_reward(acr_result: dict) -> float:
     """Extract scalar reward from an ACR S3 result dict."""
     rewards = acr_result.get("rewards", 0.0)

--- a/src/agentcore_rl_toolkit/backends/slime/runner.py
+++ b/src/agentcore_rl_toolkit/backends/slime/runner.py
@@ -30,7 +30,11 @@ _TOOLKIT_CONFIG_KEYS = (
     "model_id",
     "acr_tps_limit",
     "max_concurrent",
+    "max_pool_connections",
     "reward_postprocessing",
+    "cumulative_token_mode",
+    "renderer_family",
+    "gateway_log_level",
 )
 
 
@@ -64,13 +68,28 @@ class SlimeRunner:
     slime_dir: str = "/root/slime"
     megatron_dir: str = "/root/Megatron-LM"
 
+    # --- Optional: CUDA toolchain pinning ---
+    # When set, the runner pins the worker env to one CUDA toolkit (mirrors
+    # train.sh): exports CUDA_HOME/PATH, prepends the venv-bundled nvidia/*/lib
+    # dirs, and strips every other /usr/local/cuda-* from LD_LIBRARY_PATH so
+    # TransformerEngine doesn't abort with "Multiple libcudart libraries found".
+    # Leave None to inherit the ambient environment unchanged.
+    cuda_home: str | None = None
+
     # --- Optional: ACR / toolkit (forwarded to slime via custom-config yaml) ---
     model_id: str = "default"
     acr_timeout: int = 900
     acr_tps_limit: int = 25
     max_concurrent: int = 100
+    max_pool_connections: int = 100
     gateway_port: int = 9090
     reward_postprocessing: str = "grpo"
+    # Gateway use_sglang parsers (must match the served model) + cumulative mode.
+    sglang_tool_call_parser: str = "qwen"
+    sglang_reasoning_parser: str | None = None
+    cumulative_token_mode: bool = False
+    renderer_family: str = "auto"
+    gateway_log_level: str = "warning"
 
     # --- Optional: training hyperparameters ---
     rollout_batch_size: int = 32
@@ -83,6 +102,7 @@ class SlimeRunner:
     weight_decay: float = 0.1
     adam_beta2: float = 0.98
     sglang_mem_fraction_static: float = 0.7
+    sglang_context_length: int | None = None
     max_tokens_per_gpu: int = 9216
 
     # --- Wandb (opt-in; no defaults injected if unset) ---
@@ -152,17 +172,41 @@ class SlimeRunner:
         items = out.split(b"\0")
         return [x.decode() for x in items if x]
 
+    def _cuda_ld_library_path(self) -> str:
+        """LD_LIBRARY_PATH pinned to a single CUDA toolkit (mirrors train.sh).
+
+        Prepends every venv-bundled ``nvidia/*/lib`` dir (runtime+cublas, cudnn,
+        nccl, cusparselt, nvshmem) and ``$CUDA_HOME/lib64``, after stripping every
+        other ``/usr/local/cuda-*`` from the ambient LD_LIBRARY_PATH so
+        TransformerEngine sees only this CUDA runtime. Requires ``cuda_home``.
+        """
+        import glob
+        import re
+        import sysconfig
+
+        nvidia_base = os.path.join(sysconfig.get_path("purelib"), "nvidia")
+        nvidia_libs = sorted(glob.glob(os.path.join(nvidia_base, "*", "lib")))
+        ambient = os.environ.get("LD_LIBRARY_PATH", "")
+        kept = [p for p in ambient.split(":") if p and not re.match(r"^/usr/local/cuda(-[0-9.]+)?/", p)]
+        parts = [*nvidia_libs, f"{self.cuda_home}/lib64", *kept]
+        return ":".join(parts)
+
     def _build_runtime_env(self) -> dict:
         """Runtime env forwarded to every Ray worker.
 
         Mirrors train.sh's inline python snippet: PYTHONPATH for Megatron,
-        CUDA_DEVICE_MAX_CONNECTIONS for Megatron TP, plus wandb keys when
-        set in the parent environment.
+        CUDA_DEVICE_MAX_CONNECTIONS for Megatron TP, plus wandb keys when set in
+        the parent environment. When ``cuda_home`` is set, also pins CUDA_HOME +
+        LD_LIBRARY_PATH to one toolkit so the worker (and the train actors, via
+        --train-env-vars) avoid the "Multiple libcudart libraries found" abort.
         """
         env_vars: dict[str, str] = {
             "PYTHONPATH": self.megatron_dir,
             "CUDA_DEVICE_MAX_CONNECTIONS": "1",
         }
+        if self.cuda_home:
+            env_vars["CUDA_HOME"] = self.cuda_home
+            env_vars["LD_LIBRARY_PATH"] = self._cuda_ld_library_path()
         for key in ("WANDB_API_KEY", "WANDB_ENTITY"):
             val = os.environ.get(key)
             if val:
@@ -276,7 +320,11 @@ class SlimeRunner:
             "--sglang-cuda-graph-max-bs",
             "32",
             "--sglang-tool-call-parser",
-            "qwen25",
+            self.sglang_tool_call_parser,
+            "--sglang-log-level",
+            "warning",
+            "--sglang-log-level-http",
+            "warning",
             "--attention-dropout",
             "0.0",
             "--hidden-dropout",
@@ -301,6 +349,20 @@ class SlimeRunner:
             "--max-tokens-per-gpu",
             str(self.max_tokens_per_gpu),
         ]
+
+        # Optional SGLang reasoning parser (split <think>...</think> in the gateway).
+        if self.sglang_reasoning_parser:
+            flags.extend(["--sglang-reasoning-parser", self.sglang_reasoning_parser])
+        # Optional SGLang context length cap.
+        if self.sglang_context_length is not None:
+            flags.extend(["--sglang-context-length", str(self.sglang_context_length)])
+        # CUDA pinning for the Megatron train actors: slime gives them their own
+        # runtime_env that does NOT carry CUDA_HOME/LD_LIBRARY_PATH, so pass the
+        # pinned paths through --train-env-vars too (mirrors train.sh). Only when
+        # cuda_home is set.
+        if self.cuda_home:
+            train_env = {"CUDA_HOME": self.cuda_home, "LD_LIBRARY_PATH": self._cuda_ld_library_path()}
+            flags.extend(["--train-env-vars", json.dumps(train_env)])
 
         # Wandb opt-in: only emit --use-wandb if the user (or env) supplied an API key.
         if os.environ.get("WANDB_API_KEY"):


### PR DESCRIPTION
This PR adds drift-free multi-turn trajectory merging to the slime custom rollout
function and fixes several issues that surfaced when running on full training /
validation datasets (eval episodes timing out and crashing the engine, connection-pool
churn, and unreadably noisy logs). It also brings `SlimeRunner` and the example scripts
in line with these changes.

## Custom rollout function (`integration/`)

- **feat — auto-merge multi-turn conversations (`traces.py`).** Added
  `merge_traces_to_samples`: an episode's turns are folded into one training
  Sample per contiguous prefix-extending segment (bridge tokens masked out,
  completions trained), instead of one Sample per turn. Pairs with the gateway's
  cumulative token mode; falls back to one-Sample-per-turn when a turn breaks the
  prefix.
- **feat — cumulative token mode plumbing (`rollout.py`, `gateway.py`).** New
  `cumulative_token_mode` / `renderer_family` config knobs, forwarded to the
  gateway; `merge_traces_to_samples` is wired in as the rollout's sample builder.
- **feat — validation (`rollout.py`).**  Supported doing validation on an input validation
  set periodically with an interval in training. Bounded in-flight agent sessions in validation 
  by `max_concurrent` in yaml config. 
- **fix — connection-pool churn (`rollout.py`).** Added `max_pool_connections`
  so user can set `>= max_concurrent`to stop boto3 client logging "Connection pool
  is full, discarding connection" under concurrent ACR sessions.
- **fix — log noise (`rollout.py`, `gateway.py`).** Replaced per-session logging
  with a single per-batch summary (`episodes / succeeded / failed / sequences`);
  failed episodes log once at INFO with the full ACR `session_id` for CloudWatch
  lookup. Added `gateway_log_level` (default `warning`) to silence the gateway's
  uvicorn/httpx access logs.
- **fix — gateway always uses SGLang `/generate` (`gateway.py`).** The slime
  backend now enables `use_sglang` unconditionally and always passes the served
  `--model`; removed the dead `use_sglang` config field. (The `/generate`
  mechanics live in the rllm-model-gateway PR.)

## Training scripts & runner

- **`runner.py`** — exposed the new knobs on `SlimeRunner`
  (`sglang_tool_call_parser`, `sglang_reasoning_parser`, `cumulative_token_mode`,
  `renderer_family`, `max_pool_connections`, `gateway_log_level`,
  `sglang_context_length`) and added `cuda_home` to pin CUDA_HOME/LD_LIBRARY_PATH
  (incl. `--train-env-vars` for the Megatron actors), fixing TransformerEngine's
  "Multiple libcudart" abort. The tool-call parser is now a field instead of a
  hardcoded `qwen25`.
- **`examples/math_agent/train.sh`** — ported the CUDA-toolchain pinning,
  `torch_memory_saver` fixup, eval flags, log suppression, and checkpointing from
  the working run; all paths/credentials stay env-var placeholders.
- **`config.yaml.example`** — documented the new `max_pool_connections`,
  `cumulative_token_mode`, and `renderer_family` settings.

This PR must work together with https://github.com/rllm-org/rllm/pull/715.
A follow-up PR with slime environment setup guide in docs changes will come soon.
