### PR TITLE
Fix/slime sglang data parallel size

### DIFF
--- a/src/agentcore_rl_toolkit/backends/slime/runner.py
+++ b/src/agentcore_rl_toolkit/backends/slime/runner.py
@@ -87,6 +87,7 @@ class SlimeRunner:
     # Gateway use_sglang parsers (must match the served model) + cumulative mode.
     sglang_tool_call_parser: str = "qwen"
     sglang_reasoning_parser: str | None = None
+    sglang_data_parallel_size: int = 1
     cumulative_token_mode: bool = False
     renderer_family: str = "auto"
     gateway_log_level: str = "warning"
@@ -356,6 +357,8 @@ class SlimeRunner:
         # Optional SGLang context length cap.
         if self.sglang_context_length is not None:
             flags.extend(["--sglang-context-length", str(self.sglang_context_length)])
+        # SGLang data parallel size (required by slime's sglang_utils validation).
+        flags.extend(["--sglang-data-parallel-size", str(self.sglang_data_parallel_size)])
         # CUDA pinning for the Megatron train actors: slime gives them their own
         # runtime_env that does NOT carry CUDA_HOME/LD_LIBRARY_PATH, so pass the
         # pinned paths through --train-env-vars too (mirrors train.sh). Only when

--- a/tests/test_slime_runner.py
+++ b/tests/test_slime_runner.py
@@ -88,3 +88,20 @@ def test_toolkit_config_yaml_includes_acr_pointers():
     assert data["s3_bucket"] == REQUIRED_KWARGS["s3_bucket"]
     assert data["exp_id"] == REQUIRED_KWARGS["exp_id"]
     assert data["model_id"] == "qwen-served"
+
+
+def test_sglang_data_parallel_size_default_in_flags():
+    """--sglang-data-parallel-size is always emitted with default value 1."""
+    runner = SlimeRunner(**REQUIRED_KWARGS)
+    flags = runner._build_slime_flags(num_rollout=1, model_args=[], config_path="/tmp/cfg.yaml")
+
+    assert "--sglang-data-parallel-size" in flags
+    assert flags[flags.index("--sglang-data-parallel-size") + 1] == "1"
+
+
+def test_sglang_data_parallel_size_custom_value():
+    """--sglang-data-parallel-size respects a non-default value."""
+    runner = SlimeRunner(**REQUIRED_KWARGS, sglang_data_parallel_size=4)
+    flags = runner._build_slime_flags(num_rollout=1, model_args=[], config_path="/tmp/cfg.yaml")
+
+    assert flags[flags.index("--sglang-data-parallel-size") + 1] == "4"


### PR DESCRIPTION
### Problem
SlimeRunner._build_slime_flags() doesn't pass --sglang-data-parallel-size to slime's train.py. Slime versions after commit fa3c990 added validation at sglang_utils/arguments.py:142 that reads args.sglang_data_parallel_size — an attribute that only exists if argparse registers it via the CLI flag. Since SlimeRunner never passed it, argparse never creates the attribute, and validation crashes with AttributeError.

Additionally, the [slime] extra was missing ray as a dependency despite SlimeRunner directly invoking ray start, ray stop, and ray job submit.

## Fix
   - Add sglang_data_parallel_size: int = 1 field to the SlimeRunner dataclass
   - Emit --sglang-data-parallel-size <value> unconditionally in _build_slime_flags()
   - Add ray to the [slime] optional dependency group in pyproject.toml

### Tests

   - Added two unit tests covering default and custom values for the new flag
   - Full test suite passes (173 tests)
Additionally this fix was tested for small scale RL experiments using a manual patch internally.