### PR TITLE
feat: add sandbox SDK (sync client + sandboxd + quickstart example)

### DIFF
--- a/.github/workflows/sandboxd.yml
+++ b/.github/workflows/sandboxd.yml
@@ -1,0 +1,29 @@
+name: Sandboxd
+
+on:
+  push:
+    branches: [main]
+    paths: ["sandboxd/**"]
+  pull_request:
+    branches: [main]
+    paths: ["sandboxd/**"]
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sandboxd
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - name: gofmt check
+        run: test -z "$(gofmt -l .)"
+      - name: go vet
+        run: go vet ./...
+      - name: go build
+        run: go build ./...
+      - name: go test
+        run: go test -race ./...

--- a/.github/workflows/sandboxd.yml
+++ b/.github/workflows/sandboxd.yml
@@ -1,5 +1,8 @@
 name: Sandboxd
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,7 @@ config.toml
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/check-cloudwatch-session-logs/
+# Personal per-project Claude instructions (loaded alongside CLAUDE.md, never committed)
+CLAUDE.local.md
 
 .bedrock_agentcore.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,7 +369,7 @@ sb = client.attach(session_id)                  # reconnect to a live session
   failures: `ClientError`/`EventStreamError` propagate; `SandboxProtocolError` means the
   deployed container isn't behaving like sandboxd (wrong image) or the stream was invalid.
 - **Commands are stateless** — each `exec()` runs in a fresh process. `cwd=`/`env=` params
-  are composed into the command string per call (`cd ... && export ...; <command>`).
+  are composed into the command string per call (`cd ... && export ... && <command>`).
 - **The command API does not invoke a shell itself** (it word-splits argv-style), so the
   client wraps every command in `<shell> -c '...'` on the wire — default `/bin/sh` for
   arbitrary-image portability, overridable via `SandboxClient(shell=...)`/`exec(shell=...)`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This document provides context, patterns, and guidelines for AI coding assistant
   - [Background: BedrockAgentCoreApp](#background-bedrockagentcoreapp)
   - [What agentcore-rl-toolkit Provides](#what-agentcore-rl-toolkit-provides)
   - [Rollout Gateway](#rollout-gateway)
+  - [Sandbox SDK](#sandbox-sdk)
   - [Migration Guide (basic_app → rl_app)](#migration-guide-basic_app--rl_app)
   - [Deployment to ACR](#deployment-to-acr)
   - [Evaluation](#evaluation)
@@ -51,6 +52,8 @@ cd examples/strands_math_agent && uv sync && uv run python rl_app.py
 | `src/agentcore_rl_toolkit/client.py` | `RolloutClient` and `RolloutFuture` for training integration and batch evaluation |
 | `src/agentcore_rl_toolkit/reward_function.py` | `RewardFunction` base class |
 | `src/agentcore_rl_toolkit/rollout_gateway/` | In-repo token-level trajectory capture layer: `RolloutGateway`, `Renderer`, `SamplingBackend`, `TraceRecord` (see [Rollout Gateway](#rollout-gateway)) |
+| `src/agentcore_rl_toolkit/sandbox/` | Sandbox SDK: `SandboxClient`, `Sandbox`, `ExecResult` — run shell commands in arbitrary images on ACR (see [Sandbox SDK](#sandbox-sdk)) |
+| `sandboxd/` | Go health shim (`agentcore-sandboxd`) that makes arbitrary Docker images satisfy the ACR container contract |
 | `examples/strands_math_agent/` | GSM8K math agent example |
 | `examples/strands_migration_agent/` | Java migration agent example |
 | `examples/strands_officebench_agent/` | OfficeBench office automation agent example |
@@ -67,6 +70,9 @@ agentcore-rl-toolkit/
 │   ├── app.py                      # AgentCoreRLApp base class
 │   ├── client.py                   # RolloutClient for batch evaluation
 │   ├── reward_function.py          # RewardFunction base class
+│   ├── sandbox/                    # Sandbox SDK (sync client for command execution)
+│   │   ├── client.py               # SandboxClient (start/attach) + Sandbox (exec/terminate)
+│   │   └── types.py                # ExecResult, SandboxProtocolError
 │   └── rollout_gateway/            # Token-level trajectory capture layer (trainer-side)
 │       ├── trace.py                # TraceRecord — torch-free output boundary
 │       ├── trajectory.py           # TrajectoryManager — per-session message tree
@@ -94,17 +100,28 @@ agentcore-rl-toolkit/
 │   │   ├── reward.py               # OfficeBenchReward implementation
 │   │   ├── tools.py                # Office automation tools
 │   │   └── pyproject.toml          # Example-specific dependencies
-│   └── strands_appworld_agent/    # AppWorld example
-│       ├── rl_app.py               # RL-adapted AppWorld code agent
-│       ├── evaluate.py             # Async batch evaluation script
-│       ├── deploy.py               # Deploy container to AgentCore
-│       ├── reward.py               # AppWorldReward implementation
-│       ├── Dockerfile              # ACR container (AppWorld data baked in)
-│       └── pyproject.toml          # Example-specific dependencies
+│   ├── strands_appworld_agent/    # AppWorld example
+│   │   ├── rl_app.py               # RL-adapted AppWorld code agent
+│   │   ├── evaluate.py             # Async batch evaluation script
+│   │   ├── deploy.py               # Deploy container to AgentCore
+│   │   ├── reward.py               # AppWorldReward implementation
+│   │   ├── Dockerfile              # ACR container (AppWorld data baked in)
+│   │   └── pyproject.toml          # Example-specific dependencies
+│   └── sandbox_quickstart/         # Sandbox SDK example (no agent server)
+│       ├── Dockerfile              # debian-slim + prebuilt sandboxd binary
+│       ├── build_and_push.sh       # binary + image + ECR push in one command
+│       ├── deploy.py               # create the sandbox runtime (temp scaffolding)
+│       ├── run_sandbox.py          # start -> exec -> terminate demo
+│       └── README.md               # binary build + deploy + run walkthrough
+├── sandboxd/                       # Go health shim (self-contained module, stdlib only)
+│   ├── main.go                     # /ping + /invocations busy-state server
+│   ├── main_test.go
+│   └── build.sh                    # cross-compile (arm64 default; docker fallback)
 ├── tests/
 │   ├── test_rollout_entrypoint.py
 │   ├── test_client.py
-│   └── test_async_client.py
+│   ├── test_async_client.py
+│   └── sandbox/                    # Sandbox SDK tests (mocked boto3)
 ├── scripts/
 │   └── build_docker_image_and_push_to_ecr.sh
 ├── pyproject.toml
@@ -320,6 +337,63 @@ Re-sync workflow: `git -C <slime> diff 90c212b5..HEAD -- slime/agent/<file>` sho
 changes since the lift. Our copies are intentionally modified (torch-free; `Sample` →
 `TraceRecord`; injected backend/renderer seams; sglang parser hook removed), so treat the diff
 as a review aid, not an automatic merge. Bump the baseline commit here when you re-sync.
+
+### Sandbox SDK
+
+`src/agentcore_rl_toolkit/sandbox/` runs shell commands in **arbitrary Docker images**
+(e.g. SWE-bench-style coding environments) deployed as ACR runtimes — the substrate for
+coding-agent evaluation and RL rollouts.
+
+**How it works.** Most coding-environment images are not HTTP agent servers, but ACR
+requires containers to expose `/ping` and `/invocations` on port 8080. The bridge is
+`agentcore-sandboxd` (Go, stdlib-only, source in `sandboxd/`): a health shim added to the
+image that manages the Healthy/HealthyBusy ping state. Command execution does NOT go
+through the shim — the client uses ACR's native `InvokeAgentRuntimeCommand` API, which
+runs shell commands in the same session/container and streams back stdout/stderr/exit code.
+
+```python
+from agentcore_rl_toolkit.sandbox import SandboxClient
+
+client = SandboxClient(runtime_arn="arn:aws:bedrock-agentcore:...:runtime/...")
+with client.start() as sb:                      # session starts, ping -> HealthyBusy
+    result = sb.exec("cd /app && pytest -q", timeout=900)
+    result.exit_code, result.stdout, result.stderr, result.timed_out
+# __exit__ -> terminate(): ping -> Healthy, then StopRuntimeSession
+sb = client.attach(session_id)                  # reconnect to a live session
+```
+
+**Key semantics:**
+
+- **Nonzero exit and timeout are data, not exceptions** (`ExecResult.exit_code`,
+  `ExecResult.timed_out` with partial output). Exceptions are reserved for infrastructure
+  failures: `ClientError`/`EventStreamError` propagate; `SandboxProtocolError` means the
+  deployed container isn't behaving like sandboxd (wrong image) or the stream was invalid.
+- **Commands are stateless** — each `exec()` runs in a fresh process. `cwd=`/`env=` params
+  are composed into the command string per call (`cd ... && export ...; <command>`).
+- **The command API does not invoke a shell itself** (it word-splits argv-style), so the
+  client wraps every command in `<shell> -c '...'` on the wire — default `/bin/sh` for
+  arbitrary-image portability, overridable via `SandboxClient(shell=...)`/`exec(shell=...)`.
+  Users just write shell strings; pipes, `;`, and `$VAR` work.
+- **Verbs**: `start`/`attach`/`terminate` are the per-session data plane. `create` is
+  reserved for future control-plane provisioning (`CreateAgentRuntime` from an ECR image).
+- `terminate()` is idempotent and best-effort: it flips the ping to Healthy first so the
+  idle reaper collects the session even if `StopRuntimeSession` fails.
+- The base image must contain a shell (`InvokeAgentRuntimeCommand` executes shell
+  commands); scratch/distroless images won't work.
+- Sync-only today. Planned next phases: TTL leak protection + async client (aiobotocore),
+  then detached exec (`spawn`/`ExecHandle`), interactive shells, file transfer.
+
+**Building the shim binary** (static, cross-compiled; works on x86 hosts, falls back to a
+golang container if Go isn't installed):
+
+```bash
+sandboxd/build.sh                 # -> sandboxd/dist/agentcore-sandboxd-linux-arm64
+sandboxd/build.sh --stage examples/sandbox_quickstart   # also copy into a build context
+```
+
+See `examples/sandbox_quickstart/` for the full walkthrough (wrap image → push to ECR →
+create runtime → run). Python tests: `tests/sandbox/` (boto3 fully mocked). Go tests:
+`cd sandboxd && go test -race ./...` (CI: `.github/workflows/sandboxd.yml`).
 
 ### Migration Guide (basic_app → rl_app)
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ While session routing is valuable for multi-turn production agents, RL rollouts 
 - **Async end-to-end**: Fire-and-forget server + future-based client — no long-lived TCP connections needed for long-running agent rollouts
 - **Simplified rollout collection**: `RolloutClient` manages concurrency, rate limiting, and S3 result polling out of the box for both training loops and batch evaluation
 - **Production parity**: Direct code reuse from production agents ensures training behavior matches real deployment
+- **Sandbox on ACR** (`SandboxClient` + `agentcore-sandboxd`): Run shell commands in arbitrary Docker images (e.g. SWE-bench-style coding environments) as isolated AgentCore runtime sessions — no agent server required in the image
 
 ## Agent-Side: Adapting Your Agent for RL
 
@@ -308,6 +309,21 @@ chmod +x scripts/build_docker_image_and_push_to_ecr.sh
   --tag=dev \
   --context=examples/strands_math_agent
 ```
+
+## Sandbox: Command Execution in Arbitrary Images
+
+Coding-agent evaluation and RL training typically start from prebuilt environment images (repository checkout, dependencies, test runner) that are not HTTP agent servers. The sandbox SDK bridges them onto AgentCore Runtime: a tiny health shim (`agentcore-sandboxd`, built from [`sandboxd/`](./sandboxd/)) is added to the image to satisfy the ACR container contract, and commands run through ACR's native `InvokeAgentRuntimeCommand` API.
+
+```python
+from agentcore_rl_toolkit.sandbox import SandboxClient
+
+client = SandboxClient(runtime_arn="arn:aws:bedrock-agentcore:...:runtime/...")
+with client.start() as sb:
+    result = sb.exec("cd /app && pytest -q", timeout=900)
+    print(result.exit_code, result.stdout)
+```
+
+Failing commands and timeouts are results, not exceptions — exactly what reward functions need. See [`examples/sandbox_quickstart/`](./examples/sandbox_quickstart/) for the full walkthrough (build the shim binary, wrap and push an image, create a runtime, run commands).
 
 ## Contributing
 

--- a/examples/sandbox_quickstart/.gitignore
+++ b/examples/sandbox_quickstart/.gitignore
@@ -1,0 +1,4 @@
+# Prebuilt sandboxd binary staged by ../../sandboxd/build.sh --stage .
+agentcore-sandboxd-linux-*
+# Standalone uv project: users run `uv sync` themselves; examples don't track lockfiles
+uv.lock

--- a/examples/sandbox_quickstart/Dockerfile
+++ b/examples/sandbox_quickstart/Dockerfile
@@ -1,0 +1,13 @@
+# A shell IS required in the base image: the sandbox SDK runs commands via
+# AgentCore Runtime's InvokeAgentRuntimeCommand API, which executes shell
+# commands inside this container (scratch/distroless images would break exec).
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
+
+# Prebuilt static binary — build it first with: ../../sandboxd/build.sh --stage .
+# --chmod instead of a RUN chmod: RUN would execute arm64 /bin/sh, which needs
+# qemu on x86 build hosts; with COPY-only layers no emulation is required.
+COPY --chmod=0755 agentcore-sandboxd-linux-arm64 /opt/agentcore-sandbox/agentcore-sandboxd
+
+WORKDIR /app
+EXPOSE 8080
+CMD ["/opt/agentcore-sandbox/agentcore-sandboxd"]

--- a/examples/sandbox_quickstart/README.md
+++ b/examples/sandbox_quickstart/README.md
@@ -1,0 +1,106 @@
+# Sandbox Quickstart
+
+Run shell commands in an arbitrary Docker image deployed as a Bedrock AgentCore
+Runtime sandbox. This example wraps a plain `debian:bookworm-slim` image with the
+`agentcore-sandboxd` health shim and drives it with the sync sandbox client
+(`agentcore_rl_toolkit.sandbox.SandboxClient`).
+
+How it works: `agentcore-sandboxd` (a tiny Go binary, source in
+[`sandboxd/`](../../sandboxd/)) satisfies AgentCore Runtime's container contract
+(`/ping`, `/invocations` on port 8080) and manages the Healthy/HealthyBusy session
+state. Command execution uses AgentCore Runtime's native
+`InvokeAgentRuntimeCommand` API — no exec daemon runs inside the image.
+
+> **Note:** The base image must contain a shell (`/bin/sh`): commands are executed
+> as shell commands inside the container. `scratch`/distroless images will not work.
+
+## 1. Build the binary and push the image to ECR
+
+With `.env` configured at the repo root (`ECR_REPO_NAME`, `AWS_REGION`,
+`AWS_ACCOUNT` — see `.env.example`), one command does both steps:
+
+```bash
+./build_and_push.sh              # optional: pass a tag (default: sandbox-quickstart)
+```
+
+Note the sandbox image does **not** contain `agentcore-rl-toolkit` (unlike the agent
+examples) — the SDK runs client-side; the image only needs the sandboxd binary and a shell.
+
+<details>
+<summary>What the wrapper runs (manual steps)</summary>
+
+Build the sandboxd binary and stage it into this folder for the Docker build:
+
+```bash
+../../sandboxd/build.sh --stage .
+```
+
+This cross-compiles a static arm64 Linux binary (AgentCore Runtime is arm64-only
+today). Works on x86 hosts — Go cross-compiles natively; if you have no Go
+toolchain the script builds inside a `golang` container instead (no qemu needed).
+
+Then build and push the image from the repo root:
+
+```bash
+./scripts/build_docker_image_and_push_to_ecr.sh \
+  --dockerfile=examples/sandbox_quickstart/Dockerfile \
+  --tag=sandbox-quickstart \
+  --context=examples/sandbox_quickstart
+```
+
+The script builds with `--platform linux/arm64`. Since this Dockerfile only COPYs
+the prebuilt binary (no RUN of arm64 tools), the build needs no qemu emulation.
+
+</details>
+
+## 2. Create the AgentCore runtime
+
+```bash
+uv sync                                   # installs example deps into ./.venv
+cp config.example.toml config.toml        # fill in image_uri and execution_role_arn
+uv run python deploy.py
+```
+
+`deploy.py` creates (or updates) the runtime from the pushed image and prints the
+runtime ARN when the endpoint is ready. Like `build_and_push.sh`, it is temporary
+scaffolding — a future phase moves provisioning into the SDK (`SandboxClient.create()`).
+
+The caller also needs IAM permissions for `bedrock-agentcore:InvokeAgentRuntime`,
+`bedrock-agentcore:InvokeAgentRuntimeCommand`, and
+`bedrock-agentcore:StopRuntimeSession` on the runtime.
+
+## 3. Run the demo
+
+```bash
+SANDBOX_RUNTIME_ARN=arn:aws:bedrock-agentcore:...:runtime/... uv run python run_sandbox.py
+```
+
+Expected output:
+
+```text
+Sandbox session: 1f0e7a2c-...
+exit_code=0 timed_out=False
+stdout: hello from aarch64
+/app
+stderr:
+stdout: hi from /tmp
+Sandbox terminated.
+```
+
+Failing commands are results, not exceptions — `sb.exec("exit 3")` returns
+`ExecResult(exit_code=3, ...)`. Timeouts likewise: `result.timed_out` is `True`
+and any partial output is retained.
+
+## Local smoke test (no AWS needed)
+
+The server is plain HTTP, so you can exercise the contract locally:
+
+```bash
+../../sandboxd/build.sh --arch amd64        # match your host arch
+../../sandboxd/dist/agentcore-sandboxd-linux-amd64 &
+curl -s localhost:8080/ping                                          # {"status":"Healthy"}
+curl -s -XPOST localhost:8080/invocations -d '{"action":"start"}'    # {"status":"ok","state":"busy"}
+curl -s localhost:8080/ping                                          # {"status":"HealthyBusy"}
+curl -s -XPOST localhost:8080/invocations -d '{"action":"stop"}'
+kill %1
+```

--- a/examples/sandbox_quickstart/build_and_push.sh
+++ b/examples/sandbox_quickstart/build_and_push.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Convenience wrapper: build the sandboxd binary, stage it here, and build/push
+# the sandbox image to ECR in one command.
+#
+# Usage:
+#   ./build_and_push.sh [tag]      # tag defaults to "sandbox-quickstart"
+#
+# Requires a .env at the repo root with ECR_REPO_NAME, AWS_REGION, AWS_ACCOUNT
+# (see .env.example) — same as the other examples.
+#
+# NOTE: temporary scaffolding. This script owns no build or ECR logic — it only
+# sequences ../../sandboxd/build.sh (binary) and
+# ../../scripts/build_docker_image_and_push_to_ecr.sh (image + ECR plumbing).
+# A future phase moves image wrapping into the SDK (SandboxEnv.from_image()),
+# at which point this wrapper goes away.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TAG="${1:-sandbox-quickstart}"
+
+"$REPO_ROOT/sandboxd/build.sh" --stage "$SCRIPT_DIR"
+
+cd "$REPO_ROOT"
+./scripts/build_docker_image_and_push_to_ecr.sh \
+  --dockerfile=examples/sandbox_quickstart/Dockerfile \
+  --tag="$TAG" \
+  --context=examples/sandbox_quickstart

--- a/examples/sandbox_quickstart/config.example.toml
+++ b/examples/sandbox_quickstart/config.example.toml
@@ -1,0 +1,8 @@
+# Copy this file to config.toml and fill in your values
+
+[agentcore]
+region = "us-west-2"
+agent_name = "sandbox_quickstart"
+# The image pushed by ./build_and_push.sh:
+image_uri = "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/ECR_REPO_NAME:sandbox-quickstart"
+execution_role_arn = "arn:aws:iam::ACCOUNT_ID:role/EXAMPLE_ROLE"

--- a/examples/sandbox_quickstart/deploy.py
+++ b/examples/sandbox_quickstart/deploy.py
@@ -1,0 +1,53 @@
+"""Deploy the sandbox image as an AgentCore runtime.
+
+Reads config.toml (copy config.example.toml and fill in your values), creates
+or updates the runtime, waits for the endpoint to be ready, and prints the
+runtime ARN to export as SANDBOX_RUNTIME_ARN.
+
+NOTE: temporary scaffolding, like build_and_push.sh — a future phase moves
+runtime provisioning into the SDK (SandboxClient.create()), at which point
+this script goes away.
+"""
+
+from pathlib import Path
+
+import tomllib
+from bedrock_agentcore_starter_toolkit.services.runtime import BedrockAgentCoreClient
+
+
+def main():
+    config_path = Path(__file__).parent / "config.toml"
+    if not config_path.exists():
+        raise SystemExit("config.toml not found — copy config.example.toml and fill in your values")
+    with open(config_path, "rb") as f:
+        config = tomllib.load(f)
+
+    agentcore_config = config["agentcore"]
+
+    agentcore_client = BedrockAgentCoreClient(region=agentcore_config["region"])
+
+    # The sandbox container needs no env vars — unlike the agent examples,
+    # the image only runs the sandboxd contract shim.
+    response = agentcore_client.create_agent(
+        agent_name=agentcore_config["agent_name"],
+        deployment_type="container",
+        image_uri=agentcore_config["image_uri"],
+        execution_role_arn=agentcore_config["execution_role_arn"],
+        network_config={"networkMode": "PUBLIC"},
+        env_vars={},
+        auto_update_on_conflict=True,
+    )
+
+    agent_id = response["id"]
+    agent_arn = response["arn"]
+
+    endpoint_response = agentcore_client.wait_for_agent_endpoint_ready(agent_id=agent_id, max_wait=120)
+    if agent_arn not in endpoint_response:
+        raise TimeoutError(endpoint_response)
+
+    print(f"Sandbox runtime ready: {agent_arn}")
+    print(f'\nRun the demo with:\n  SANDBOX_RUNTIME_ARN="{agent_arn}" python run_sandbox.py')
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sandbox_quickstart/pyproject.toml
+++ b/examples/sandbox_quickstart/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "sandbox-quickstart-example"
+version = "0.1.0"
+description = "Run shell commands in an arbitrary Docker image on AgentCore Runtime"
+requires-python = ">=3.11"
+dependencies = [
+    "agentcore-rl-toolkit>=0.1.3",
+    "bedrock-agentcore-starter-toolkit>=0.2.0",
+]
+
+[tool.setuptools]
+py-modules = ["run_sandbox", "deploy"]

--- a/examples/sandbox_quickstart/run_sandbox.py
+++ b/examples/sandbox_quickstart/run_sandbox.py
@@ -1,0 +1,31 @@
+"""Sandbox quickstart: start a sandbox session, run commands, terminate.
+
+Usage:
+    SANDBOX_RUNTIME_ARN=arn:aws:bedrock-agentcore:...:runtime/... python run_sandbox.py
+"""
+
+import os
+import sys
+
+from agentcore_rl_toolkit.sandbox import SandboxClient
+
+runtime_arn = os.environ.get("SANDBOX_RUNTIME_ARN")
+if not runtime_arn:
+    sys.exit("Set SANDBOX_RUNTIME_ARN to the ARN of your deployed sandbox runtime (see README.md)")
+
+client = SandboxClient(runtime_arn=runtime_arn)
+
+with client.start() as sb:
+    print(f"Sandbox session: {sb.session_id}")
+
+    result = sb.exec("echo hello from $(uname -m); pwd", timeout=60)
+    print(f"exit_code={result.exit_code} timed_out={result.timed_out}")
+    print(f"stdout: {result.stdout}")
+    print(f"stderr: {result.stderr}")
+
+    # Commands are stateless (fresh shell each call) — use cwd/env to
+    # re-establish state per call.
+    result = sb.exec("echo $GREETING from $PWD", cwd="/tmp", env={"GREETING": "hi"})
+    print(f"stdout: {result.stdout}")
+# Context exit terminates the sandbox (ping -> Healthy, then StopRuntimeSession).
+print("Sandbox terminated.")

--- a/sandboxd/README.md
+++ b/sandboxd/README.md
@@ -1,0 +1,46 @@
+# agentcore-sandboxd
+
+A minimal (stdlib-only) Go server that makes arbitrary Docker images satisfy the
+[Bedrock AgentCore Runtime container contract](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-http-protocol-contract.html)
+so they can be used as command-execution sandboxes.
+
+It does exactly one thing: hold a busy/healthy flag.
+
+- `GET /ping` → `{"status": "Healthy" | "HealthyBusy"}`. While `HealthyBusy`, AgentCore
+  keeps the runtime session alive past its idle timeout.
+- `POST /invocations` with `{"action": "start"}` → flips to busy; `{"action": "stop"}` →
+  flips back to healthy; `{"action": "status"}` → reports without changing state.
+  Unknown JSON fields are ignored (forward compatibility).
+
+Command execution is **not** handled here — the sandbox SDK
+(`agentcore_rl_toolkit.sandbox`) uses AgentCore Runtime's native
+`InvokeAgentRuntimeCommand` API, which runs shell commands in the container
+independently of this server.
+
+## Build
+
+```bash
+./build.sh                       # arm64 (AgentCore's platform), -> dist/agentcore-sandboxd-linux-arm64
+./build.sh --arch amd64          # for local testing on x86 hosts
+./build.sh --stage ../examples/sandbox_quickstart   # also copy into a Docker build context
+```
+
+Requires either a local Go toolchain (≥1.21) or Docker (the script falls back to
+building inside a `golang` container — no qemu needed, Go cross-compiles natively).
+
+## Test
+
+```bash
+go test -race ./...
+```
+
+## Local smoke test
+
+```bash
+go run . &
+curl -s localhost:8080/ping                                            # {"status":"Healthy"}
+curl -s -XPOST localhost:8080/invocations -d '{"action":"start"}'      # {"status":"ok","state":"busy"}
+curl -s localhost:8080/ping                                            # {"status":"HealthyBusy"}
+curl -s -XPOST localhost:8080/invocations -d '{"action":"stop"}'       # {"status":"ok","state":"healthy"}
+curl -s localhost:8080/ping                                            # {"status":"Healthy"}
+```

--- a/sandboxd/build.sh
+++ b/sandboxd/build.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Cross-compile agentcore-sandboxd as a static Linux binary.
+#
+# Usage:
+#   ./build.sh [--arch arm64|amd64] [--stage <dir>]
+#
+#   --arch   Target architecture (default: arm64 — AgentCore Runtime is arm64-only today).
+#   --stage  Additionally copy the built binary into <dir> (e.g. an example's Docker
+#            build context).
+#
+# Works on any host (including x86): Go cross-compiles natively, and if no Go
+# toolchain is installed the build runs inside a golang container instead (the
+# container runs natively on the host arch and cross-compiles — no qemu needed).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARCH="arm64"
+STAGE_DIR=""
+GO_IMAGE="public.ecr.aws/docker/library/golang:1.24"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arch)
+      ARCH="$2"
+      shift 2
+      ;;
+    --arch=*)
+      ARCH="${1#*=}"
+      shift
+      ;;
+    --stage)
+      STAGE_DIR="$2"
+      shift 2
+      ;;
+    --stage=*)
+      STAGE_DIR="${1#*=}"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--arch arm64|amd64] [--stage <dir>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$ARCH" != "arm64" && "$ARCH" != "amd64" ]]; then
+  echo "Unsupported --arch '$ARCH' (expected arm64 or amd64)" >&2
+  exit 1
+fi
+
+OUTPUT="dist/agentcore-sandboxd-linux-${ARCH}"
+
+if command -v go >/dev/null 2>&1; then
+  echo "Building with local Go toolchain ($(go version))..."
+  (cd "$SCRIPT_DIR" && CGO_ENABLED=0 GOOS=linux GOARCH="$ARCH" go build -ldflags "-s -w" -o "$OUTPUT" .)
+elif command -v docker >/dev/null 2>&1; then
+  echo "No local Go toolchain found; building inside $GO_IMAGE..."
+  docker run --rm -v "$SCRIPT_DIR":/src -w /src \
+    -e CGO_ENABLED=0 -e GOOS=linux -e GOARCH="$ARCH" -e GOFLAGS=-buildvcs=false \
+    "$GO_IMAGE" go build -ldflags "-s -w" -o "$OUTPUT" .
+else
+  echo "Neither 'go' nor 'docker' found on PATH." >&2
+  echo "Install Go (https://go.dev/dl/) or Docker, then re-run." >&2
+  exit 1
+fi
+
+echo "Built: $SCRIPT_DIR/$OUTPUT"
+
+if [[ -n "$STAGE_DIR" ]]; then
+  cp "$SCRIPT_DIR/$OUTPUT" "$STAGE_DIR/"
+  echo "Staged: $STAGE_DIR/$(basename "$OUTPUT")"
+fi

--- a/sandboxd/go.mod
+++ b/sandboxd/go.mod
@@ -1,0 +1,3 @@
+module github.com/awslabs/agentcore-rl-toolkit/sandboxd
+
+go 1.21

--- a/sandboxd/main.go
+++ b/sandboxd/main.go
@@ -1,0 +1,100 @@
+// agentcore-sandboxd is a minimal health shim that makes arbitrary Docker images
+// satisfy the Bedrock AgentCore Runtime container contract (port 8080, /ping,
+// /invocations) so they can be used as sandboxes for command execution.
+//
+// It holds a single busy/healthy flag driven by /invocations actions. Command
+// execution itself is NOT handled here — the SDK uses AgentCore Runtime's native
+// InvokeAgentRuntimeCommand API, which runs shell commands in this container
+// out-of-band of this server.
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"sync/atomic"
+)
+
+// serverState holds the busy flag reported via /ping. While busy, AgentCore
+// keeps the runtime session alive past its idle timeout ("HealthyBusy").
+type serverState struct {
+	busy atomic.Bool
+}
+
+// invocationRequest is the /invocations payload. Unknown JSON fields are
+// deliberately ignored so future clients (e.g. sending ttl_seconds) remain
+// compatible with this binary.
+type invocationRequest struct {
+	Action string `json:"action"`
+}
+
+func (s *serverState) stateName() string {
+	if s.busy.Load() {
+		return "busy"
+	}
+	return "healthy"
+}
+
+func writeJSON(w http.ResponseWriter, status int, body map[string]string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func (s *serverState) handlePing(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"status": "error", "error": "method not allowed"})
+		return
+	}
+	// Never include time_of_last_update: advancing it on every ping would
+	// prevent the session from ever idling out.
+	status := "Healthy"
+	if s.busy.Load() {
+		status = "HealthyBusy"
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": status})
+}
+
+func (s *serverState) handleInvocations(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"status": "error", "error": "method not allowed"})
+		return
+	}
+	var req invocationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"status": "error", "error": "malformed JSON body"})
+		return
+	}
+	switch req.Action {
+	case "start":
+		s.busy.Store(true)
+		log.Printf("sandbox started (state=busy)")
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "state": "busy"})
+	case "stop":
+		s.busy.Store(false)
+		log.Printf("sandbox stopped (state=healthy)")
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "state": "healthy"})
+	case "status":
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "state": s.stateName()})
+	case "":
+		writeJSON(w, http.StatusBadRequest, map[string]string{"status": "error", "error": "missing action"})
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"status": "error", "error": "unknown action: " + req.Action})
+	}
+}
+
+func newMux(s *serverState) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", s.handlePing)
+	mux.HandleFunc("/invocations", s.handleInvocations)
+	return mux
+}
+
+func main() {
+	s := &serverState{}
+	addr := "0.0.0.0:8080"
+	log.Printf("agentcore-sandboxd listening on %s", addr)
+	if err := http.ListenAndServe(addr, newMux(s)); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
+}

--- a/sandboxd/main_test.go
+++ b/sandboxd/main_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func newTestServer(t *testing.T) (*httptest.Server, *serverState) {
+	t.Helper()
+	s := &serverState{}
+	srv := httptest.NewServer(newMux(s))
+	t.Cleanup(srv.Close)
+	return srv, s
+}
+
+func getJSON(t *testing.T, url string) (int, map[string]string) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp.StatusCode, body
+}
+
+func postJSON(t *testing.T, url, payload string) (int, map[string]string) {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp.StatusCode, body
+}
+
+func TestPingInitiallyHealthy(t *testing.T) {
+	srv, _ := newTestServer(t)
+	code, body := getJSON(t, srv.URL+"/ping")
+	if code != http.StatusOK || body["status"] != "Healthy" {
+		t.Fatalf("got %d %v, want 200 Healthy", code, body)
+	}
+	if _, ok := body["time_of_last_update"]; ok {
+		t.Fatal("ping response must not include time_of_last_update")
+	}
+}
+
+func TestStartFlipsToBusy(t *testing.T) {
+	srv, _ := newTestServer(t)
+	code, body := postJSON(t, srv.URL+"/invocations", `{"action":"start"}`)
+	if code != http.StatusOK || body["status"] != "ok" || body["state"] != "busy" {
+		t.Fatalf("got %d %v, want 200 ok/busy", code, body)
+	}
+	_, ping := getJSON(t, srv.URL+"/ping")
+	if ping["status"] != "HealthyBusy" {
+		t.Fatalf("ping after start = %v, want HealthyBusy", ping)
+	}
+}
+
+func TestStopFlipsToHealthy(t *testing.T) {
+	srv, _ := newTestServer(t)
+	postJSON(t, srv.URL+"/invocations", `{"action":"start"}`)
+	code, body := postJSON(t, srv.URL+"/invocations", `{"action":"stop"}`)
+	if code != http.StatusOK || body["state"] != "healthy" {
+		t.Fatalf("got %d %v, want 200 healthy", code, body)
+	}
+	_, ping := getJSON(t, srv.URL+"/ping")
+	if ping["status"] != "Healthy" {
+		t.Fatalf("ping after stop = %v, want Healthy", ping)
+	}
+}
+
+func TestStatusDoesNotMutate(t *testing.T) {
+	srv, s := newTestServer(t)
+	code, body := postJSON(t, srv.URL+"/invocations", `{"action":"status"}`)
+	if code != http.StatusOK || body["state"] != "healthy" {
+		t.Fatalf("got %d %v, want 200 healthy", code, body)
+	}
+	if s.busy.Load() {
+		t.Fatal("status action must not change state")
+	}
+	postJSON(t, srv.URL+"/invocations", `{"action":"start"}`)
+	_, body = postJSON(t, srv.URL+"/invocations", `{"action":"status"}`)
+	if body["state"] != "busy" {
+		t.Fatalf("status after start = %v, want busy", body)
+	}
+	if !s.busy.Load() {
+		t.Fatal("status action must not change state")
+	}
+}
+
+func TestStartStopIdempotent(t *testing.T) {
+	srv, _ := newTestServer(t)
+	for i := 0; i < 2; i++ {
+		code, body := postJSON(t, srv.URL+"/invocations", `{"action":"start"}`)
+		if code != http.StatusOK || body["state"] != "busy" {
+			t.Fatalf("start #%d: got %d %v", i+1, code, body)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		code, body := postJSON(t, srv.URL+"/invocations", `{"action":"stop"}`)
+		if code != http.StatusOK || body["state"] != "healthy" {
+			t.Fatalf("stop #%d: got %d %v", i+1, code, body)
+		}
+	}
+}
+
+func TestUnknownFieldsIgnored(t *testing.T) {
+	// Forward compatibility: a Phase 1 client sending ttl_seconds must work
+	// against this binary.
+	srv, _ := newTestServer(t)
+	code, body := postJSON(t, srv.URL+"/invocations", `{"action":"start","ttl_seconds":60}`)
+	if code != http.StatusOK || body["state"] != "busy" {
+		t.Fatalf("got %d %v, want 200 busy", code, body)
+	}
+}
+
+func TestBadRequests(t *testing.T) {
+	srv, _ := newTestServer(t)
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"unknown action", `{"action":"reboot"}`},
+		{"missing action", `{}`},
+		{"malformed JSON", `{not json`},
+	}
+	for _, tc := range cases {
+		code, body := postJSON(t, srv.URL+"/invocations", tc.payload)
+		if code != http.StatusBadRequest || body["status"] != "error" {
+			t.Fatalf("%s: got %d %v, want 400 error", tc.name, code, body)
+		}
+	}
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	code, _ := postJSON(t, srv.URL+"/ping", `{}`)
+	if code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /ping: got %d, want 405", code)
+	}
+	code, _ = getJSON(t, srv.URL+"/invocations")
+	if code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET /invocations: got %d, want 405", code)
+	}
+}
+
+func TestConcurrentStartStop(t *testing.T) {
+	srv, _ := newTestServer(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		action := `{"action":"start"}`
+		if i%2 == 0 {
+			action = `{"action":"stop"}`
+		}
+		go func(payload string) {
+			defer wg.Done()
+			resp, err := http.Post(srv.URL+"/invocations", "application/json", strings.NewReader(payload))
+			if err == nil {
+				resp.Body.Close()
+			}
+		}(action)
+	}
+	wg.Wait()
+	// State must be one of the two valid values; -race verifies no data race.
+	_, ping := getJSON(t, srv.URL+"/ping")
+	if ping["status"] != "Healthy" && ping["status"] != "HealthyBusy" {
+		t.Fatalf("ping after concurrent ops = %v", ping)
+	}
+}

--- a/src/agentcore_rl_toolkit/sandbox/__init__.py
+++ b/src/agentcore_rl_toolkit/sandbox/__init__.py
@@ -1,0 +1,16 @@
+"""Sandbox SDK: run shell commands in arbitrary Docker images on AgentCore Runtime.
+
+Pairs with the ``agentcore-sandboxd`` health shim (see ``sandboxd/`` at the repo
+root), which makes any image satisfy the AgentCore Runtime container contract.
+Command execution uses AgentCore Runtime's native ``InvokeAgentRuntimeCommand``.
+"""
+
+from .client import Sandbox, SandboxClient
+from .types import ExecResult, SandboxProtocolError
+
+__all__ = [
+    "SandboxClient",
+    "Sandbox",
+    "ExecResult",
+    "SandboxProtocolError",
+]

--- a/src/agentcore_rl_toolkit/sandbox/client.py
+++ b/src/agentcore_rl_toolkit/sandbox/client.py
@@ -1,0 +1,352 @@
+"""Sync client for running shell commands in AgentCore Runtime sandbox sessions.
+
+A "sandbox" is an AgentCore Runtime session whose container runs the
+``agentcore-sandboxd`` health shim (see ``sandboxd/`` at the repo root). The
+shim only manages the Healthy/HealthyBusy ping state; command execution goes
+through AgentCore Runtime's native ``InvokeAgentRuntimeCommand`` API, which runs
+shell commands inside the same session/container.
+
+Usage:
+    from agentcore_rl_toolkit.sandbox import SandboxClient
+
+    client = SandboxClient(runtime_arn="arn:aws:bedrock-agentcore:...")
+    with client.start() as sb:
+        result = sb.exec("cd /app && pytest -q", timeout=900)
+        print(result.exit_code, result.stdout)
+"""
+
+import json
+import logging
+import re
+import shlex
+import uuid
+
+import boto3
+from botocore.config import Config
+
+from .types import ExecResult, SandboxProtocolError
+
+logger = logging.getLogger(__name__)
+
+# runtimeSessionId constraints from the bedrock-agentcore service model.
+_SESSION_ID_MIN_LEN = 33
+_SESSION_ID_MAX_LEN = 256
+
+_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _wrap_in_shell(command: str, shell: str = "/bin/sh") -> str:
+    """Wrap a shell command string for InvokeAgentRuntimeCommand.
+
+    The command API does NOT interpret the command through a shell — it
+    word-splits argv-style, passing ``;``, ``|``, ``$VAR`` etc. through as
+    literal arguments (verified against the live service; every example in the
+    official docs likewise wraps commands, in ``/bin/bash -c "..."``:
+    https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-execute-command.html).
+    Shell semantics therefore require an explicit ``<shell> -c`` wrapper.
+
+    We default to ``/bin/sh`` rather than the docs' ``/bin/bash`` because the
+    sandbox use case targets arbitrary images: POSIX sh exists in any image
+    with a shell at all (including busybox/alpine), while bash is often absent
+    from minimal images.
+
+    Wrapper quoting, per the service tokenizer's semantics (live-verified):
+
+    - Single-quoted args pass through fully verbatim (backslashes untouched),
+      but POSIX quote concatenation (``'it'"'"'s'``) is NOT supported — so the
+      single-quote wrapper only fits commands without single quotes.
+    - Double-quoted args support ``\\"`` and ``\\\\`` escapes, and the tokenizer
+      does NOT expand ``$`` or backticks (they reach the inner shell, which
+      expands them — the semantics we want). Escaping ``\\`` and ``"`` therefore
+      round-trips any command exactly.
+
+    Both forms keep the wire format human-readable — the service logs the input
+    command to the runtime's CloudWatch log group for auditing.
+    """
+    if "'" not in command:
+        return f"{shell} -c '{command}'"
+    escaped = command.replace("\\", "\\\\").replace('"', '\\"')
+    return f'{shell} -c "{escaped}"'
+
+
+def _compose_command(command: str, cwd: str = None, env: dict = None) -> str:
+    """Compose cwd/env into a shell command string.
+
+    Commands are stateless — each ``InvokeAgentRuntimeCommand`` runs in a fresh
+    shell, so working directory and environment variables must be re-established
+    per call. The user command is appended raw (it is already a shell string);
+    only ``cwd`` and env values are quoted.
+
+    Args:
+        command: The shell command to run.
+        cwd: Working directory to ``cd`` into first.
+        env: Environment variables to export first. Keys must be valid shell
+            identifiers; values are shell-quoted.
+
+    Returns:
+        The composed command string.
+
+    Raises:
+        ValueError: If an env key is not a valid shell identifier.
+    """
+    prefix = ""
+    if cwd is not None:
+        prefix += f"cd {shlex.quote(cwd)} && "
+    if env:
+        for key in env:
+            if not _ENV_KEY_RE.match(key):
+                raise ValueError(f"Invalid environment variable name: {key!r}")
+        exports = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env.items())
+        prefix += f"export {exports}; "
+    return prefix + command
+
+
+class SandboxClient:
+    """Client bound to a deployed sandbox runtime (data plane).
+
+    Manages per-session lifecycle against an AgentCore runtime that was already
+    created from a sandboxd-wrapped image: ``start()`` a new sandbox session,
+    ``attach()`` to a live one, and run commands via ``Sandbox.exec()``.
+
+    Args:
+        runtime_arn: ARN of the deployed AgentCore runtime.
+        region: AWS region. Defaults to the region parsed from ``runtime_arn``.
+        qualifier: Runtime endpoint qualifier.
+        max_retry_attempts: Max boto3 retry attempts (adaptive mode).
+        max_pool_connections: Max boto3 connection pool size.
+        shell: Shell used to interpret ``exec()`` commands in the container.
+            Defaults to ``/bin/sh`` (present in any image with a shell,
+            including busybox/alpine); set to ``/bin/bash`` if your image has
+            bash and your commands use bashisms. Overridable per call via
+            ``Sandbox.exec(shell=...)``.
+    """
+
+    @staticmethod
+    def _parse_region_from_arn(arn: str) -> str:
+        """Extract AWS region from an ARN.
+
+        ARN format: arn:partition:service:region:account-id:resource-type/resource-id
+
+        Args:
+            arn: The ARN to parse
+
+        Returns:
+            The region string (e.g., "us-west-2")
+
+        Raises:
+            ValueError: If the ARN format is invalid
+        """
+        parts = arn.split(":")
+        if len(parts) < 4 or not parts[3]:
+            raise ValueError(f"Invalid ARN format, cannot extract region: {arn}")
+        return parts[3]
+
+    def __init__(
+        self,
+        runtime_arn: str,
+        region: str = None,
+        qualifier: str = "DEFAULT",
+        max_retry_attempts: int = 5,
+        max_pool_connections: int = 10,
+        shell: str = "/bin/sh",
+    ):
+        self.runtime_arn = runtime_arn
+        self.region = region or self._parse_region_from_arn(runtime_arn)
+        self.qualifier = qualifier
+        self.shell = shell
+
+        config = Config(
+            retries={"max_attempts": max_retry_attempts, "mode": "adaptive"},
+            max_pool_connections=max_pool_connections,
+        )
+        self._client = boto3.client("bedrock-agentcore", region_name=self.region, config=config)
+
+    def start(self, session_id: str = None) -> "Sandbox":
+        """Start a new sandbox session and flip its ping state to HealthyBusy.
+
+        Sends ``{"action": "start"}`` to the runtime's ``/invocations`` endpoint.
+        The first invocation with a fresh session id provisions the microVM.
+
+        Args:
+            session_id: Session id to use. Defaults to a generated UUID (the
+                service requires 33-256 characters; a UUID string is 36).
+
+        Returns:
+            A ``Sandbox`` handle, usable as a context manager (``__exit__``
+            calls ``terminate()``).
+
+        Raises:
+            SandboxProtocolError: If the runtime's response is not the expected
+                sandboxd handshake — usually a sign that a non-sandboxd image
+                was deployed to this runtime.
+        """
+        session_id = session_id or str(uuid.uuid4())
+        response = self._client.invoke_agent_runtime(
+            agentRuntimeArn=self.runtime_arn,
+            runtimeSessionId=session_id,
+            qualifier=self.qualifier,
+            payload=json.dumps({"action": "start"}),
+        )
+        raw = response["response"].read()
+        try:
+            body = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise SandboxProtocolError(
+                f"Sandbox start returned a non-JSON response (is a sandboxd image deployed?): {raw[:500]!r}"
+            ) from None
+        if not isinstance(body, dict) or body.get("status") != "ok":
+            raise SandboxProtocolError(f"Unexpected sandbox start response: {body!r}")
+        logger.info(f"Started sandbox session {session_id[:8]}...")
+        return Sandbox(self, session_id)
+
+    def attach(self, session_id: str) -> "Sandbox":
+        """Attach to a live sandbox session without invoking the runtime.
+
+        Args:
+            session_id: Id of an existing session (33-256 characters).
+
+        Returns:
+            A ``Sandbox`` handle for the session.
+
+        Raises:
+            ValueError: If ``session_id`` does not satisfy the service's length
+                constraints.
+        """
+        if not (_SESSION_ID_MIN_LEN <= len(session_id) <= _SESSION_ID_MAX_LEN):
+            raise ValueError(
+                f"session_id must be {_SESSION_ID_MIN_LEN}-{_SESSION_ID_MAX_LEN} characters, " f"got {len(session_id)}"
+            )
+        return Sandbox(self, session_id)
+
+
+class Sandbox:
+    """Handle to one sandbox session. Create via ``SandboxClient.start()`` or ``attach()``.
+
+    Usable as a context manager: ``__exit__`` calls ``terminate()`` and never
+    suppresses exceptions.
+    """
+
+    def __init__(self, client: SandboxClient, session_id: str):
+        self._client = client
+        self.session_id = session_id
+        self._terminated = False
+
+    def exec(
+        self, command: str, timeout: int = None, cwd: str = None, env: dict = None, shell: str = None
+    ) -> ExecResult:
+        """Run a shell command in the sandbox and wait for it to complete.
+
+        Nonzero exit codes and timeouts are returned as data on ``ExecResult``,
+        never raised. Infrastructure failures raise: ``botocore`` ``ClientError``
+        (throttling, session not found) from the call itself,
+        ``EventStreamError`` if botocore surfaces an in-stream error event as an
+        exception, or ``SandboxProtocolError`` if an error event arrives as a
+        stream member or the stream ends without a result.
+
+        Commands are stateless — each call runs in a fresh shell. Use ``cwd``
+        and ``env`` to re-establish state per call; they are composed into the
+        command string (``cd ... && export ...; <command>``).
+
+        The command is interpreted by a shell (default ``/bin/sh``): pipes,
+        ``;``, variable expansion and command substitution all work. (On the
+        wire the SDK wraps it in ``<shell> -c`` because the command API itself
+        does not invoke a shell — see ``_wrap_in_shell``.)
+
+        Args:
+            command: Shell command string to execute.
+            timeout: Server-enforced timeout in seconds (1-3600, service default
+                300). On expiry the command is terminated and the result has
+                ``timed_out=True`` with any partial output.
+            cwd: Working directory for the command.
+            env: Environment variables for the command. Keys must be valid shell
+                identifiers.
+            shell: Shell for this command. Defaults to the client's ``shell``
+                (``/bin/sh`` unless configured otherwise).
+
+        Returns:
+            An ``ExecResult`` with exit code, accumulated stdout/stderr, and the
+            timeout flag.
+        """
+        composed = _compose_command(command, cwd=cwd, env=env)
+        body = {"command": _wrap_in_shell(composed, shell=shell or self._client.shell)}
+        if timeout is not None:
+            body["timeout"] = timeout
+
+        response = self._client._client.invoke_agent_runtime_command(
+            agentRuntimeArn=self._client.runtime_arn,
+            runtimeSessionId=self.session_id,
+            qualifier=self._client.qualifier,
+            body=body,
+        )
+
+        stdout_parts = []
+        stderr_parts = []
+        exit_code = None
+        status = None
+        for event in response["stream"]:
+            chunk = event.get("chunk")
+            if chunk is None:
+                # Error events (throttlingException, runtimeClientError, ...) can
+                # arrive as stream members; botocore may instead raise
+                # EventStreamError, which propagates from the iteration above.
+                raise SandboxProtocolError(f"Error event in command stream: {event!r}")
+            if "contentDelta" in chunk:
+                delta = chunk["contentDelta"]
+                if delta.get("stdout"):
+                    stdout_parts.append(delta["stdout"])
+                if delta.get("stderr"):
+                    stderr_parts.append(delta["stderr"])
+            elif "contentStop" in chunk:
+                exit_code = chunk["contentStop"]["exitCode"]
+                status = chunk["contentStop"]["status"]
+            # contentStart: ignore
+
+        if exit_code is None:
+            raise SandboxProtocolError("Command stream ended without a result (no contentStop event)")
+
+        return ExecResult(
+            exit_code=exit_code,
+            stdout="".join(stdout_parts),
+            stderr="".join(stderr_parts),
+            timed_out=(status == "TIMED_OUT"),
+        )
+
+    def terminate(self):
+        """Terminate the sandbox session (idempotent, best-effort).
+
+        Two steps, both best-effort: flip the ping state back to Healthy via
+        ``{"action": "stop"}`` (so that even if the subsequent stop call fails,
+        the idle reaper collects the session within the idle timeout), then call
+        ``StopRuntimeSession``. Failures are logged as warnings, never raised —
+        this must be safe to call from ``__exit__``.
+        """
+        if self._terminated:
+            return
+        self._terminated = True
+
+        try:
+            response = self._client._client.invoke_agent_runtime(
+                agentRuntimeArn=self._client.runtime_arn,
+                runtimeSessionId=self.session_id,
+                qualifier=self._client.qualifier,
+                payload=json.dumps({"action": "stop"}),
+            )
+            response["response"].read()
+        except Exception as e:
+            logger.warning(f"Failed to send stop action to sandbox {self.session_id[:8]}...: {e}")
+
+        try:
+            self._client._client.stop_runtime_session(
+                agentRuntimeArn=self._client.runtime_arn,
+                runtimeSessionId=self.session_id,
+                clientToken=str(uuid.uuid4()),
+            )
+            logger.info(f"Terminated sandbox session {self.session_id[:8]}...")
+        except Exception as e:
+            logger.warning(f"Failed to stop runtime session {self.session_id[:8]}...: {e}")
+
+    def __enter__(self) -> "Sandbox":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.terminate()

--- a/src/agentcore_rl_toolkit/sandbox/client.py
+++ b/src/agentcore_rl_toolkit/sandbox/client.py
@@ -268,7 +268,17 @@ class Sandbox:
         Returns:
             An ``ExecResult`` with exit code, accumulated stdout/stderr, and the
             timeout flag.
+
+        Raises:
+            RuntimeError: If the sandbox has been terminated. (After
+                ``StopRuntimeSession`` the session id remains valid, so an
+                unguarded exec would silently provision a fresh microVM and run
+                against empty state instead of failing.)
         """
+        if self._terminated:
+            raise RuntimeError(
+                f"Sandbox {self.session_id[:8]}... is terminated; use SandboxClient.start() for a new session"
+            )
         composed = _compose_command(command, cwd=cwd, env=env)
         body = {"command": _wrap_in_shell(composed, shell=shell or self._client.shell)}
         if timeout is not None:

--- a/src/agentcore_rl_toolkit/sandbox/client.py
+++ b/src/agentcore_rl_toolkit/sandbox/client.py
@@ -97,7 +97,9 @@ def _compose_command(command: str, cwd: str = None, env: dict = None) -> str:
             if not _ENV_KEY_RE.match(key):
                 raise ValueError(f"Invalid environment variable name: {key!r}")
         exports = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env.items())
-        prefix += f"export {exports}; "
+        # && (not ;) so a failed cd cannot fall through to running the command
+        # in the wrong directory with a clean exit code.
+        prefix += f"export {exports} && "
     return prefix + command
 
 
@@ -245,7 +247,7 @@ class Sandbox:
 
         Commands are stateless — each call runs in a fresh shell. Use ``cwd``
         and ``env`` to re-establish state per call; they are composed into the
-        command string (``cd ... && export ...; <command>``).
+        command string (``cd ... && export ... && <command>``).
 
         The command is interpreted by a shell (default ``/bin/sh``): pipes,
         ``;``, variable expansion and command substitution all work. (On the
@@ -339,6 +341,7 @@ class Sandbox:
             self._client._client.stop_runtime_session(
                 agentRuntimeArn=self._client.runtime_arn,
                 runtimeSessionId=self.session_id,
+                qualifier=self._client.qualifier,
                 clientToken=str(uuid.uuid4()),
             )
             logger.info(f"Terminated sandbox session {self.session_id[:8]}...")

--- a/src/agentcore_rl_toolkit/sandbox/types.py
+++ b/src/agentcore_rl_toolkit/sandbox/types.py
@@ -1,0 +1,36 @@
+"""Data types for the sandbox SDK."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ExecResult:
+    """Result of a completed sandbox command.
+
+    Nonzero exit codes and timeouts are normal results, not errors — eval and RL
+    workloads expect failing commands (that is the reward signal). Exceptions are
+    reserved for infrastructure failures (throttling, session not found, network).
+
+    Attributes:
+        exit_code: The command's exit code, passed through verbatim from the
+            service (``contentStop.exitCode``). ``-1`` indicates a platform error.
+        stdout: Accumulated standard output.
+        stderr: Accumulated standard error.
+        timed_out: True if the command hit its server-enforced timeout
+            (``status == "TIMED_OUT"``). Partial output produced before the
+            timeout is retained in ``stdout``/``stderr``.
+    """
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    timed_out: bool
+
+
+class SandboxProtocolError(RuntimeError):
+    """Unexpected response or stream from the sandbox runtime.
+
+    Raised when the deployed container does not behave like agentcore-sandboxd
+    (e.g. an agent image was deployed instead), when an error event arrives
+    in a command stream, or when a command stream ends without a result.
+    """

--- a/tests/sandbox/test_client.py
+++ b/tests/sandbox/test_client.py
@@ -189,7 +189,7 @@ class TestExec:
         mock_acr.invoke_agent_runtime_command.return_value = make_command_response()
         client.attach(FAKE_SESSION_ID).exec("pytest -q", cwd="/app", env={"FOO": "bar"})
         body = mock_acr.invoke_agent_runtime_command.call_args.kwargs["body"]
-        assert body["command"] == "/bin/sh -c 'cd /app && export FOO=bar; pytest -q'"
+        assert body["command"] == "/bin/sh -c 'cd /app && export FOO=bar && pytest -q'"
 
     def test_client_level_shell(self):
         with patch("agentcore_rl_toolkit.sandbox.client.boto3") as mock_boto3:
@@ -263,7 +263,19 @@ class TestTerminate:
         kwargs = mock_acr.stop_runtime_session.call_args.kwargs
         assert kwargs["agentRuntimeArn"] == FAKE_ARN
         assert kwargs["runtimeSessionId"] == FAKE_SESSION_ID
+        assert kwargs["qualifier"] == "DEFAULT"
         assert kwargs["clientToken"]
+
+    def test_terminate_forwards_custom_qualifier(self):
+        """A non-DEFAULT qualifier must reach stop_runtime_session, not just start/exec."""
+        with patch("agentcore_rl_toolkit.sandbox.client.boto3") as mock_boto3:
+            mock_acr = MagicMock()
+            mock_boto3.client.return_value = mock_acr
+            client = SandboxClient(runtime_arn=FAKE_ARN, qualifier="prod-endpoint")
+        mock_acr.invoke_agent_runtime.return_value = make_start_response({"status": "ok", "state": "healthy"})
+        client.attach(FAKE_SESSION_ID).terminate()
+        assert mock_acr.invoke_agent_runtime.call_args.kwargs["qualifier"] == "prod-endpoint"
+        assert mock_acr.stop_runtime_session.call_args.kwargs["qualifier"] == "prod-endpoint"
 
     def test_stop_action_failure_still_stops_session(self):
         client, mock_acr = make_client_and_mock()

--- a/tests/sandbox/test_client.py
+++ b/tests/sandbox/test_client.py
@@ -303,6 +303,24 @@ class TestTerminate:
         assert mock_acr.invoke_agent_runtime.call_count == 1
 
 
+class TestExecAfterTerminate:
+    def test_exec_after_terminate_raises(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime.return_value = make_start_response({"status": "ok", "state": "healthy"})
+        sandbox = client.attach(FAKE_SESSION_ID)
+        sandbox.terminate()
+        with pytest.raises(RuntimeError, match="is terminated"):
+            sandbox.exec("echo hi")
+        mock_acr.invoke_agent_runtime_command.assert_not_called()
+
+    def test_exec_after_context_exit_raises(self):
+        client, _ = make_client_and_mock(make_start_response())
+        with client.start() as sandbox:
+            pass
+        with pytest.raises(RuntimeError, match="is terminated"):
+            sandbox.exec("echo hi")
+
+
 class TestContextManager:
     def test_exit_terminates(self):
         client, mock_acr = make_client_and_mock(make_start_response())

--- a/tests/sandbox/test_client.py
+++ b/tests/sandbox/test_client.py
@@ -1,0 +1,307 @@
+"""Tests for SandboxClient and Sandbox with mocked boto3."""
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError, EventStreamError
+
+from agentcore_rl_toolkit.sandbox import Sandbox, SandboxClient, SandboxProtocolError
+
+FAKE_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/sandbox-test"
+FAKE_SESSION_ID = "a" * 40
+
+
+def mock_streaming_body(data: dict) -> io.BytesIO:
+    """Create a mock StreamingBody-like object for /invocations responses."""
+    return io.BytesIO(json.dumps(data).encode())
+
+
+def make_start_response(body: dict = None) -> dict:
+    return {"response": mock_streaming_body(body if body is not None else {"status": "ok", "state": "busy"})}
+
+
+def make_command_response(deltas: list = None, exit_code: int = 0, status: str = "COMPLETED") -> dict:
+    """Build a fake invoke_agent_runtime_command response with an eventstream.
+
+    Botocore eventstreams are iterables of event dicts; a plain list suffices.
+    """
+    events = [{"chunk": {"contentStart": {}}}]
+    for delta in deltas or []:
+        events.append({"chunk": {"contentDelta": delta}})
+    events.append({"chunk": {"contentStop": {"exitCode": exit_code, "status": status}}})
+    return {"stream": events}
+
+
+def make_client_and_mock(start_response: dict = None):
+    """Create a SandboxClient with a mocked bedrock-agentcore client."""
+    with patch("agentcore_rl_toolkit.sandbox.client.boto3") as mock_boto3:
+        mock_acr = MagicMock()
+        mock_boto3.client.return_value = mock_acr
+        client = SandboxClient(runtime_arn=FAKE_ARN)
+    if start_response is not None:
+        mock_acr.invoke_agent_runtime.return_value = start_response
+    return client, mock_acr
+
+
+class TestSandboxClientInit:
+    def test_region_parsed_from_arn(self):
+        client, _ = make_client_and_mock()
+        assert client.region == "us-west-2"
+
+    def test_explicit_region_wins(self):
+        with patch("agentcore_rl_toolkit.sandbox.client.boto3"):
+            client = SandboxClient(runtime_arn=FAKE_ARN, region="eu-west-1")
+        assert client.region == "eu-west-1"
+
+    def test_invalid_arn_raises(self):
+        with pytest.raises(ValueError, match="Invalid ARN format"):
+            SandboxClient(runtime_arn="not-an-arn")
+
+    def test_default_qualifier(self):
+        client, _ = make_client_and_mock()
+        assert client.qualifier == "DEFAULT"
+
+    def test_boto3_client_config(self):
+        with patch("agentcore_rl_toolkit.sandbox.client.boto3") as mock_boto3:
+            SandboxClient(runtime_arn=FAKE_ARN, max_retry_attempts=7)
+        args, kwargs = mock_boto3.client.call_args
+        assert args == ("bedrock-agentcore",)
+        assert kwargs["region_name"] == "us-west-2"
+        assert kwargs["config"].retries == {"max_attempts": 7, "mode": "adaptive"}
+
+
+class TestStart:
+    def test_start_invokes_runtime_with_start_action(self):
+        client, mock_acr = make_client_and_mock(make_start_response())
+        sandbox = client.start()
+        kwargs = mock_acr.invoke_agent_runtime.call_args.kwargs
+        assert kwargs["agentRuntimeArn"] == FAKE_ARN
+        assert kwargs["qualifier"] == "DEFAULT"
+        assert json.loads(kwargs["payload"]) == {"action": "start"}
+        assert isinstance(sandbox, Sandbox)
+
+    def test_generated_session_id_long_enough(self):
+        client, mock_acr = make_client_and_mock(make_start_response())
+        sandbox = client.start()
+        assert len(sandbox.session_id) >= 33
+        assert mock_acr.invoke_agent_runtime.call_args.kwargs["runtimeSessionId"] == sandbox.session_id
+
+    def test_explicit_session_id_honored(self):
+        client, _ = make_client_and_mock(make_start_response())
+        sandbox = client.start(session_id=FAKE_SESSION_ID)
+        assert sandbox.session_id == FAKE_SESSION_ID
+
+    def test_extra_response_fields_ignored(self):
+        client, _ = make_client_and_mock(make_start_response({"status": "ok", "state": "busy", "future": "field"}))
+        client.start()  # no raise
+
+    def test_non_json_response_raises(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime.return_value = {"response": io.BytesIO(b"<html>not json</html>")}
+        with pytest.raises(SandboxProtocolError, match="non-JSON"):
+            client.start()
+
+    def test_error_status_response_raises(self):
+        client, _ = make_client_and_mock(make_start_response({"status": "error", "error": "boom"}))
+        with pytest.raises(SandboxProtocolError, match="Unexpected sandbox start response"):
+            client.start()
+
+    def test_client_error_propagates(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime.side_effect = ClientError(
+            {"Error": {"Code": "ThrottlingException", "Message": "slow down"}}, "InvokeAgentRuntime"
+        )
+        with pytest.raises(ClientError):
+            client.start()
+
+
+class TestAttach:
+    def test_attach_makes_no_api_call(self):
+        client, mock_acr = make_client_and_mock()
+        sandbox = client.attach(FAKE_SESSION_ID)
+        assert sandbox.session_id == FAKE_SESSION_ID
+        mock_acr.invoke_agent_runtime.assert_not_called()
+
+    def test_short_session_id_raises(self):
+        client, _ = make_client_and_mock()
+        with pytest.raises(ValueError, match="33-256 characters"):
+            client.attach("too-short")
+
+
+class TestExec:
+    def test_happy_path_accumulates_output(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.return_value = make_command_response(
+            deltas=[{"stdout": "hello "}, {"stdout": "world"}, {"stderr": "warn"}],
+        )
+        result = client.attach(FAKE_SESSION_ID).exec("echo hello world")
+        assert result.exit_code == 0
+        assert result.stdout == "hello world"
+        assert result.stderr == "warn"
+        assert result.timed_out is False
+
+    def test_nonzero_exit_is_data(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.return_value = make_command_response(
+            deltas=[{"stderr": "tests failed"}], exit_code=1
+        )
+        result = client.attach(FAKE_SESSION_ID).exec("pytest -q")
+        assert result.exit_code == 1
+        assert result.timed_out is False
+
+    def test_timed_out_is_data_with_partial_output(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.return_value = make_command_response(
+            deltas=[{"stdout": "partial"}], exit_code=-1, status="TIMED_OUT"
+        )
+        result = client.attach(FAKE_SESSION_ID).exec("sleep 999", timeout=1)
+        assert result.timed_out is True
+        assert result.exit_code == -1
+        assert result.stdout == "partial"
+
+    def test_mixed_delta_in_one_event(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.return_value = make_command_response(
+            deltas=[{"stdout": "out", "stderr": "err"}],
+        )
+        result = client.attach(FAKE_SESSION_ID).exec("cmd")
+        assert result.stdout == "out"
+        assert result.stderr == "err"
+
+    def test_timeout_forwarded_in_body(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.return_value = make_command_response()
+        client.attach(FAKE_SESSION_ID).exec("cmd", timeout=600)
+        body = mock_acr.invoke_agent_runtime_command.call_args.kwargs["body"]
+        assert body == {"command": "/bin/sh -c 'cmd'", "timeout": 600}
+
+    def test_timeout_omitted_when_none(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.return_value = make_command_response()
+        client.attach(FAKE_SESSION_ID).exec("cmd")
+        body = mock_acr.invoke_agent_runtime_command.call_args.kwargs["body"]
+        assert body == {"command": "/bin/sh -c 'cmd'"}
+
+    def test_cwd_and_env_composed(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.return_value = make_command_response()
+        client.attach(FAKE_SESSION_ID).exec("pytest -q", cwd="/app", env={"FOO": "bar"})
+        body = mock_acr.invoke_agent_runtime_command.call_args.kwargs["body"]
+        assert body["command"] == "/bin/sh -c 'cd /app && export FOO=bar; pytest -q'"
+
+    def test_client_level_shell(self):
+        with patch("agentcore_rl_toolkit.sandbox.client.boto3") as mock_boto3:
+            mock_acr = MagicMock()
+            mock_boto3.client.return_value = mock_acr
+            client = SandboxClient(runtime_arn=FAKE_ARN, shell="/bin/bash")
+        mock_acr.invoke_agent_runtime_command.return_value = make_command_response()
+        client.attach(FAKE_SESSION_ID).exec("cmd")
+        body = mock_acr.invoke_agent_runtime_command.call_args.kwargs["body"]
+        assert body["command"] == "/bin/bash -c 'cmd'"
+
+    def test_per_exec_shell_overrides_client(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.return_value = make_command_response()
+        client.attach(FAKE_SESSION_ID).exec("cmd", shell="/bin/bash")
+        body = mock_acr.invoke_agent_runtime_command.call_args.kwargs["body"]
+        assert body["command"] == "/bin/bash -c 'cmd'"
+
+    def test_session_and_arn_forwarded(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.return_value = make_command_response()
+        client.attach(FAKE_SESSION_ID).exec("cmd")
+        kwargs = mock_acr.invoke_agent_runtime_command.call_args.kwargs
+        assert kwargs["agentRuntimeArn"] == FAKE_ARN
+        assert kwargs["runtimeSessionId"] == FAKE_SESSION_ID
+        assert kwargs["qualifier"] == "DEFAULT"
+
+    def test_error_event_in_stream_raises(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.return_value = {
+            "stream": [{"throttlingException": {"message": "too fast"}}]
+        }
+        with pytest.raises(SandboxProtocolError, match="Error event in command stream"):
+            client.attach(FAKE_SESSION_ID).exec("cmd")
+
+    def test_eventstream_error_propagates(self):
+        client, mock_acr = make_client_and_mock()
+
+        def raising_stream():
+            yield {"chunk": {"contentStart": {}}}
+            raise EventStreamError({"Error": {"Code": "InternalServerException", "Message": "boom"}}, "ResponseStream")
+
+        mock_acr.invoke_agent_runtime_command.return_value = {"stream": raising_stream()}
+        with pytest.raises(EventStreamError):
+            client.attach(FAKE_SESSION_ID).exec("cmd")
+
+    def test_stream_without_content_stop_raises(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.return_value = {
+            "stream": [{"chunk": {"contentStart": {}}}, {"chunk": {"contentDelta": {"stdout": "x"}}}]
+        }
+        with pytest.raises(SandboxProtocolError, match="without a result"):
+            client.attach(FAKE_SESSION_ID).exec("cmd")
+
+    def test_client_error_propagates(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime_command.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "no session"}}, "InvokeAgentRuntimeCommand"
+        )
+        with pytest.raises(ClientError):
+            client.attach(FAKE_SESSION_ID).exec("cmd")
+
+
+class TestTerminate:
+    def test_terminate_sends_stop_then_stops_session(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime.return_value = make_start_response({"status": "ok", "state": "healthy"})
+        client.attach(FAKE_SESSION_ID).terminate()
+        payload = json.loads(mock_acr.invoke_agent_runtime.call_args.kwargs["payload"])
+        assert payload == {"action": "stop"}
+        kwargs = mock_acr.stop_runtime_session.call_args.kwargs
+        assert kwargs["agentRuntimeArn"] == FAKE_ARN
+        assert kwargs["runtimeSessionId"] == FAKE_SESSION_ID
+        assert kwargs["clientToken"]
+
+    def test_stop_action_failure_still_stops_session(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime.side_effect = ClientError(
+            {"Error": {"Code": "RuntimeClientError", "Message": "gone"}}, "InvokeAgentRuntime"
+        )
+        client.attach(FAKE_SESSION_ID).terminate()  # no raise
+        mock_acr.stop_runtime_session.assert_called_once()
+
+    def test_stop_session_failure_swallowed(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime.return_value = make_start_response({"status": "ok", "state": "healthy"})
+        mock_acr.stop_runtime_session.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "already gone"}}, "StopRuntimeSession"
+        )
+        client.attach(FAKE_SESSION_ID).terminate()  # no raise
+
+    def test_terminate_idempotent(self):
+        client, mock_acr = make_client_and_mock()
+        mock_acr.invoke_agent_runtime.return_value = make_start_response({"status": "ok", "state": "healthy"})
+        sandbox = client.attach(FAKE_SESSION_ID)
+        sandbox.terminate()
+        sandbox.terminate()
+        assert mock_acr.stop_runtime_session.call_count == 1
+        assert mock_acr.invoke_agent_runtime.call_count == 1
+
+
+class TestContextManager:
+    def test_exit_terminates(self):
+        client, mock_acr = make_client_and_mock(make_start_response())
+        with client.start() as sandbox:
+            pass
+        assert sandbox._terminated
+        mock_acr.stop_runtime_session.assert_called_once()
+
+    def test_exception_propagates_and_terminates(self):
+        client, mock_acr = make_client_and_mock(make_start_response())
+        with pytest.raises(RuntimeError, match="boom"):
+            with client.start():
+                raise RuntimeError("boom")
+        mock_acr.stop_runtime_session.assert_called_once()

--- a/tests/sandbox/test_types.py
+++ b/tests/sandbox/test_types.py
@@ -25,19 +25,28 @@ class TestComposeCommand:
         assert _compose_command("pytest -q", cwd="/app") == "cd /app && pytest -q"
 
     def test_env_only(self):
-        assert _compose_command("run.sh", env={"FOO": "bar"}) == "export FOO=bar; run.sh"
+        assert _compose_command("run.sh", env={"FOO": "bar"}) == "export FOO=bar && run.sh"
 
     def test_cwd_and_env(self):
         composed = _compose_command("pytest -q", cwd="/app", env={"FOO": "bar"})
-        assert composed == "cd /app && export FOO=bar; pytest -q"
+        assert composed == "cd /app && export FOO=bar && pytest -q"
+
+    def test_failed_cd_never_falls_through_to_command(self):
+        """The whole prefix chains with && — a failed cd must not run the command."""
+        import subprocess
+
+        composed = _compose_command("echo LEAKED", cwd="/nonexistent-dir-xyz", env={"FOO": "bar"})
+        proc = subprocess.run(["/bin/sh", "-c", composed], capture_output=True, text=True)
+        assert proc.returncode != 0
+        assert "LEAKED" not in proc.stdout
 
     def test_multiple_env_vars(self):
         composed = _compose_command("cmd", env={"A": "1", "B": "2"})
-        assert composed == "export A=1 B=2; cmd"
+        assert composed == "export A=1 B=2 && cmd"
 
     def test_quoting_value_with_spaces(self):
         composed = _compose_command("cmd", env={"MSG": "hello world"})
-        assert composed == "export MSG='hello world'; cmd"
+        assert composed == "export MSG='hello world' && cmd"
 
     def test_quoting_value_with_single_quote(self):
         composed = _compose_command("cmd", env={"MSG": "it's"})
@@ -45,14 +54,14 @@ class TestComposeCommand:
         # shlex.quote produces a shell-safe form; exact escaping is delegated
         import shlex
 
-        assert shlex.split(composed.removeprefix("export ").removesuffix("; cmd"))[0] == "MSG=it's"
+        assert shlex.split(composed.removeprefix("export ").removesuffix(" && cmd"))[0] == "MSG=it's"
 
     def test_quoting_cwd_with_spaces(self):
         composed = _compose_command("ls", cwd="/tmp/my dir")
         assert composed == "cd '/tmp/my dir' && ls"
 
     def test_non_string_env_value_coerced(self):
-        assert _compose_command("cmd", env={"N": 3}) == "export N=3; cmd"
+        assert _compose_command("cmd", env={"N": 3}) == "export N=3 && cmd"
 
     def test_invalid_env_key_raises(self):
         with pytest.raises(ValueError, match="Invalid environment variable name"):

--- a/tests/sandbox/test_types.py
+++ b/tests/sandbox/test_types.py
@@ -1,0 +1,91 @@
+"""Tests for sandbox data types and command composition."""
+
+import pytest
+
+from agentcore_rl_toolkit.sandbox import ExecResult
+from agentcore_rl_toolkit.sandbox.client import _compose_command, _wrap_in_shell
+
+
+class TestExecResult:
+    def test_fields(self):
+        """All four fields are stored as given."""
+        result = ExecResult(exit_code=17, stdout="out", stderr="err", timed_out=False)
+        assert result.exit_code == 17
+        assert result.stdout == "out"
+        assert result.stderr == "err"
+        assert result.timed_out is False
+
+
+class TestComposeCommand:
+    def test_passthrough(self):
+        """Without cwd/env the command is unchanged."""
+        assert _compose_command("pytest -q") == "pytest -q"
+
+    def test_cwd_only(self):
+        assert _compose_command("pytest -q", cwd="/app") == "cd /app && pytest -q"
+
+    def test_env_only(self):
+        assert _compose_command("run.sh", env={"FOO": "bar"}) == "export FOO=bar; run.sh"
+
+    def test_cwd_and_env(self):
+        composed = _compose_command("pytest -q", cwd="/app", env={"FOO": "bar"})
+        assert composed == "cd /app && export FOO=bar; pytest -q"
+
+    def test_multiple_env_vars(self):
+        composed = _compose_command("cmd", env={"A": "1", "B": "2"})
+        assert composed == "export A=1 B=2; cmd"
+
+    def test_quoting_value_with_spaces(self):
+        composed = _compose_command("cmd", env={"MSG": "hello world"})
+        assert composed == "export MSG='hello world'; cmd"
+
+    def test_quoting_value_with_single_quote(self):
+        composed = _compose_command("cmd", env={"MSG": "it's"})
+        assert "it" in composed
+        # shlex.quote produces a shell-safe form; exact escaping is delegated
+        import shlex
+
+        assert shlex.split(composed.removeprefix("export ").removesuffix("; cmd"))[0] == "MSG=it's"
+
+    def test_quoting_cwd_with_spaces(self):
+        composed = _compose_command("ls", cwd="/tmp/my dir")
+        assert composed == "cd '/tmp/my dir' && ls"
+
+    def test_non_string_env_value_coerced(self):
+        assert _compose_command("cmd", env={"N": 3}) == "export N=3; cmd"
+
+    def test_invalid_env_key_raises(self):
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _compose_command("cmd", env={"BAD-KEY": "x"})
+
+    def test_env_key_injection_raises(self):
+        with pytest.raises(ValueError):
+            _compose_command("cmd", env={"X; rm -rf /": "x"})
+
+
+class TestWrapInShell:
+    def test_simple_command(self):
+        assert _wrap_in_shell("echo hi") == "/bin/sh -c 'echo hi'"
+
+    def test_shell_metacharacters_preserved(self):
+        assert _wrap_in_shell("echo one; echo two | wc -l") == "/bin/sh -c 'echo one; echo two | wc -l'"
+
+    def test_double_quotes_ok(self):
+        assert _wrap_in_shell('echo "a b"') == "/bin/sh -c 'echo \"a b\"'"
+
+    def test_single_quote_switches_to_double_quote_wrapper(self):
+        # The docs pattern: single quotes ride inside a double-quoted wrapper.
+        assert _wrap_in_shell("echo it's fine") == '/bin/sh -c "echo it\'s fine"'
+
+    def test_double_quote_wrapper_escapes_double_quotes(self):
+        assert _wrap_in_shell("echo 'a' \"b\"") == '/bin/sh -c "echo \'a\' \\"b\\""'
+
+    def test_double_quote_wrapper_escapes_backslashes(self):
+        # Tokenizer consumes one escaping level in double quotes: \\ -> \.
+        assert _wrap_in_shell(r"echo 'a\tb'") == "/bin/sh -c \"echo 'a\\\\tb'\""
+
+    def test_custom_shell(self):
+        assert _wrap_in_shell("echo hi", shell="/bin/bash") == "/bin/bash -c 'echo hi'"
+
+    def test_custom_shell_double_quote_path(self):
+        assert _wrap_in_shell("echo it's", shell="/bin/bash") == '/bin/bash -c "echo it\'s"'


### PR DESCRIPTION
## Motivation

Coding-agent evaluation and RL training run against large collections of prebuilt Docker images (e.g. SWE-bench-style environments): a filesystem, dependencies, and a test runner waiting for shell commands — not HTTP agent servers. AgentCore Runtime already has the right primitives for this workload (per-session microVM isolation, session routing, auto-scaling, and a native `InvokeAgentRuntimeCommand` API that executes shell commands inside a live session), but such images cannot be deployed today: ACR requires containers to expose `/ping` and `/invocations` on port 8080, and session health/busy state must be managed correctly or sessions get idle-reaped mid-task.

This PR closes that gap so any image with a shell can serve as a scalable, isolated command-execution sandbox on ACR.

## Approach

Two small pieces, deliberately kept apart:

1. **`sandboxd/` — a minimal Go health shim** (stdlib-only, single static binary) added to the image as its entrypoint. It satisfies the ACR container contract and holds one busy/healthy flag: `/invocations {"action":"start"}` flips ping to `HealthyBusy` (session survives idle timeout across quiet gaps between commands), `{"action":"stop"}` flips it back. It contains **no execution logic**; unknown JSON fields are ignored for forward compatibility.

2. **`agentcore_rl_toolkit.sandbox` — a sync Python client** (boto3 only, zero new deps). `client.start()` / `client.attach(session_id)` / `sb.exec(...)` / `sb.terminate()`. Command execution goes through ACR's native `InvokeAgentRuntimeCommand`, never through the shim; the client consumes the event stream into `ExecResult(exit_code, stdout, stderr, timed_out)`.

Key semantics:

- **Failure is data**: nonzero exit codes and timeouts are ordinary results (the reward signal in eval/RL), never exceptions — exceptions are reserved for infrastructure faults (`ClientError`, `EventStreamError`, `SandboxProtocolError` for misdeployed images).
- **Stateless commands**: each `exec()` runs in a fresh process; `cwd=`/`env=` are composed into the command per call. The command API doesn't invoke a shell itself, so the client wraps commands in `<shell> -c '...'` (default `/bin/sh` for arbitrary-image portability, overridable).
- **Fault-tolerant teardown**: `terminate()` flips ping to Healthy *before* calling `StopRuntimeSession`, so the idle reaper collects the session even if the stop call fails; idempotent, safe in `__exit__`.

`examples/sandbox_quickstart/` provides the end-to-end walkthrough: build the binary (`sandboxd/build.sh`, cross-compiles arm64 on x86 hosts with a golang-container fallback), wrap + push image, create the runtime, run commands. The sandbox image does not contain this toolkit — the SDK is purely client-side.

## Scope

First PR of a phased feature. Deliberately excluded (planned next): async client (aiobotocore), TTL-based leak protection, image wrapping/ECR automation in the SDK, detached exec, interactive shells, file transfer.

## Testing

- `tests/sandbox/`: unit tests with fully mocked boto3 (fake event streams) — no AWS access needed; runs in existing `unit-tests.yml`.
- `sandboxd/`: Go unit tests incl. race detector; new path-gated CI workflow (`.github/workflows/sandboxd.yml`: gofmt, vet, build, `go test -race`).
- Shell-wrapping and exec semantics verified against the live service; quickstart validated end-to-end on a deployed runtime (`exit_code=0`, `hello from aarch64`).