### PR TITLE
fix(examples): fix conflicting dependency in MigrationBench example.

### DIFF
--- a/examples/strands_migration_agent/pyproject.toml
+++ b/examples/strands_migration_agent/pyproject.toml
@@ -18,6 +18,11 @@ dependencies = [
 [tool.setuptools]
 py-modules = ["rl_app", "reward", "models", "utils"]
 
+[tool.uv]
+override-dependencies = [
+    "migrationbench @ git+https://github.com/amazon-science/MigrationBench.git@19acd9eb3a402d825f200eb14cf01584eaa1f6e9",
+]
+
 [tool.uv.sources]
 migrationbench = { git = "https://github.com/amazon-science/MigrationBench.git", rev = "19acd9eb3a402d825f200eb14cf01584eaa1f6e9" }
 java-migration-agent = { git = "https://github.com/amazon-science/JavaMigration.git", subdirectory = "java_migration_agent" }


### PR DESCRIPTION
*Issue #, if available:*
java-migration-agent depends on `migrationbench@git+https://.../MigrationBench.git` without a rev. Force our pinned commit for the transitive dep too, otherwise uv treats the two URL specs as conflicting.

*Description of changes:*
Add
```
override-dependencies = [
    "migrationbench @ git+https://github.com/amazon-science/MigrationBench.git@19acd9eb3a402d825f200eb14cf01584eaa1f6e9",
]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
