### PR TITLE
fix(verl): dependency pacakge update, fix megatron installation script and example training script for different cuda version compatibility

### DIFF
--- a/docs/site/src/content/docs/guides/verl-backend-setup.md
+++ b/docs/site/src/content/docs/guides/verl-backend-setup.md
@@ -87,12 +87,17 @@ Before running the training:
 
 The training can be launched with the following commands:
 
+:::note
+The following commands assume CUDA 13.0 is installed at `/usr/local/cuda-13.0`; adjust `CUDA_HOME` if yours differs.
+:::
+
 ```bash
 export VLLM_ALLREDUCE_USE_SYMM_MEM=0
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 export CUDA_HOME=/usr/local/cuda-13.0
-VENV_CU13_LIB=$(python -c "import sysconfig, os; print(os.path.join(sysconfig.get_path('purelib'), 'nvidia', 'cu13', 'lib'))")
-export LD_LIBRARY_PATH=$VENV_CU13_LIB:$LD_LIBRARY_PATH
+NVIDIA_LIBS=$(python -c "import sysconfig, os, glob; base=os.path.join(sysconfig.get_path('purelib'), 'nvidia'); print(':'.join(sorted(glob.glob(os.path.join(base, '*', 'lib')))))")
+LD_LIBRARY_PATH="$(echo "${LD_LIBRARY_PATH:-}" | tr ':' '\n' | grep -vE '^/usr/local/cuda(-[0-9.]+)?/' | paste -sd ':' -)"
+export LD_LIBRARY_PATH="${NVIDIA_LIBS}:${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}"
 export WANDB_API_KEY="your-wandb-api-key"
 
 python3 -m agentcore_rl_toolkit.backends.verl.main \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,14 @@ verl = [
 Homepage = "https://github.com/awslabs/agentcore-rl-toolkit"
 
 [tool.uv]
+# Declaring verl and rllm as conflicting extras lets uv resolve each
+# in its own fork instead of forcing one universal lock.
+conflicts = [
+    [
+        { extra = "verl" },
+        { extra = "rllm" },
+    ],
+]
 override-dependencies = [
     "numpy>=1.26.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,12 +80,14 @@ rllm = [
 ]
 verl = [
     "transformers>=5.5.3",
+    "datasets>=5.0.0",
     "numpy",
     "verl==0.8.0",
     "ray",
     "torch>=2.10.0",
     "torchvision>=0.23.0",
-    "vllm==0.21.0",
+    "vllm==0.22.0",
+    "flash-linear-attention",
     "flash-attn==2.8.3",
     "qwen-vl-utils",
     "rllm-model-gateway>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,7 @@ rllm = [
     "rllm",
 ]
 verl = [
-    "transformers>=5.5.3",
-    "datasets>=5.0.0",
+    "transformers==5.8.1",
     "numpy",
     "verl==0.8.0",
     "ray",

--- a/src/agentcore_rl_toolkit/backends/verl/examples/math_agent/run_agentcore_grpo.sh
+++ b/src/agentcore_rl_toolkit/backends/verl/examples/math_agent/run_agentcore_grpo.sh
@@ -7,10 +7,9 @@ export CUDA_DEVICE_MAX_CONNECTIONS=1
 # Set your cuda path
 export CUDA_HOME=/usr/local/cuda-13.0
 
-# If you installed nvidia-cublas-cu13 library in python environment, run the following two
-# to add it to system library paths.
-VENV_CU13_LIB=$(python -c "import sysconfig, os; print(os.path.join(sysconfig.get_path('purelib'), 'nvidia', 'cu13', 'lib'))")
-export LD_LIBRARY_PATH=$VENV_CU13_LIB:$LD_LIBRARY_PATH
+NVIDIA_LIBS=$(python -c "import sysconfig, os, glob; base=os.path.join(sysconfig.get_path('purelib'), 'nvidia'); print(':'.join(sorted(glob.glob(os.path.join(base, '*', 'lib')))))")
+LD_LIBRARY_PATH="$(echo "${LD_LIBRARY_PATH:-}" | tr ':' '\n' | grep -vE '^/usr/local/cuda(-[0-9.]+)?/' | paste -sd ':' -)"
+export LD_LIBRARY_PATH="${NVIDIA_LIBS}:${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}"
 
 # If you want to use wandb to visualize your training curves, set your wandb API key here.
 export WANDB_API_KEY="your-wandb-api-key"

--- a/src/agentcore_rl_toolkit/backends/verl/scripts/install_megatron.sh
+++ b/src/agentcore_rl_toolkit/backends/verl/scripts/install_megatron.sh
@@ -20,8 +20,17 @@ echo "[1/5] Installing nvidia-modelopt..."
 uv pip install 'nvidia-modelopt>=0.37.0'
 
 echo "[2/5] Installing transformer-engine (this may take a while)..."
-MAX_JOBS=128 uv pip install --no-cache --no-build-isolation \
-    "transformer_engine[pytorch,core-cu${CUDA_MAJOR}]==2.11"
+if [ "${CUDA_MAJOR}" != "12" ]; then
+    # If CUDA version is not cu12, explicitly exclude transformer-engine-cu12
+    # to avoid "Multiple libcudart libraries found" errors.
+    echo "transformer-engine-cu12 ; sys_platform == 'never'" | \
+    MAX_JOBS=128 uv pip install --no-cache --no-build-isolation \
+        --overrides - \
+        "transformer_engine[pytorch,core-cu${CUDA_MAJOR}]==2.11"
+else
+    MAX_JOBS=128 uv pip install --no-cache --no-build-isolation \
+        "transformer_engine[pytorch,core-cu${CUDA_MAJOR}]==2.11"
+fi
 
 # megatron-core > 0.15.0 required for numpy>=2.0.0 compatibility
 echo "[3/5] Installing megatron-core..."

--- a/uv.lock
+++ b/uv.lock
@@ -2,25 +2,42 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
 ]
+conflicts = [[
+    { package = "agentcore-rl-toolkit", extra = "rllm" },
+    { package = "agentcore-rl-toolkit", extra = "verl" },
+]]
 
 [manifest]
 overrides = [{ name = "numpy", specifier = ">=1.26.0" }]
@@ -40,9 +57,9 @@ version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "packaging" },
     { name = "psutil" },
     { name = "pyyaml" },
@@ -72,29 +89,33 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
-    { name = "transformers" },
+    { name = "transformers", version = "5.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "transformers", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or extra != 'extra-20-agentcore-rl-toolkit-rllm' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 gateway = [
     { name = "aiohttp" },
-    { name = "transformers" },
+    { name = "transformers", version = "5.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "transformers", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or extra != 'extra-20-agentcore-rl-toolkit-rllm' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 rllm = [
     { name = "rllm" },
 ]
 slime = [
-    { name = "rllm-model-gateway" },
+    { name = "rllm-model-gateway", version = "0.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-20-agentcore-rl-toolkit-verl' or extra != 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "rllm-model-gateway", version = "0.1.0", source = { git = "https://github.com/rllm-org/rllm.git?subdirectory=rllm-model-gateway#b9dfebf0157ce1d6dfe595d90d36836623702564" }, marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
 ]
 verl = [
     { name = "flash-attn" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "flash-linear-attention" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "qwen-vl-utils" },
     { name = "ray" },
-    { name = "rllm-model-gateway" },
+    { name = "rllm-model-gateway", version = "0.1.0", source = { registry = "https://pypi.org/simple" } },
     { name = "torch" },
     { name = "torchvision" },
-    { name = "transformers" },
+    { name = "transformers", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
     { name = "verl" },
     { name = "vllm" },
 ]
@@ -107,6 +128,7 @@ requires-dist = [
     { name = "bedrock-agentcore-starter-toolkit", specifier = ">=0.2.0" },
     { name = "boto3", specifier = ">=1.40.55" },
     { name = "flash-attn", marker = "extra == 'verl'", specifier = "==2.8.3" },
+    { name = "flash-linear-attention", marker = "extra == 'verl'" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "numpy", marker = "extra == 'verl'" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
@@ -122,9 +144,9 @@ requires-dist = [
     { name = "torchvision", marker = "extra == 'verl'", specifier = ">=0.23.0" },
     { name = "transformers", marker = "extra == 'dev'", specifier = ">=4.44" },
     { name = "transformers", marker = "extra == 'gateway'", specifier = ">=4.44" },
-    { name = "transformers", marker = "extra == 'verl'", specifier = ">=5.5.3" },
+    { name = "transformers", marker = "extra == 'verl'", specifier = "==5.8.1" },
     { name = "verl", marker = "extra == 'verl'", specifier = "==0.8.0" },
-    { name = "vllm", marker = "extra == 'verl'", specifier = "==0.21.0" },
+    { name = "vllm", marker = "extra == 'verl'", specifier = "==0.22.0" },
 ]
 provides-extras = ["dev", "gateway", "slime", "rllm", "verl"]
 
@@ -144,12 +166,12 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
-    { name = "async-timeout", marker = "python_full_version < '3.11'" },
+    { name = "async-timeout", marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "attrs" },
     { name = "frozenlist" },
     { name = "multidict" },
     { name = "propcache" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "yarl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
@@ -292,7 +314,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -336,8 +358,8 @@ dependencies = [
     { name = "docstring-parser" },
     { name = "httpx" },
     { name = "jiter" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
@@ -357,9 +379,9 @@ name = "anyio"
 version = "4.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/ce/8a777047513153587e5434fd752e89334ac33e379aa3497db860eeb60377/anyio-4.12.0.tar.gz", hash = "sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0", size = 228266, upload-time = "2025-11-28T23:37:38.911Z" }
 wheels = [
@@ -446,7 +468,7 @@ version = "2.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pycodestyle" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758", size = 92210, upload-time = "2025-01-14T14:46:18.454Z" }
 wheels = [
@@ -657,8 +679,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "starlette" },
     { name = "typing-extensions" },
     { name = "urllib3" },
@@ -686,8 +708,8 @@ dependencies = [
     { name = "prance" },
     { name = "prompt-toolkit" },
     { name = "py-openapi-schema-to-json-schema" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "pyyaml" },
     { name = "questionary" },
     { name = "requests" },
@@ -921,7 +943,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "(implementation_name != 'PyPy' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (implementation_name != 'PyPy' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1122,7 +1144,7 @@ name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
@@ -1174,10 +1196,10 @@ version = "0.15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "loguru" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "torch" },
-    { name = "transformers" },
+    { name = "transformers", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/1b/c3c4a98ec5f2727656336f07a0c35862195c310d8eb0b2fa5b4be6848680/compressed_tensors-0.15.0.1.tar.gz", hash = "sha256:a8e93054e8a5ec49c980b09ed36c4c1249b4a8ee167920a8e461c4da26e78d99", size = 229412, upload-time = "2026-04-10T14:23:54.708Z" }
 wheels = [
@@ -1201,8 +1223,8 @@ name = "cryptography"
 version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "cffi", marker = "(platform_python_implementation != 'PyPy' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (platform_python_implementation != 'PyPy' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -1258,7 +1280,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -1288,9 +1310,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
     { name = "cuda-pathfinder" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/21/ef85f3e15d394c9ca41fe116d78cd9e28533b9d7ead842f9241b332acf01/cuda_core-1.0.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9632db74eceb1cd72a7c95b61a5e4cfb9cc2291de0503e170334d936cab3316", size = 4788165, upload-time = "2026-05-12T20:11:17.116Z" },
@@ -1372,37 +1394,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cufft", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-curand", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusolver", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvtx", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 
 [[package]]
@@ -1410,23 +1432,23 @@ name = "datasets"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill" },
-    { name = "filelock" },
-    { name = "fsspec", extra = ["http"] },
-    { name = "httpx" },
-    { name = "huggingface-hub" },
-    { name = "multiprocess" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pyarrow" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "xxhash" },
+    { name = "dill", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "filelock", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "fsspec", extra = ["http"], marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "httpx", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "huggingface-hub", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "multiprocess", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "packaging", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pyarrow", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "pyyaml", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "requests", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "tqdm", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "xxhash", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/85/ce4f780c32f7e36d71257f1c27e8ba898ebe379cb54f211f5f2013f2c219/datasets-5.0.0.tar.gz", hash = "sha256:83dbbbdb07a33b82192b8c419deb18739b138ee2ce1a322d55ce6b100954ec1a", size = 631708, upload-time = "2026-06-05T13:18:26.124Z" }
 wheels = [
@@ -1523,8 +1545,8 @@ name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dnspython" },
-    { name = "idna" },
+    { name = "dnspython", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "idna", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
@@ -1536,7 +1558,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version == '3.11.*' and extra != 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version == '3.12.*' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version == '3.12.*' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.13' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1549,8 +1571,8 @@ version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "starlette" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
@@ -1563,14 +1585,14 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "email-validator" },
-    { name = "fastapi-cli", extra = ["standard"] },
+    { name = "fastapi-cli", extra = ["standard"], marker = "extra == 'extra-20-agentcore-rl-toolkit-verl'" },
     { name = "fastar" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "pydantic-extra-types" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 
 [[package]]
@@ -1581,7 +1603,7 @@ dependencies = [
     { name = "rich-toolkit" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typer" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/d0/ee5678346811967b8d096d5d5604e71b50d6bf5a2abfbdb331157e2bbaa9/fastapi_cli-0.0.27.tar.gz", hash = "sha256:1dffb1e40c0c88f2e0171a8a252a2b615c1e63ff8c05626649e4badd6a84336a", size = 23630, upload-time = "2026-06-18T14:48:43.421Z" }
 wheels = [
@@ -1591,7 +1613,7 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "fastapi-cloud-cli" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 
 [[package]]
@@ -1602,13 +1624,13 @@ dependencies = [
     { name = "detect-installer" },
     { name = "fastar" },
     { name = "httpx" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "(python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "rich-toolkit" },
     { name = "rignore" },
     { name = "sentry-sdk" },
     { name = "typer" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/e5/bee77aa542ec66bcc55b458d606f3356a58f5bb9f2c59006f6ff53a3869b/fastapi_cloud_cli-0.22.1.tar.gz", hash = "sha256:50d80de6ce397a4959e6f3509574edac65d0a6998655215c95d077b18ec2f4b1", size = 94501, upload-time = "2026-07-01T22:09:03.358Z" }
 wheels = [
@@ -1623,8 +1645,8 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "oauthlib" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/9b/25c43c928b46ec919cb8941d3de53dd2e12bab12e1c0182646425dbefd60/fastapi_sso-0.16.0.tar.gz", hash = "sha256:f3941f986347566b7d3747c710cf474a907f581bfb6697ff3bb3e44eb76b438c", size = 16555, upload-time = "2024-11-04T11:54:38.579Z" }
 wheels = [
@@ -1846,6 +1868,18 @@ wheels = [
 ]
 
 [[package]]
+name = "fla-core"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "einops" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/62/99e149f19a447ce809d7f4fa64ae61c073da337505b9db7f389502470820/fla_core-0.5.1.tar.gz", hash = "sha256:7f3cf56edfbaa9115f4937d1181372e5c7b11809ad8eb2e411fffc3caf729f48", size = 498800, upload-time = "2026-06-18T18:17:15.377Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/78/a55ee7a62515dcb9220770dd99dfe59ac6599da8af84ad1d20f9f407df4d/fla_core-0.5.1-py3-none-any.whl", hash = "sha256:02150d34aa1e37f6b8ed9b2feec5d29af93680573e5077ed981238179c11fb06", size = 702955, upload-time = "2026-06-18T18:17:12.229Z" },
+]
+
+[[package]]
 name = "flash-attn"
 version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1856,16 +1890,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3b/b2/8d76c41ad7974ee264754709c22963447f7f8134613fd9ce80984ed0dab7/flash_attn-2.8.3.tar.gz", hash = "sha256:1e71dd64a9e0280e0447b8a0c2541bad4bf6ac65bdeaa2f90e51a9e57de0370d", size = 8447812, upload-time = "2025-08-15T08:28:12.911Z" }
 
 [[package]]
+name = "flash-linear-attention"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fla-core" },
+    { name = "transformers", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/e8/8f115be585a046795e4a1f7ade727889219bb66b8d96cc668b8c9e437c0e/flash_linear_attention-0.5.1.tar.gz", hash = "sha256:8840fd4c37de8b0612dc8fd493867f3d330672ba2f17c024a2ce37239634e247", size = 221733, upload-time = "2026-06-18T18:17:16.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/3c/5819fb19dc071302ca818616a4e64d4454e1f1193929eb8365c8d38e9052/flash_linear_attention-0.5.1-py3-none-any.whl", hash = "sha256:9022862f0a238752372c81290694b8b2ed1cb2d13fc40d340ffeeb554d6bee5c", size = 403096, upload-time = "2026-06-18T18:17:14.025Z" },
+]
+
+[[package]]
 name = "flashinfer-cubin"
-version = "0.6.8.post1"
+version = "0.6.11.post2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/b7/5e3b1a8c67031b421a8bd29c2bc29b900a550bb3392e8bda18bb15b5e476/flashinfer_cubin-0.6.8.post1-py3-none-any.whl", hash = "sha256:43636d4cd39e694a83d76a89f87fefcdf4cecb4c4f7dd22dac25ec368c1e901f", size = 295154113, upload-time = "2026-04-18T18:28:21.738Z" },
+    { url = "https://files.pythonhosted.org/packages/29/96/da75a9f61c64c87b16baa339fc8216a6c3743c5d263c555fded30fcbe6f7/flashinfer_cubin-0.6.11.post2-py3-none-any.whl", hash = "sha256:eb01c2801ee31d145bbf7afb2c223150333e602c8208216017b0190b1087b990", size = 360908523, upload-time = "2026-05-14T04:57:41.355Z" },
 ]
 
 [[package]]
 name = "flashinfer-python"
-version = "0.6.8.post1"
+version = "0.6.11.post2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
@@ -1873,9 +1920,9 @@ dependencies = [
     { name = "cuda-tile" },
     { name = "einops" },
     { name = "ninja" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "nvidia-cudnn-frontend" },
     { name = "nvidia-cutlass-dsl" },
     { name = "nvidia-ml-py" },
@@ -1885,9 +1932,9 @@ dependencies = [
     { name = "torch" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/1e/2760fef9e74abc4480961048e5790b4c9e955872fb4d7d97900cfddced5a/flashinfer_python-0.6.8.post1.tar.gz", hash = "sha256:b18e4121baf9b93fa9a9f368ba9b981a0342895f50ab9dddc224aeb964ed346f", size = 6675885, upload-time = "2026-04-18T18:28:13.299Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/53/dbf2157f2bbb96d6f7a6891cf6abfb2e6e18963760a0c53e96c2de5c59db/flashinfer_python-0.6.11.post2.tar.gz", hash = "sha256:e9fdac56aea9f0f58a4e69b0645c54993760d3cc6c7bf5c2df4ce5a0aecc7953", size = 9248515, upload-time = "2026-05-14T04:57:32.83Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/6d/1e8a8533913e33a50a486332ce0673f4fdb860f6eb9ed450327c5c1762cb/flashinfer_python-0.6.8.post1-py3-none-any.whl", hash = "sha256:818f9b8cc2fe66c42a1f6264be4841ac8821ada703685a02cfccb2b5124a710b", size = 9385316, upload-time = "2026-04-18T18:28:10.285Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bc/518b092473f37d904ae07766ad37c772b93da13ea788777b22a80c3f1a7c/flashinfer_python-0.6.11.post2-py3-none-any.whl", hash = "sha256:550cbdb760f9f7ec0e42055e06636b9489d05f1a38989cafd77e6eb820de0138", size = 13746417, upload-time = "2026-05-14T04:57:30.25Z" },
 ]
 
 [[package]]
@@ -2022,7 +2069,7 @@ wheels = [
 
 [package.optional-dependencies]
 http = [
-    { name = "aiohttp" },
+    { name = "aiohttp", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 
 [[package]]
@@ -2030,9 +2077,9 @@ name = "gguf"
 version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "tqdm" },
@@ -2342,7 +2389,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -2356,13 +2403,44 @@ wheels = [
 ]
 
 [[package]]
+name = "humming-kernels"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings" },
+    { name = "jinja2" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "nvidia-ml-py" },
+    { name = "pyelftools" },
+    { name = "safetensors" },
+    { name = "tabulate" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "triton" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/f4/e141f45697b7d0d38bfaf8766a7362d8f0136e3cff2620624f24f68e2700/humming_kernels-0.1.2.tar.gz", hash = "sha256:7894c80061c7866591bef12617da720ac4e925636ffc99464af433a5dcb035eb", size = 117251, upload-time = "2026-05-23T16:18:08.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/41/288bf756d921dbe98982eeb3ec4c20e7cb5224ea6dcb164f2df3d2f68a7f/humming_kernels-0.1.2-py3-none-any.whl", hash = "sha256:f7434b0424946445ef5ad5682bcabf309d97721818ed5bdc4c6f61de3c6b9d2f", size = 160951, upload-time = "2026-05-23T16:18:06.405Z" },
+]
+
+[package.optional-dependencies]
+cu13 = [
+    { name = "nvidia-cuda-cccl" },
+    { name = "nvidia-cuda-nvcc" },
+    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-runtime" },
+]
+
+[[package]]
 name = "hydra-core"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime" },
-    { name = "omegaconf" },
-    { name = "packaging" },
+    { name = "antlr4-python3-runtime", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "omegaconf", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "packaging", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0d/0b/7c0d941311aadc6479ec01767edba9c8a07db1452685de3567ed3058d0c9/hydra_core-1.3.3.tar.gz", hash = "sha256:b7477ee21f08b62f71bf0126d44695c048dc7e9c0cc79e2d593b707cb1e44048", size = 3262532, upload-time = "2026-06-11T05:54:26.835Z" }
 wheels = [
@@ -2492,7 +2570,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -2828,8 +2906,8 @@ dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "openai" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "python-dotenv" },
     { name = "tiktoken" },
     { name = "tokenizers" },
@@ -2888,15 +2966,25 @@ wheels = [
 
 [[package]]
 name = "llguidance"
-version = "1.3.0"
+version = "1.7.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/48/3f7a9d3ff1b36bba92b5107a3a21286821227afe9ea464736133994d61fb/llguidance-1.3.0.tar.gz", hash = "sha256:861249afd51dc325646834462ea827e57a5c2b2042e108e6aae7059fdad9104d", size = 1070460, upload-time = "2025-10-20T19:58:44.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/91/6bc8bb503dc259e46d253b5424385a54fe06c38a4c7a12befe69a3c2455a/llguidance-1.7.6.tar.gz", hash = "sha256:db7febbe412ed2015501904646750071d7e00e6df7f85c4b956ad4f206fd2df7", size = 1156574, upload-time = "2026-06-03T20:13:25.316Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/33/be5acb85cd8cdc4afde33d9c234eece9f318e087920255af3c05864cd3e7/llguidance-1.3.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f7685222660a762e481ac633d49cc559c64980fe2ee59c8f932a5bb5cbc0c2c2", size = 3220647, upload-time = "2025-10-20T19:58:42.542Z" },
-    { url = "https://files.pythonhosted.org/packages/82/e6/b48bda5b15efeaeb62bd0dba8fc6a01d4ae5457a85dbb5d18632385fe15c/llguidance-1.3.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:098030ff0687261a3f1bd54cf21fe951fc861d56d37a0671250dd36677eaf224", size = 3099830, upload-time = "2025-10-20T19:58:40.826Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/11/44389d3d1526d7a5c38ffd587a5ebc61d7bee443ac1dea95f2089ad58f5f/llguidance-1.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f6caca5d78db7f76e1fbb0fff8607b861c32d47fa3d5dee2fc49de27ee269df", size = 2835242, upload-time = "2025-10-20T19:58:34.518Z" },
-    { url = "https://files.pythonhosted.org/packages/83/a8/1ff2bedb8f9acb46a2d2d603415d272bb622c142ea86f5b95445cc6e366c/llguidance-1.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc17e9dd602c3879bf91664a64bf72f54c74dbfbeb24ccfab6a5fe435b12f7aa", size = 3033133, upload-time = "2025-10-20T19:58:38.721Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/7e/809349638231f469b9056c0e1bfd924d5ef5558b3b3ec72d093b6fad33b1/llguidance-1.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:1d1cd1c8618d1a13605d3e057c978651e551c8c469b481ee4041f1d6c436002d", size = 2789946, upload-time = "2025-10-20T19:58:45.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/70/fec801b305437f946aefc52b126534766415810771172f3f615d0fd7ef8b/llguidance-1.7.6-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:c88787845b94d301d91c4e9ad27eac9d05c334a1ba2c7ff29cca66f26d5b5c3c", size = 3218286, upload-time = "2026-06-03T20:12:55.042Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/22/f45b19379e162511a60b655037b1c3a3fadcb0c05aee082055a7be36fc15/llguidance-1.7.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7def42f7866239b3b940982ed1dcae6b142c212fbd68b57107c1560d778f94f8", size = 3131216, upload-time = "2026-06-03T20:12:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/67/da/28756068fa9f7147874fcd712e7317c24785f25d762a96e901850d9a2f5f/llguidance-1.7.6-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0444020249cde1292f13acf786e35c245fd3572d466877d2734824a9026e55aa", size = 3470362, upload-time = "2026-06-03T20:12:59.813Z" },
+    { url = "https://files.pythonhosted.org/packages/13/54/5009398b8949481ada1ffc882f46fd304f75e66f73d8f6fbb3495681c052/llguidance-1.7.6-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30be5939340f008b5093286f0bbbb9804f58e292ecca5f8b144823d43ff5068b", size = 3760869, upload-time = "2026-06-03T20:13:01.749Z" },
+    { url = "https://files.pythonhosted.org/packages/11/90/37cc12dd44c1f8fd84d5cc4e293467febe5a9899d6b55805485af7c21c9a/llguidance-1.7.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e4f2a489c1c3943bb1b3c206b45794153cb6954f45cd3de8e02198319ddc6b1", size = 3485304, upload-time = "2026-06-03T20:13:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/05/10e1f7ee8ddb7cf49a75af6cc4ca370c88c39a9ee321903818de91e59ae2/llguidance-1.7.6-cp314-cp314t-win32.whl", hash = "sha256:ef907a562d91f32e13cb3131ee5e1574b9ba5beac5bceedd795f8316a16d94d6", size = 2604035, upload-time = "2026-06-03T20:13:05.268Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/14/3d1b0d0738c7843e074e38a45e4641302565a1ec9f4eb4dfbc7b394b3314/llguidance-1.7.6-cp314-cp314t-win_amd64.whl", hash = "sha256:d0e1f5402bbc2688bc790d56995f0263978b55771493fceddc09b805dacc83b6", size = 2871993, upload-time = "2026-06-03T20:13:07.416Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/1d/5a9a13421b1f3f1c1acf82beb63ed72fa4d302e65099b72f4a4fe5a098ab/llguidance-1.7.6-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:eabf4572c8731734c0444c353b9ea06bc5c156986d2ff0a4ec0499159271381f", size = 3227892, upload-time = "2026-06-03T20:13:09.533Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fe/bb185f11bad82f2637e3cd8cbf6b200cbb6ed56ac395de47ea05a60d4649/llguidance-1.7.6-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:9c54c899db8cb4b4fba128a7d844730066576c70d806c95ada92b2bd2d6ab498", size = 3138127, upload-time = "2026-06-03T20:13:11.649Z" },
+    { url = "https://files.pythonhosted.org/packages/51/b9/dc76d7716e04dc7b3427cae52eaa32bd20771382d4d1dd9f4538a9dd2086/llguidance-1.7.6-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:e70fa25ed550c2b50c2fd70baa9e2808b4ecb859d01e453bd5459aff62ba38c3", size = 2899993, upload-time = "2026-06-03T20:13:13.563Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/64/d74336f22242ef94356a456057d4ff1be7c1bc9c7dbc867171c6982a5512/llguidance-1.7.6-cp39-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:ceec951d29a74309984e3be0fe7f5f56c1362434cd937abd517b259a60908b1e", size = 3074809, upload-time = "2026-06-03T20:13:15.498Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e9/8b449baf0c4c8c7ea94a0514f8ec725a8d1e8d23a1d1e0d67b6b3835281c/llguidance-1.7.6-cp39-abi3-manylinux_2_34_i686.whl", hash = "sha256:0fda51daa7951217ca164f735e96a1929d9aefb804a0b28ee43b16173e1c7325", size = 3319900, upload-time = "2026-06-03T20:13:17.58Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e6/6b61cecced5233739bc85e463d68d67d4b4c29fb6f91bd12e6b6a65647e3/llguidance-1.7.6-cp39-abi3-manylinux_2_39_riscv64.whl", hash = "sha256:e9f68206e0f3f89aceabb90aa1f8ed570db22fb7cb1fd9ebf96fa7727a65af55", size = 3603845, upload-time = "2026-06-03T20:13:19.473Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3b/70e2093f1b1b76469fa306a498295e94da115dec1e6c488094a02f66837e/llguidance-1.7.6-cp39-abi3-win32.whl", hash = "sha256:1158cfce353d331859054aad80a5543167da8b45e01c18f93272027a155df449", size = 2615095, upload-time = "2026-06-03T20:13:21.512Z" },
+    { url = "https://files.pythonhosted.org/packages/49/37/99d700f0e2c83acf25a8d8946b2bee9f5eac47bc530bfbd53ba3126c667f/llguidance-1.7.6-cp39-abi3-win_amd64.whl", hash = "sha256:ace7e81cd31950a87186356ab24bd7f75fbc10a05ca9d9f7f8748f931963f763", size = 2879207, upload-time = "2026-06-03T20:13:23.341Z" },
 ]
 
 [[package]]
@@ -2938,8 +3026,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "interegular" },
     { name = "packaging" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/d5/41cd417ba7dfdbbcfe46cebf81fb3dfd7c591b89897560ad05bb410a465d/lm_format_enforcer-0.11.3.tar.gz", hash = "sha256:e68081c108719cce284a9bcc889709b26ffb085a1945b5eba3a12cfa96d528da", size = 40258, upload-time = "2025-08-24T19:37:47.527Z" }
@@ -3189,21 +3277,21 @@ name = "mcp"
 version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "jsonschema" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pydantic-settings" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python-multipart" },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "sse-starlette" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+    { name = "anyio", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "httpx", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "httpx-sse", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "jsonschema", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic-settings", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "python-multipart", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "pywin32", marker = "(sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "sse-starlette", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "starlette", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "typing-extensions", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "typing-inspection", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "uvicorn", marker = "(sys_platform != 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform != 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
@@ -3225,13 +3313,13 @@ version = "1.11.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "pillow" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pydantic-extra-types", extra = ["pycountry"] },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "extra == 'extra-20-agentcore-rl-toolkit-verl'" },
     { name = "requests" },
     { name = "tiktoken" },
     { name = "typing-extensions" },
@@ -3251,9 +3339,9 @@ name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
 wheels = [
@@ -3301,8 +3389,8 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jmespath" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "setuptools" },
     { name = "starlette" },
     { name = "supervisor" },
@@ -3327,7 +3415,7 @@ version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
-    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pyjwt", extra = ["crypto"], marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
     { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
@@ -3481,7 +3569,7 @@ name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
 wheels = [
@@ -3619,7 +3707,7 @@ name = "multiprocess"
 version = "0.70.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill" },
+    { name = "dill", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
 wheels = [
@@ -3642,10 +3730,10 @@ name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
@@ -3710,22 +3798,31 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -3773,9 +3870,9 @@ version = "0.65.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llvmlite" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/61/7299643b9c18d669e04be7c5bcb64d985070d07553274817b45b049e7bfe/numba-0.65.0.tar.gz", hash = "sha256:edad0d9f6682e93624c00125a471ae4df186175d71fd604c983c377cdc03e68b", size = 2764131, upload-time = "2026-04-01T03:52:01.946Z" }
 wheels = [
@@ -3810,8 +3907,10 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -3876,10 +3975,14 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -3961,18 +4064,25 @@ name = "numpy"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
 wheels = [
@@ -4028,6 +4138,27 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226, upload-time = "2025-10-09T08:59:04.818Z" },
     { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236, upload-time = "2025-10-09T08:59:32.536Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f5/f50bc3f5c2bb57ab8f5b4d78bc1146b57810d42cb8fcb28cbe2e14050376/nvidia_cublas-13.1.0.3-py3-none-win_amd64.whl", hash = "sha256:2a3b94a37def342471c59fad7856caee4926809a72dd5270155d6a31b5b277be", size = 404355960, upload-time = "2025-10-09T09:07:00.987Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cccl"
+version = "13.3.3.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/bd/572971ffc14bd36676c821fc15d991b08fe6179cb09368250147475f954d/nvidia_cuda_cccl-13.3.3.4.1-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:067d19b4b3c9d0f2ebec9f29a311b2863db96bf98e058bbc331597d51ce818cf", size = 3454030, upload-time = "2026-06-29T16:41:49.092Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ab/049726d90147865a3ea53bae6cb7c35b98bf1fdf96cdb967101329625f83/nvidia_cuda_cccl-13.3.3.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc0adc188d570b09f4d606c7dc05a42aa3d8aa082e0d60f7bbfc5b6435f627c6", size = 3454034, upload-time = "2026-06-29T16:42:07.435Z" },
+    { url = "https://files.pythonhosted.org/packages/24/d3/b1afcd9c40ceca72022579215fcaf5318cd747fd896cb928d4a1de924ff8/nvidia_cuda_cccl-13.3.3.4.1-py3-none-win_amd64.whl", hash = "sha256:d7c92cc03047031fa7af30866636d35ce4af409c28fc7dd8f69cb17053741399", size = 3454014, upload-time = "2026-06-29T17:09:09.012Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-crt"
+version = "13.3.73"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/41/2089e411507d66458d67208bdd1bc562d492bb6458c3d2aea4603072a219/nvidia_cuda_crt-13.3.73-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:60aacc0b5e1e8b40c62abe4d1ab16440add91b99bd2f17f62dd091586b73d166", size = 157353, upload-time = "2026-06-29T16:42:38.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ce/16d76f4b5b3f7460f5ebd17516685495c149c66651ffdd381f90e4d4e65c/nvidia_cuda_crt-13.3.73-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df14a17ae1c5c3171265411212246654d780f89344ea85344466c6b955247543", size = 157352, upload-time = "2026-06-29T16:43:09.209Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b3/6791ffba6f4b8e0d3ed875285aad8078ee407afa464ecd934ae298c205b1/nvidia_cuda_crt-13.3.73-py3-none-win_amd64.whl", hash = "sha256:af04e75148db1f0eea30958f33a9ec5a5a2dc2afa99ca4323f9a93b840602ca5", size = 158286, upload-time = "2026-06-29T17:09:28.621Z" },
 ]
 
 [[package]]
@@ -4037,6 +4168,22 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
     { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/df/b74b10025c1205695c5676373f2edd3e87a7202cc62ead0dfbc373b0f6ea/nvidia_cuda_cupti-13.0.85-py3-none-win_amd64.whl", hash = "sha256:683f58d301548deeefcb8f6fac1b8d907691b9d8b18eccab417f51e362102f00", size = 7736776, upload-time = "2025-09-04T08:38:08.38Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvcc"
+version = "13.3.73"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-crt" },
+    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-nvvm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/14/9f5cdc994d5431e2f08f62ffe34509e7feabd1f2e18517e2d7720c6ff0fd/nvidia_cuda_nvcc-13.3.73-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:70f250825355d2c3aa6c7a972a0ec00f020bad66d2679e527eb4336301c904aa", size = 39515578, upload-time = "2026-06-29T16:47:40.318Z" },
+    { url = "https://files.pythonhosted.org/packages/83/19/e46ef3597ba47a9f8a91ab24533db42a600b659fc418dbe4af0b630bcb41/nvidia_cuda_nvcc-13.3.73-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f483af83166c4fa356a21606076d553b0b4ceaebbd9912e537545080db695bdd", size = 44942138, upload-time = "2026-06-29T16:48:13.615Z" },
+    { url = "https://files.pythonhosted.org/packages/79/89/97eb797bb8bdee1d4e74069d072c24b79ae90c012fa3b539f2a7ccecf6cf/nvidia_cuda_nvcc-13.3.73-py3-none-win_amd64.whl", hash = "sha256:3d9da631bcac3dee49d1357b84cd05abe56aa3ccf76b05a7df8a80ef78addcb5", size = 32536529, upload-time = "2026-06-29T17:11:25.455Z" },
 ]
 
 [[package]]
@@ -4046,6 +4193,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
     { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/af/345fedb9f4c76c84ab4fa445b36bd4048a4d9db60e6bc76b4f913ff4b852/nvidia_cuda_nvrtc-13.0.88-py3-none-win_amd64.whl", hash = "sha256:6bcd4e7f8e205cbe644f5a98f2f799bef9556fefc89dd786e79a16312ce49872", size = 76807835, upload-time = "2025-09-04T08:39:15.274Z" },
 ]
 
 [[package]]
@@ -4055,6 +4203,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
     { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/94/6b867483bec07da24ffa32736c79fabb94ef3a7af4d787a9d4a974868576/nvidia_cuda_runtime-13.0.96-py3-none-win_amd64.whl", hash = "sha256:f79298c8a098cec150a597c8eba58ecdab96e3bdc4b9bc4f9983635031740492", size = 2927037, upload-time = "2025-10-09T09:04:23.782Z" },
 ]
 
 [[package]]
@@ -4062,11 +4211,12 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
     { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a2/f020386683ee9ab2c9a9f7f79290d9b0d07f7241de54dc746af2abd188d2/nvidia_cudnn_cu13-9.19.0.56-py3-none-win_amd64.whl", hash = "sha256:40d8c375005bcb01495f8edf375230b203a411a0c05fb6dc92a3781edcb23eac", size = 350547366, upload-time = "2026-02-03T20:50:49.563Z" },
 ]
 
 [[package]]
@@ -4096,11 +4246,12 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'darwin' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
     { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/f8af21a2ed1beed337a6a02c5a28aeb85441f4d578ec3d529543c775ea4b/nvidia_cufft-12.0.0.61-py3-none-win_amd64.whl", hash = "sha256:2abce5b39d2f5ae12730fb7e5db6696533e36c26e2d3e8fd1750bdd2853364eb", size = 213342123, upload-time = "2025-09-04T08:40:51.145Z" },
 ]
 
 [[package]]
@@ -4119,6 +4270,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
     { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+    { url = "https://files.pythonhosted.org/packages/99/27/72103153b1ffc00e09fdc40ac970235343dcd1ea8bd762e84d2d73219ffa/nvidia_curand-10.4.0.35-py3-none-win_amd64.whl", hash = "sha256:65b1710aa6961d326b411e314b374290904c5ddf41dc3f766ebc3f1d7d4ca69f", size = 55242481, upload-time = "2025-08-04T10:30:41.831Z" },
 ]
 
 [[package]]
@@ -4126,13 +4278,14 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'darwin' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'darwin' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'darwin' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
     { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ef/332a0101260ca78a1daef046bf0b06199e8ed4dac1d2aa698289c358169c/nvidia_cusolver-12.0.4.66-py3-none-win_amd64.whl", hash = "sha256:16515bd33a8e76bb54d024cfa068fa68d30e80fc34b9e1090813ea9362e0cb65", size = 193551444, upload-time = "2025-09-04T08:41:46.813Z" },
 ]
 
 [[package]]
@@ -4140,11 +4293,12 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'darwin' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
     { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+    { url = "https://files.pythonhosted.org/packages/02/b0/b043d6f3480f102f885cf87fc3ffd3edcb5e23b855025a50e2ef4d059185/nvidia_cusparse-12.6.3.3-py3-none-win_amd64.whl", hash = "sha256:cbcf42feb737bd7ec15b4c0a63e62351886bd3f975027b8815d7f720a2b5ea79", size = 143783033, upload-time = "2025-09-04T08:42:12.391Z" },
 ]
 
 [[package]]
@@ -4154,41 +4308,76 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
     { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
+    { url = "https://files.pythonhosted.org/packages/57/de/8f0578928b9b1246d7b1324db0528e6b9f9fb54496a49f40bf71f09f1a27/nvidia_cusparselt_cu13-0.8.0-py3-none-win_amd64.whl", hash = "sha256:e80212ed7b1afc97102fbb2b5c82487aa73f6a0edfa6d26c5a152593e520bb8f", size = 156459710, upload-time = "2025-08-13T19:24:18.043Z" },
 ]
 
 [[package]]
 name = "nvidia-cutlass-dsl"
-version = "4.4.2"
+version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-cutlass-dsl-libs-base" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/03/678dab0383db1ddfc449da216220f40404189eb36eeed9d87a4fa4bdb0e6/nvidia_cutlass_dsl-4.4.2-py3-none-any.whl", hash = "sha256:7cfb9ef19062b055b9372c7a627004724e2755e4c8b16c3cc88807d64501a4ae", size = 10167, upload-time = "2026-03-16T02:18:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/15/575d7df4fe2f3406f1cfc68be72aeff2834f8a696daf1cd5bee8017e4507/nvidia_cutlass_dsl-4.5.2-py3-none-any.whl", hash = "sha256:68ed1b63ca74aae87955012da9dfd7fdaae471329d0028b229b841c7192ccf52", size = 10179, upload-time = "2026-05-25T03:38:56.364Z" },
+]
+
+[package.optional-dependencies]
+cu13 = [
+    { name = "nvidia-cutlass-dsl-libs-cu13" },
 ]
 
 [[package]]
 name = "nvidia-cutlass-dsl-libs-base"
-version = "4.4.2"
+version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-python" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/07/af1b456b5b6dd4a49e71a952a182a99fc863f70b9f78725324f89e0384e5/nvidia_cutlass_dsl_libs_base-4.4.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:06acb3acff3dcf4bf6630476efac7de94de30b988ded4fa00b647bbcec4224ff", size = 75471025, upload-time = "2026-03-16T02:23:49.61Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/12/f0770811d2874af7e04623d3baa83c445c49f38c00c4e5d20e1daae54b5d/nvidia_cutlass_dsl_libs_base-4.4.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:916bf612fba5fbc5162e300fe18196e960dac2328c1c1360c0939d3be05c7c71", size = 74355272, upload-time = "2026-03-16T02:24:44.22Z" },
-    { url = "https://files.pythonhosted.org/packages/60/bf/b9d0fd1ba281b111c941d9616dd9f98a509d84bf35076e60fef27ec7abd6/nvidia_cutlass_dsl_libs_base-4.4.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:261832dafe7579dc83cd3816ab9ea845e3de3737d876c215f01fb4edff1f4473", size = 75476977, upload-time = "2026-03-16T02:26:40.932Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/23/86dda6d69a3fc29d0cde2a8b54c056ad69b73a6e5e230e18d906d2ec3b7c/nvidia_cutlass_dsl_libs_base-4.4.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:40c2352b2fcc80789a216cbeb9b2ee10c85c15de839cda8f5c1d18166b8249df", size = 74356100, upload-time = "2026-03-16T02:26:12.778Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/7d/0df5e38d11e52cc72095a14d6448bc1c5d0d4b00b069a1189ca417fb225b/nvidia_cutlass_dsl_libs_base-4.4.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2ec8812eeadcbb6fe20bda2e295ed9c00653f8253b78e33cf0ab65a47b829e73", size = 75473821, upload-time = "2026-03-16T02:27:08.371Z" },
-    { url = "https://files.pythonhosted.org/packages/56/98/e264964741d9cc9816625d9600d17a5249fd5cbd8c2d166fb0d0c34dfe5a/nvidia_cutlass_dsl_libs_base-4.4.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:22e37b58f7a6f2f43bba533c4df8a088012122e0b4e9a632eca23937adeafb39", size = 74355593, upload-time = "2026-03-16T02:25:11.762Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/c9/2f17950ee2deb4b5f6b82f8155515a21792fe296e81bb638f164d8e2ca9b/nvidia_cutlass_dsl_libs_base-4.4.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b59a052cbfb9a25747d1b6d413615456bea38d1f377da085af07c0d86a4c8b39", size = 75477304, upload-time = "2026-03-16T02:27:35.645Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/68/27380038ebd9c8eab4be364e833fea144aef597704f44948921668f7adf4/nvidia_cutlass_dsl_libs_base-4.4.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8e3324a33afa7424e93beae7e54a311e80db82b9e4ed4bba2aeeda1d6c888cd9", size = 74355765, upload-time = "2026-03-16T02:24:16.778Z" },
-    { url = "https://files.pythonhosted.org/packages/12/44/0dc7f2e5b5c65106a5bb05e60654f1a79abe92e27e9b00588a73cd26ca1f/nvidia_cutlass_dsl_libs_base-4.4.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:af96c1170569138b3cb965202907fbf5ab95d7c1dcc210952d00cdf9ab7b859a", size = 75472171, upload-time = "2026-03-16T02:28:03.136Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/ae/0998f328b28b956d7eb399d16f4ee681ca318b306007264444a623e86c64/nvidia_cutlass_dsl_libs_base-4.4.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:95db0c8d1d56992e2f5c2dcd5b3baab0297bedc0cbcefc1e70b57acd934e7b23", size = 74356280, upload-time = "2026-03-16T02:25:43.789Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3e/2cca8745885aaba0d835a8be29e516e56930791c01f0806da95d3017a495/nvidia_cutlass_dsl_libs_base-4.5.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b62807bc5ea13bbdef648212893fac407ed943f940cece56b880d44af243e075", size = 75635922, upload-time = "2026-05-25T03:46:33.526Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/2b/4de80442d33791322aa496e2a7f47ed08a42578bd1c7031ef0602009f8ad/nvidia_cutlass_dsl_libs_base-4.5.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:386e832427e3670479049a1560e4d8d2e565d8c0f37a6852c6d7043d046548f1", size = 74512458, upload-time = "2026-05-25T03:49:47.052Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/0cca1d11787128c66c0774374d1bb09313352eee11560dd00f36d6d62f36/nvidia_cutlass_dsl_libs_base-4.5.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:cbb555a95c7011e4b3ca328be407299c77d289660adbea22ed515d4406e6949c", size = 75637009, upload-time = "2026-05-25T03:48:37.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e0/78eded54b4478ec01a91c75f1b9bc6dc73a2ec205c4fa2fdc25a456f4089/nvidia_cutlass_dsl_libs_base-4.5.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:9117900cba53d3c21a8dacba6bbf3d6e5f269e427a526c320fb44707a0d57363", size = 74511501, upload-time = "2026-05-25T03:52:03.798Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ef/e827e3c67d72adbf4e8f680bdf03b1b67723d9e1ae7c3d0a1751f39f69ce/nvidia_cutlass_dsl_libs_base-4.5.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d2a3c412287e356fbe48fe9f845d6d33cd35dea5e20d7e4f628c20957967cacd", size = 75643473, upload-time = "2026-05-25T03:49:15.857Z" },
+    { url = "https://files.pythonhosted.org/packages/97/68/c1247ab848f26c4ab56e562eea0e3f31fc14c9aaf0d883afaa92d8f05592/nvidia_cutlass_dsl_libs_base-4.5.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:15ef6a59193667e663934ef4873f8ccad37455e9b7c3c419c3072113b8aedf61", size = 74513226, upload-time = "2026-05-25T03:51:32.496Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f8/b192015e273ff023a35741d6d5e4a93e4819160dee3955fc5d3d53534450/nvidia_cutlass_dsl_libs_base-4.5.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:395bd77cf642aeef311313453e6582f11c9357a4b81fe620ea3daccd1fccab9b", size = 75645002, upload-time = "2026-05-25T03:48:01.887Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6e/bfe256ac08e5a6dfb11444809e54c76c3a2f05fff38dd173e2e71b95e4d2/nvidia_cutlass_dsl_libs_base-4.5.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e59da7d89e5e4f8514c6530843f910f9d8734d8042dcaa079c9d9c5063eb3514", size = 74514312, upload-time = "2026-05-25T03:50:56.343Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b2/7a5de500bb74915ab8b3875f4952ae07d562f33d06eef9b2569adf4c09ab/nvidia_cutlass_dsl_libs_base-4.5.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:216eee6aa8107d35569f9451b66b03a3c53167841d1af9b630b966ef8d966e19", size = 75636795, upload-time = "2026-05-25T03:47:31.081Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/bc/5f9dd8c05c3e2f435228224f0b0e76e324c1bf0a6dcd3cfb917b5e94bad7/nvidia_cutlass_dsl_libs_base-4.5.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:12c29f7c1f1f82851092ba3869264dafafb035228c0d9827a8db08b884fb80ca", size = 74511193, upload-time = "2026-05-25T03:52:39.444Z" },
+    { url = "https://files.pythonhosted.org/packages/61/7c/76a9d1ce5ade3f43ab6f10e361a9c1962d02177deeaf46f2c3684a7ae959/nvidia_cutlass_dsl_libs_base-4.5.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:5aca392063ffbc7da30442a267928b22d4a2d37f9ea1db32e4487aa31b0fcc33", size = 75644393, upload-time = "2026-05-25T03:47:02.706Z" },
+    { url = "https://files.pythonhosted.org/packages/15/84/08d695d2e0fa95891a2e5abd978f359d50125e4d1f056e54697d465fccc3/nvidia_cutlass_dsl_libs_base-4.5.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:abab8a0d2f3f5661533c366df78f973052b86a3b52b868d997a95dce5aa8f17b", size = 74514399, upload-time = "2026-05-25T03:50:20.841Z" },
+]
+
+[[package]]
+name = "nvidia-cutlass-dsl-libs-cu13"
+version = "4.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-python" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "nvidia-cutlass-dsl-libs-base" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/96/1519dc5fb936b2e8d519710a1134ecfd162dfbdb014f15ea4534f52ca221/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:696c65ca03995713b6719bc59b7df06f8ec1d263d7eb6ac77aa011201e142bd5", size = 79086862, upload-time = "2026-05-25T03:39:21.998Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/1e/12d1773571cd5f3cb2ff2a7570badfe9ccc1361e9f6684b17f7ff092c188/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:587494d0ab615b805fac86b43a3c1b855182f455681c9cc4ddb1b8973f44a7cc", size = 78759394, upload-time = "2026-05-25T03:42:32.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/24/4ad875105f8b834ff0a6dce484c8ac124c292368338b087b993b70288385/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f4a7b72147c2efdc7963c64475eac4ed67eb1dd5fdf5b0300daf79319fe9a38a", size = 79081923, upload-time = "2026-05-25T03:40:22.457Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3d/2153608b1f8f594ccfc67daa45a1d0ff600b9e552b1e5662644e6e3ebec3/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:df61430d6110eea872acb39257042814bf02dcbb1f8d55ea0c5681bb7ce5836a", size = 78759970, upload-time = "2026-05-25T03:43:46.762Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e5/aeb570713a7bd6c2cb08102c2ebe6de234ef1bbc276d1af4643266cd71a8/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3032405dff28892340f96b467e744a822079cae454dce534fc17b77e85190e42", size = 79084280, upload-time = "2026-05-25T03:40:57.547Z" },
+    { url = "https://files.pythonhosted.org/packages/03/60/443e559139da15ab544761ac14f4206dffb981af48cc9856cd5b5b7cf0e7/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:80f0cd402e0f1d1571e5aed33bfa17dbc9cb90cc5b1352f0f806b4788558e80e", size = 78759198, upload-time = "2026-05-25T03:45:59.297Z" },
+    { url = "https://files.pythonhosted.org/packages/98/57/bc7248c02c3e4ee2ed03e194ceda9861a46fa23f0da5140bd8060a086b1e/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:64e994554af4da59f75754b9df1a2b1bdfdb96b58c2457802da13d586fb58cde", size = 79086223, upload-time = "2026-05-25T03:41:27.363Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9f/b7928ff505e577c1021c07b206ce32d285aae793763d524023c1800b6dc9/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:c7a5ce1c01616fc4c3ac492e011c543a79c3dde86aaf20a8af55e9d40ef2b2e6", size = 78759546, upload-time = "2026-05-25T03:45:25.834Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/65/a8e16a9647acef4f43ea2e046cd7eeb3e5779e89089c3939a5d25fe47f57/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:aabd41c980083db94950a4010c2c1ca156d4ab56701605739a3fba388ac9736b", size = 79087704, upload-time = "2026-05-25T03:41:57.202Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/83/d335575e1d37f6c436b1e3203ded6f352678937b9f30b900b643f9df0f9d/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:888edad4fe1e9b683fddcbc6969437527ccd0eb8740e60dce8f29f6a3a22c825", size = 78758331, upload-time = "2026-05-25T03:43:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7c/2bf50f2649f06a97a935919f71d2d0e40d7648364319b834548ed664d6d3/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c4d3ea9080c5a92f8f4a69451ef7036f43bfc3d7f8a426dd70258f0e237c05fb", size = 79092929, upload-time = "2026-05-25T03:39:51.239Z" },
+    { url = "https://files.pythonhosted.org/packages/36/80/8ced4c7e1ead8d1e3ac6c823db9e387dbcfd41232e11655d5bc94e950c75/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1d255f4a308eb0d228d2466a415a8489b8337db1d322f5d8428e60139b41a317", size = 78765148, upload-time = "2026-05-25T03:44:52.411Z" },
 ]
 
 [[package]]
@@ -4216,6 +4405,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
     { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/01/07530b0e37546231052e30234540289c42eaffa486f1a34a87fed340157b/nvidia_nvjitlink-13.0.88-py3-none-win_amd64.whl", hash = "sha256:634e96e3da9ef845ae744097a1f289238ecf946ce0b82e93cdce14b9782e682f", size = 36035115, upload-time = "2025-09-04T08:43:03.001Z" },
 ]
 
 [[package]]
@@ -4234,6 +4424,17 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/50/0e2220f8620a177de994211186ffc5bfa9f2ce1e1282797f8f90096f9f88/nvidia_nvtx-13.0.85-py3-none-win_amd64.whl", hash = "sha256:d66ea44254dd3c6eacc300047af6e1288d2269dd072b417e0adffbf479e18519", size = 137066, upload-time = "2025-09-04T08:39:25.649Z" },
+]
+
+[[package]]
+name = "nvidia-nvvm"
+version = "13.3.73"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/e7/ff646aa6015c7e6d12aad234e68925c87b6681d8d18c3ac40535994a3b0d/nvidia_nvvm-13.3.73-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:0e28e0858a3475e11ac67d35301cd5bf82666a1c0dc4ec4e80ceaf3a5fd1dea8", size = 69250424, upload-time = "2026-06-29T17:08:07.453Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/05/35754a7105563fd9b496e5ee8e1acd986aef8258760c3cbccf419aee861a/nvidia_nvvm-13.3.73-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2bcdd5783b5481445f1f0e7170cb836cc0d72999839ba850bbba6dc97b76bb8", size = 66984478, upload-time = "2026-06-29T17:07:43.765Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6b/d5756f485012b920475cbc01457c1b9a7d0485bfb04b92598c5e1ef3e9ab/nvidia_nvvm-13.3.73-py3-none-win_amd64.whl", hash = "sha256:b5c91dfa59ee4cee90b2dfb19c6203f31c914b9c9b5ca10726c2da7cf8ed401d", size = 59981103, upload-time = "2026-06-29T17:21:43.334Z" },
 ]
 
 [[package]]
@@ -4250,8 +4451,8 @@ name = "omegaconf"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime" },
-    { name = "pyyaml" },
+    { name = "antlr4-python3-runtime", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "pyyaml", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/3d/e4b57b8d9008c6ebe0d5eff901f91d5700cf7bdb8c8863df817463a7fd5e/omegaconf-2.3.1.tar.gz", hash = "sha256:e5e7de64aeebeddaf8e6d3f7a783b32ac2a01c0fbd9c878012caecb891a1f42a", size = 3298472, upload-time = "2026-06-11T05:05:12.885Z" }
 wheels = [
@@ -4263,15 +4464,15 @@ name = "openai"
 version = "2.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "distro", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "httpx", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "jiter", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "sniffio", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "tqdm", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "typing-extensions", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
 wheels = [
@@ -4283,8 +4484,8 @@ name = "openai-harmony"
 version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/92/2d038d096f29179c7c9571b431f9e739f87a487121901725e23fe338dd9d/openai_harmony-0.0.8.tar.gz", hash = "sha256:6e43f98e6c242fa2de6f8ea12eab24af63fa2ed3e89c06341fb9d92632c5cbdf", size = 284777, upload-time = "2025-11-05T19:07:06.727Z" }
 wheels = [
@@ -4359,9 +4560,9 @@ name = "opencv-python-headless"
 version = "5.0.0.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
 wheels = [
@@ -4380,7 +4581,7 @@ name = "opentelemetry-api"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
 wheels = [
@@ -4657,14 +4858,15 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "python-dateutil", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pytz", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "tzdata", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4722,26 +4924,35 @@ name = "pandas"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
     { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
@@ -4830,16 +5041,16 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accelerate" },
     { name = "huggingface-hub" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "packaging" },
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
     { name = "torch" },
     { name = "tqdm" },
-    { name = "transformers" },
+    { name = "transformers", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/cf/037f1e3d5186496c05513a6754639e2dab3038a05f384284d49a9bd06a2d/peft-0.19.1.tar.gz", hash = "sha256:0d97542fe96dcdaa20d3b81c06f26f988618f416a73544ab23c3618ccb674a40", size = 763738, upload-time = "2026-04-16T15:46:45.105Z" }
 wheels = [
@@ -5594,26 +5805,27 @@ name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
 ]
 dependencies = [
-    { name = "annotated-types", marker = "python_full_version < '3.14'" },
-    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-    { name = "typing-inspection", marker = "python_full_version < '3.14'" },
+    { name = "annotated-types", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "typing-inspection", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
@@ -5622,7 +5834,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator", marker = "python_full_version < '3.14'" },
+    { name = "email-validator", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 
 [[package]]
@@ -5630,16 +5842,28 @@ name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
 ]
 dependencies = [
-    { name = "annotated-types", marker = "python_full_version >= '3.14'" },
-    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
-    { name = "typing-inspection", marker = "python_full_version >= '3.14'" },
+    { name = "annotated-types", marker = "python_full_version >= '3.14' or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14' or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.14' or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -5648,7 +5872,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator", marker = "python_full_version >= '3.14'" },
+    { name = "email-validator", marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 
 [[package]]
@@ -5656,23 +5880,24 @@ name = "pydantic-core"
 version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
@@ -5790,13 +6015,25 @@ name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14' or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
@@ -5912,8 +6149,8 @@ name = "pydantic-extra-types"
 version = "2.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
@@ -5931,14 +6168,23 @@ name = "pydantic-settings"
 version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "python-dotenv", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "typing-inspection", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
+name = "pyelftools"
+version = "0.33"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/11/767522582afab1b884d277de0e6e011640cb9d7292a38694b4b1a1df1ae8/pyelftools-0.33.tar.gz", hash = "sha256:660d82dcbeb8e83d1702bd97f223f761625da06111c0cc988eac6b8ab0c1b61f", size = 15068655, upload-time = "2026-05-29T12:56:22.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2a/f9697576603dae937727827505a6126a066affb227034e77e6f9068910da/pyelftools-0.33-py3-none-any.whl", hash = "sha256:f215ad5f47d3f1373a21496a6c9e0707c622840d0622f23ff7ce08678b020036", size = 201178, upload-time = "2026-05-29T12:56:20.587Z" },
 ]
 
 [[package]]
@@ -5955,7 +6201,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
@@ -5964,7 +6210,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography" },
+    { name = "cryptography", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 
 [[package]]
@@ -6060,7 +6306,7 @@ name = "pyroscope-io"
 version = "0.8.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "cffi" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/50/607b38b120ba8adad954119ba512c53590c793f0cf7f009ba6549e4e1d77/pyroscope_io-0.8.16-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:e07edcfd59f5bdce42948b92c9b118c824edbd551730305f095a6b9af401a9e8", size = 3138869, upload-time = "2026-01-22T06:23:24.664Z" },
@@ -6074,13 +6320,13 @@ name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
@@ -6092,9 +6338,9 @@ name = "pytest-asyncio"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
@@ -6355,8 +6601,8 @@ name = "qwen-vl-utils"
 version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "av", version = "17.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "av", version = "18.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "av", version = "17.1.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "av", version = "18.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "requests" },
@@ -6413,8 +6659,8 @@ default = [
     { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
     { name = "py-spy" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "requests" },
     { name = "smart-open" },
     { name = "virtualenv" },
@@ -6439,7 +6685,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
 wheels = [
@@ -6572,14 +6818,15 @@ name = "renderers"
 version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "openai" },
-    { name = "openai-harmony" },
-    { name = "tiktoken" },
-    { name = "transformers" },
+    { name = "jinja2", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "openai", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "openai-harmony", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "tiktoken", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "transformers", version = "5.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "transformers", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/5f/fdd86253f562ffdecbdb56cb8591961f0b82914a9abc4ebf43976befb891/renderers-0.1.7.tar.gz", hash = "sha256:d17ccbc3813dd0ee3a6f7d8794308bd4300eb2a80dbc01e83c8f47513e9614f0", size = 209731, upload-time = "2026-05-12T12:51:07.559Z" }
 wheels = [
@@ -6620,7 +6867,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
@@ -6772,19 +7019,19 @@ dependencies = [
     { name = "codetiming" },
     { name = "datasets" },
     { name = "hydra-core" },
-    { name = "litellm", extra = ["proxy"] },
+    { name = "litellm", extra = ["proxy"], marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
     { name = "openai" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "pillow" },
     { name = "polars" },
     { name = "pyarrow" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
-    { name = "rllm-model-gateway" },
+    { name = "rllm-model-gateway", version = "0.1.0", source = { git = "https://github.com/rllm-org/rllm.git?subdirectory=rllm-model-gateway#b9dfebf0157ce1d6dfe595d90d36836623702564" } },
     { name = "simple-term-menu" },
     { name = "tinker", marker = "python_full_version >= '3.11'" },
     { name = "tinker-cookbook", marker = "python_full_version >= '3.11'" },
@@ -6794,17 +7041,71 @@ dependencies = [
 [[package]]
 name = "rllm-model-gateway"
 version = "0.1.0"
-source = { git = "https://github.com/rllm-org/rllm.git?subdirectory=rllm-model-gateway#b9dfebf0157ce1d6dfe595d90d36836623702564" }
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+]
 dependencies = [
-    { name = "aiosqlite" },
-    { name = "fastapi" },
-    { name = "httpx" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pyyaml" },
-    { name = "renderers" },
-    { name = "transformers" },
-    { name = "uvicorn" },
+    { name = "aiosqlite", marker = "extra == 'extra-20-agentcore-rl-toolkit-verl' or extra != 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "fastapi", marker = "extra == 'extra-20-agentcore-rl-toolkit-verl' or extra != 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "httpx", marker = "extra == 'extra-20-agentcore-rl-toolkit-verl' or extra != 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra != 'extra-20-agentcore-rl-toolkit-rllm') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pyyaml", marker = "extra == 'extra-20-agentcore-rl-toolkit-verl' or extra != 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "uvicorn", marker = "extra == 'extra-20-agentcore-rl-toolkit-verl' or extra != 'extra-20-agentcore-rl-toolkit-rllm'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/45/6134fa839037a425a54c6e63abeb22afbd8902564eca3890d430fb87f87a/rllm_model_gateway-0.1.0.tar.gz", hash = "sha256:11be2368ca9c1b81ce2639d6451ab9054e90a55f5c46e70971d4cd6d7a335612", size = 40247, upload-time = "2026-03-12T04:35:06.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/73/4c88d3b6f369c6643d5efa6d80e3a69099d5cba00b7a82d7f0b2ed30cb78/rllm_model_gateway-0.1.0-py3-none-any.whl", hash = "sha256:3963661cac8f29e803a725f13abfe719f3e1b94bf2885b17ffc009eafb92e562", size = 26971, upload-time = "2026-03-12T04:35:05.52Z" },
+]
+
+[[package]]
+name = "rllm-model-gateway"
+version = "0.1.0"
+source = { git = "https://github.com/rllm-org/rllm.git?subdirectory=rllm-model-gateway#b9dfebf0157ce1d6dfe595d90d36836623702564" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "aiosqlite", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "fastapi", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "httpx", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pyyaml", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "renderers", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
+    { name = "transformers", version = "5.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "transformers", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "uvicorn", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm'" },
 ]
 
 [[package]]
@@ -6948,7 +7249,7 @@ name = "ruamel-yaml"
 version = "0.18.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.15' and platform_python_implementation == 'CPython'" },
+    { name = "ruamel-yaml-clib", marker = "(python_full_version < '3.15' and platform_python_implementation == 'CPython') or (python_full_version >= '3.15' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (platform_python_implementation != 'CPython' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/2b/7a1f1ebcd6b3f14febdc003e658778d81e76b40df2267904ee6b13f0c5c6/ruamel_yaml-0.18.17.tar.gz", hash = "sha256:9091cd6e2d93a3a4b157ddb8fabf348c3de7f1fb1381346d985b6b247dcd8d3c", size = 149602, upload-time = "2025-12-17T20:02:55.757Z" }
 wheels = [
@@ -7299,8 +7600,8 @@ name = "sse-starlette"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "starlette" },
+    { name = "anyio", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "starlette", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
 wheels = [
@@ -7313,7 +7614,7 @@ version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
@@ -7334,7 +7635,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -7358,9 +7659,9 @@ dependencies = [
     { name = "absl-py" },
     { name = "grpcio" },
     { name = "markdown" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "protobuf" },
@@ -7389,9 +7690,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloudpickle" },
     { name = "importlib-metadata" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "orjson", marker = "python_full_version < '3.13'" },
     { name = "packaging" },
     { name = "pyvers" },
@@ -7434,8 +7735,8 @@ name = "tiktoken"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex" },
-    { name = "requests" },
+    { name = "regex", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
+    { name = "requests", marker = "extra == 'extra-20-agentcore-rl-toolkit-rllm' or extra == 'extra-20-agentcore-rl-toolkit-verl'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
 wheels = [
@@ -7498,9 +7799,9 @@ dependencies = [
     { name = "apache-tvm-ffi" },
     { name = "cloudpickle" },
     { name = "ml-dtypes" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "psutil" },
     { name = "setuptools", marker = "sys_platform == 'darwin'" },
     { name = "torch" },
@@ -7524,17 +7825,16 @@ dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.11'" },
     { name = "click", marker = "python_full_version >= '3.11'" },
     { name = "distro", marker = "python_full_version >= '3.11'" },
-    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "orjson", marker = "python_full_version >= '3.11'" },
     { name = "protobuf", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyqwest", marker = "python_full_version >= '3.11'" },
     { name = "rich", marker = "python_full_version >= '3.11'" },
     { name = "sniffio", marker = "python_full_version >= '3.11'" },
-    { name = "transformers", marker = "python_full_version >= '3.11'" },
+    { name = "transformers", version = "5.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
     { name = "zstandard", marker = "python_full_version >= '3.11'" },
 ]
@@ -7555,11 +7855,10 @@ dependencies = [
     { name = "cloudpickle", marker = "python_full_version >= '3.11'" },
     { name = "datasets", marker = "python_full_version >= '3.11'" },
     { name = "huggingface-hub", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "rich", marker = "python_full_version >= '3.11'" },
     { name = "safetensors", marker = "python_full_version >= '3.11'" },
     { name = "termcolor", marker = "python_full_version >= '3.11'" },
@@ -7567,7 +7866,7 @@ dependencies = [
     { name = "tinker", marker = "python_full_version >= '3.11'" },
     { name = "torch", marker = "python_full_version >= '3.11'" },
     { name = "tqdm", marker = "python_full_version >= '3.11'" },
-    { name = "transformers", marker = "python_full_version >= '3.11'" },
+    { name = "transformers", version = "5.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/66/e29025eb28c968b7d72624fa2766470a0b6d81617ef336796b5ead3979af/tinker_cookbook-0.4.3.tar.gz", hash = "sha256:15927af65c0e85f42161c4b4a03038ab5307981be16839b19003e075cb1826f5", size = 4595925, upload-time = "2026-06-24T16:35:47.605Z" }
 wheels = [
@@ -7700,21 +7999,21 @@ name = "torch"
 version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "cuda-bindings", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "filelock", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "fsspec", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "jinja2", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "nvidia-cudnn-cu13", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "nvidia-cusparselt-cu13", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "nvidia-nccl-cu13", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "nvidia-nvshmem-cu13", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "setuptools", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "sympy", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "triton", marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (sys_platform != 'linux' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (sys_platform == 'linux' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/f2/c1690994afe461aae2d0cac62251e6802a703dec0a6c549c02ecd0de92a9/torch-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2c0d7fcfbc0c4e8bb5ebc3907cbc0c6a0da1b8f82b1fc6e14e914fa0b9baf74e", size = 80526521, upload-time = "2026-03-23T18:12:06.86Z" },
@@ -7831,9 +8130,9 @@ name = "torchvision"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "pillow" },
     { name = "torch" },
 ]
@@ -7873,7 +8172,7 @@ name = "tqdm"
 version = "4.68.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
@@ -7884,22 +8183,78 @@ wheels = [
 name = "transformers"
 version = "5.5.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "regex" },
-    { name = "safetensors" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
-    { name = "typer" },
+    { name = "huggingface-hub", marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "packaging", marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pyyaml", marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "regex", marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "safetensors", marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "tokenizers", marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "tqdm", marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "typer", marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/1e/1e244ab2ab50a863e6b52cc55761910567fa532b69a6740f6e99c5fdbd98/transformers-5.5.4.tar.gz", hash = "sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e", size = 8227649, upload-time = "2026-04-13T16:55:55.181Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/fb/162a66789c65e5afa3b051309240c26bf37fbc8fea285b4546ae747995a2/transformers-5.5.4-py3-none-any.whl", hash = "sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167", size = 10236696, upload-time = "2026-04-13T16:55:51.497Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.8.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version >= '3.12' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version == '3.11.*' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+    "python_full_version < '3.11' and extra != 'extra-20-agentcore-rl-toolkit-rllm' and extra != 'extra-20-agentcore-rl-toolkit-verl'",
+]
+dependencies = [
+    { name = "huggingface-hub", marker = "python_full_version < '3.11' or extra != 'extra-20-agentcore-rl-toolkit-rllm' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra != 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra != 'extra-20-agentcore-rl-toolkit-rllm') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "packaging", marker = "python_full_version < '3.11' or extra != 'extra-20-agentcore-rl-toolkit-rllm' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pyyaml", marker = "python_full_version < '3.11' or extra != 'extra-20-agentcore-rl-toolkit-rllm' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "regex", marker = "python_full_version < '3.11' or extra != 'extra-20-agentcore-rl-toolkit-rllm' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "safetensors", marker = "python_full_version < '3.11' or extra != 'extra-20-agentcore-rl-toolkit-rllm' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "tokenizers", marker = "python_full_version < '3.11' or extra != 'extra-20-agentcore-rl-toolkit-rllm' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "tqdm", marker = "python_full_version < '3.11' or extra != 'extra-20-agentcore-rl-toolkit-rllm' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "typer", marker = "python_full_version < '3.11' or extra != 'extra-20-agentcore-rl-toolkit-rllm' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/e6/4134ea2fbea322cddc7ffc94a0d8ee47fe32ce8e876b320cd37d88edfc4d/transformers-5.8.1.tar.gz", hash = "sha256:4dd5b6de4105725104d84fd6abd74b305f4debfc251b38c648ee5dd087cf543b", size = 8532019, upload-time = "2026-05-13T03:21:57.234Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b1/8be7e7ef0b5200491312201918b6125ef9c9df9dd0f0240ccef9ac824e6b/transformers-5.8.1-py3-none-any.whl", hash = "sha256:5340fb95962162cdfdae5cc91d7f8fedd92ed75216c1154c5e1f590fcf56dd0e", size = 10632882, upload-time = "2026-05-13T03:21:52.876Z" },
 ]
 
 [[package]]
@@ -7996,7 +8351,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
 wheels = [
@@ -8056,21 +8411,21 @@ dependencies = [
     { name = "datasets" },
     { name = "dill" },
     { name = "hydra-core" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "peft" },
     { name = "pyarrow" },
     { name = "pybind11" },
     { name = "pylatexenc" },
-    { name = "ray", extra = ["default"] },
+    { name = "ray", extra = ["default"], marker = "extra == 'extra-20-agentcore-rl-toolkit-verl'" },
     { name = "tensorboard" },
     { name = "tensordict" },
     { name = "torchdata" },
-    { name = "transformers" },
+    { name = "transformers", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
     { name = "wandb" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/f7/d5ff07531e10f0278d3f2f5bf9a0a9ddd5d8d3d3eb903e2dd34c70bee28f/verl-0.8.0.tar.gz", hash = "sha256:814352ab55179dab0724091313e0367e866af667f6a749cc248b73699eb15a21", size = 1009336, upload-time = "2026-06-01T11:29:39.864Z" }
@@ -8086,7 +8441,7 @@ dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/28/e6f1a6f655d620846bd9df527390ecc26b3805a0c5989048c210e22c5ca9/virtualenv-20.35.4.tar.gz", hash = "sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c", size = 6028799, upload-time = "2025-10-29T06:57:40.511Z" }
 wheels = [
@@ -8095,7 +8450,7 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -8109,27 +8464,28 @@ dependencies = [
     { name = "depyf" },
     { name = "diskcache" },
     { name = "einops" },
-    { name = "fastapi", extra = ["standard"] },
+    { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-20-agentcore-rl-toolkit-verl'" },
     { name = "fastsafetensors" },
     { name = "filelock" },
     { name = "flashinfer-cubin" },
     { name = "flashinfer-python" },
     { name = "gguf" },
+    { name = "humming-kernels", extra = ["cu13"], marker = "extra == 'extra-20-agentcore-rl-toolkit-verl'" },
     { name = "ijson" },
     { name = "lark" },
     { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 'x86_64'" },
     { name = "lm-format-enforcer" },
     { name = "mcp" },
-    { name = "mistral-common", extra = ["image"] },
+    { name = "mistral-common", extra = ["image"], marker = "extra == 'extra-20-agentcore-rl-toolkit-verl'" },
     { name = "model-hosting-container-standards" },
     { name = "msgspec" },
     { name = "ninja" },
     { name = "numba" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "nvidia-cudnn-frontend" },
-    { name = "nvidia-cutlass-dsl" },
+    { name = "nvidia-cutlass-dsl", extra = ["cu13"], marker = "extra == 'extra-20-agentcore-rl-toolkit-verl'" },
     { name = "openai" },
     { name = "openai-harmony" },
     { name = "opencv-python-headless" },
@@ -8146,14 +8502,15 @@ dependencies = [
     { name = "psutil" },
     { name = "py-cpuinfo" },
     { name = "pybase64" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "pyzmq" },
     { name = "quack-kernels" },
     { name = "regex" },
     { name = "requests" },
+    { name = "safetensors" },
     { name = "sentencepiece" },
     { name = "setproctitle" },
     { name = "setuptools", marker = "python_full_version >= '3.12'" },
@@ -8166,17 +8523,15 @@ dependencies = [
     { name = "torchaudio" },
     { name = "torchvision" },
     { name = "tqdm" },
-    { name = "transformers" },
+    { name = "transformers", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
     { name = "typing-extensions" },
     { name = "watchfiles" },
     { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/bb/8dbba4136f6851470f4324ac665affe55c0b618341ccc42f35a53c5e708e/vllm-0.21.0.tar.gz", hash = "sha256:05ff89c3e926b88b77d7878e317a659ffba678afc21c1d48952037aa5457f058", size = 34452205, upload-time = "2026-05-15T00:09:15.481Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/bf/46631fd8e2e9d81c5abe2ab923e5367754bc0cad685c4ddac1d5d86d91b5/vllm-0.22.0.tar.gz", hash = "sha256:6d41581a9e5288cd69278518a550c6d7ce510ae27a506556a3427d01284be7fe", size = 36239170, upload-time = "2026-05-29T10:35:39.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/58/564b64d17dde6dc31faae836f98313538c152edf88e2a4fb43b9d551a635/vllm-0.21.0-1-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:dc62135a50dc4b412b4f79549208e782f1665e49e8c13c2d29d2c3d94ff8ac97", size = 239758862, upload-time = "2026-05-15T08:47:06.471Z" },
-    { url = "https://files.pythonhosted.org/packages/73/6d/9b78990c9fabc70c7731de6af246a420156dc019f66b48da7c86f509c132/vllm-0.21.0-1-cp38-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:f4a75b1391f44c67dc1ca268f5ffed9f6b7fdbc657c93db64e6892c5d1bc320b", size = 248151215, upload-time = "2026-05-15T08:47:36.846Z" },
-    { url = "https://files.pythonhosted.org/packages/59/ae/d78ef0ed561974ea61c6e0786771d3a2a575e22592bd58f2ed52417b9aa2/vllm-0.21.0-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:d6e63955b595bd2aa364e90f85c0a2e99573e701146db58394da569ddc6f4eea", size = 239758816, upload-time = "2026-05-15T00:08:22.496Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/62/8cbf7c943b0aca0538d0f5324848a3f256b8284dd4d881cd65ae106c83d7/vllm-0.21.0-cp38-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:b241b085742cf04a68c82c089d12afe4d9ee729e0c7f81b2b2b9961d36105ee5", size = 248151169, upload-time = "2026-05-15T00:08:53.502Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/e8/05a69dbd7416c5a5ac91f51e626fede9ceeabe9c6fe243fc11e2b3e1ad3e/vllm-0.22.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0fbe1ff32e9ad82c56b002de11b061ca6b5b8a256cd11473946d2222115ed267", size = 252942448, upload-time = "2026-05-29T10:32:10.261Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/23/3f7f759763fb9b4cf5787bcb4a43f74904f8e644d53d4fdb4e19654a92fd/vllm-0.22.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c387a977e35795e8f77b009e019e69722963819c26b55e4a679e09d4279ae35d", size = 261034920, upload-time = "2026-05-29T10:33:10.357Z" },
 ]
 
 [[package]]
@@ -8189,8 +8544,8 @@ dependencies = [
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "protobuf" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sentry-sdk" },
@@ -8507,13 +8862,13 @@ version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-20-agentcore-rl-toolkit-verl') or (extra == 'extra-20-agentcore-rl-toolkit-rllm' and extra == 'extra-20-agentcore-rl-toolkit-verl')" },
     { name = "torch" },
-    { name = "transformers" },
+    { name = "transformers", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
     { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]


### PR DESCRIPTION
This PR includes several updates to verl environment installation and example training script.

### Package Update
- Update `vllm` to 0.22.0
- Pin `transformers` version to 5.8.1, avoiding conflicts with megatron-bridge
- Add `flash-linear-attention` required for Qwen 3.5+ models.
- In pyproject.toml, declaring verl and rllm as conflicting extras to let uv resolve each in its own fork instead of focring one universal lock.

### CUDA Compatibility
- When installing `transformer-engine` for cuda 13, `transformer-engine-cu12` should be excluded to avoid cuda errors in training.
- Fix example training script for cuda 12/13 compatibility.
