### PR TITLE
chore: add project-scoped AWS MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "aws-mcp": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "mcp-proxy-for-aws==1.6.2",
+        "https://aws-mcp.us-east-1.api.aws/mcp",
+        "--metadata",
+        "AWS_REGION=us-west-2"
+      ],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
Adds a `.mcp.json` at the repo root so everyone developing this repo gets the [AWS MCP Server](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/getting-started-aws-mcp-server.html) automatically in Claude Code, using the SigV4 (MCP Proxy for AWS) setup from that page.

Project-scoped MCP servers checked into version control are the [documented Claude Code practice](https://code.claude.com/docs/en/mcp#project-scope) for sharing MCP tooling with a team. On first use, Claude Code shows a one-time prompt to approve the project's servers.

Requires `uv` (for `uvx`) and valid AWS credentials (e.g. `aws login`).