### PR TITLE
feat(rollout-gateway): make renderer derender stages pluggable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ build/
 .env
 .wandb.env
 
+# Logs and experiment tracking
+wandb/
+*.log
+
 # Local slime backend config (contains ARN/bucket; commit config.yaml.example only)
 src/agentcore_rl_toolkit/backends/slime/examples/**/config.yaml
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,9 +316,15 @@ drains the tree into `list[TraceRecord]`.
 **Dependencies.** The gateway is trainer-side and lives behind extras — the base install
 (agent-side `AgentCoreRLApp` / `RolloutClient`) stays lean:
 - `pip install agentcore-rl-toolkit[gateway]` → `aiohttp` + `transformers`.
-- Tool/reasoning parsing uses a dependency-free regex (common `<tool_call>` format) and
-  `</think>` split; no engine parser dependency. A caller needing engine-grade parsing
-  for an exotic format installs `sglang`/`vllm` and passes a parser name explicitly.
+- Tool/reasoning parsing defaults to a dependency-free regex (the `<tool_call><function=...>`
+  XML format) and `</think>` split; the gateway itself never imports an inference engine.
+  For any other model format (e.g. Qwen3's JSON `<tool_call>`), inject an `output_parser`
+  callable (`(raw_output, tools_schema) -> ParsedOutput`) into `HfTemplateRenderer` — it
+  replaces the built-in derender entirely. The slime backend ships such a parser built from
+  SGLang's own detectors (`backends/slime/integration/sglang_parsing.py`, composing
+  `FunctionCallParser` + `ReasoningParser`) and wires it automatically from slime's
+  `--sglang-tool-call-parser` / `--sglang-reasoning-parser` args (names must match the
+  served model); sglang is always importable there because the trainer serves SGLang.
 - For the Tinker backend (`TinkerSdkBackend` + `TinkerRenderer`), install `tinker` and
   `tinker-cookbook` manually — they require Python ≥3.11, so they are not declared as an
   extra (this package supports ≥3.10). Both pull torch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ agentcore-rl-toolkit/
 │   │   ├── render.py               # Renderer protocol; HfTemplateRenderer, TinkerRenderer
 │   │   ├── parsing.py              # tool/reasoning output parsing (sglang optional)
 │   │   ├── gateway.py              # RolloutGateway — assembles the serving unit
+│   │   ├── server.py               # ThreadedGatewayServer — serve the gateway from sync trainers
 │   │   ├── adapters/               # OpenAI + Anthropic wire protocol adapters
 │   │   └── sampling_backends/      # SamplingBackend impls (vLLM/SGLang HTTP, Tinker SDK)
 │   └── backends/experimental/verl/ # Experimental verl backend on the rollout gateway
@@ -288,6 +289,7 @@ sample-only backends like Tinker, which cannot render themselves.
 | `SamplingBackend` | `sampling_backends/` | The one per-engine seam: `token_ids -> token_ids + logprobs` as a `TurnRecord`. Impls: `VllmHttpBackend`, `SglangHttpBackend`, `TinkerSdkBackend`. Placement rule: engine seams for independently reachable inference services (HTTP endpoints, hosted SDKs like Tinker) live here; seams over trainer-internal handles (e.g. `VerlSamplingBackend` over verl's Ray-based `LLMServerClient`) live with that trainer's integration under `backends/`. |
 | Adapters | `adapters/` | Wire-protocol translation: `OpenAIAdapter` (`/v1/chat/completions`), `AnthropicAdapter` (`/v1/messages`). An agent drives the gateway in its *native* protocol unmodified (just point `base_url` at it); both normalize to one canonical message form and share one `TrajectoryManager`. |
 | `RolloutGateway` | `gateway.py` | Assembles tokenizer + renderer + backend + adapters onto one aiohttp app sharing one `TrajectoryManager`. Session identity rides in the api-key / Bearer slot; `base_url` is a fixed gateway address (no per-session URLs). |
+| `ThreadedGatewayServer` | `server.py` | Serves an assembled gateway on a background thread with its own event loop — the deployment shape for synchronous trainers (slime, verl). Async trainers can mount `gateway.app` into their own loop instead. |
 
 **Session model.** A session id (in the Bearer slot) keys one trajectory tree.
 `gateway.create_session(sid)` → agent turns are captured → `gateway.finish_session(sid)`
@@ -383,6 +385,7 @@ upstream before re-syncing, diff the source file against the baseline commit bel
 | `rollout_gateway/trajectory.py` | `slime/agent/trajectory.py` | `90c212b5` |
 | `rollout_gateway/adapters/{common,openai,anthropic}.py` | `slime/agent/adapters/` | `90c212b5` |
 | `rollout_gateway/parsing.py` | `slime/agent/parsing.py` | `90c212b5` |
+| `rollout_gateway/server.py` | `slime/agent/aiohttp_threaded.py` | `fa3c990a` |
 
 Re-sync workflow: `git -C <slime> diff 90c212b5..HEAD -- slime/agent/<file>` shows upstream
 changes since the lift. Our copies are intentionally modified (torch-free; `Sample` →

--- a/NOTICE
+++ b/NOTICE
@@ -13,3 +13,5 @@ slime, notably:
   - adapters/      — OpenAIAdapter, AnthropicAdapter, and the shared BaseAdapter
                      pipeline, adapted from slime/agent/adapters/.
   - parsing.py     — output-parsing helpers, adapted from slime/agent/parsing.py.
+  - server.py      — background-thread serving mechanics and FilteredAccessLogger,
+                     adapted from slime/agent/aiohttp_threaded.py.

--- a/examples/strands_math_agent/rl_app.py
+++ b/examples/strands_math_agent/rl_app.py
@@ -40,6 +40,9 @@ def invoke_agent(payload: dict, context):
     base_url = payload["_rollout"]["base_url"]
     model_id = payload["_rollout"]["model_id"]
     params = payload["_rollout"].get("sampling_params", {})
+    # During training the rollout gateway keys the session off the api-key slot;
+    # "EMPTY" (the vLLM convention) is fine for plain evaluation endpoints.
+    api_key = payload["_rollout"].get("api_key", "EMPTY")
 
     # The ACR session id doubles as the trajectory-capture session key: rollout
     # gateways read it from the api-key slot. "EMPTY" for local runs and
@@ -65,8 +68,13 @@ def invoke_agent(payload: dict, context):
 
     response = agent(user_input)
 
-    # Compute rewards
-    rewards = reward_fn(response_text=response.message["content"][0]["text"], ground_truth=answer)
+    # Compute rewards. Join the text blocks instead of indexing content[0]: a
+    # reasoning-parsing server (vllm/sglang --reasoning-parser, or the rollout
+    # gateway) returns reasoning_content, which Strands surfaces as a leading
+    # reasoningContent block before the text block.
+    content = response.message.get("content") or []
+    response_text = "".join(block["text"] for block in content if "text" in block)
+    rewards = reward_fn(response_text=response_text, ground_truth=answer)
 
     return {"rewards": rewards}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,3 +212,6 @@ select = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["agentcore_rl_toolkit"]
+
+[tool.pytest.ini_options]
+addopts = "--ignore=tests/rollout_gateway/integration_test"

--- a/src/agentcore_rl_toolkit/rollout_gateway/__init__.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/__init__.py
@@ -10,9 +10,9 @@ Import layering:
   imports with nothing beyond the stdlib — torch-free and aiohttp-free.
   (``HfTemplateRenderer`` needs a HF tokenizer only when *used*, not to import; sglang
   parsers and tinker are lazy/optional.)
-- ``RolloutGateway`` and the HTTP adapters require ``aiohttp`` (the ``[gateway]`` extra),
-  so ``RolloutGateway`` is exposed lazily via ``__getattr__`` — importing this package
-  never requires aiohttp.
+- ``RolloutGateway``, ``ThreadedGatewayServer``, and the HTTP adapters require
+  ``aiohttp`` (the ``[gateway]`` extra), so both are exposed lazily via
+  ``__getattr__`` — importing this package never requires aiohttp.
 """
 
 from .render import HfTemplateRenderer, ParsedOutput, Renderer
@@ -32,6 +32,7 @@ __all__ = [
     "RolloutGateway",
     "SamplingBackend",
     "Status",
+    "ThreadedGatewayServer",
     "TraceRecord",
     "TrajectoryManager",
     "TurnRecord",
@@ -39,9 +40,13 @@ __all__ = [
 
 
 def __getattr__(name: str):
-    # RolloutGateway pulls in the aiohttp adapters; keep it off the plain import path.
+    # These pull in aiohttp; keep them off the plain import path.
     if name == "RolloutGateway":
         from .gateway import RolloutGateway
 
         return RolloutGateway
+    if name == "ThreadedGatewayServer":
+        from .server import ThreadedGatewayServer
+
+        return ThreadedGatewayServer
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/agentcore_rl_toolkit/rollout_gateway/parsing.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/parsing.py
@@ -25,16 +25,35 @@ class ParsedModelOutput:
     ill_formed: bool = False
 
 
+def split_reasoning(raw_output: str) -> tuple[str, str]:
+    """Default reasoning stage: split ``(reasoning, body)`` on a ``</think>`` marker.
+
+    Text with no marker is all body. This is the fallback for the renderer's
+    ``reasoning_parser`` seam.
+    """
+    if "</think>" not in raw_output:
+        return "", raw_output
+    reasoning, body_text = raw_output.split("</think>", 1)
+    return reasoning.removeprefix("<think>"), body_text
+
+
+def parse_tool_uses(body_text: str, tools_schema: list[dict]) -> tuple[str, list[dict[str, Any]], bool]:
+    """Default tool stage: ``(text, tool_uses, ill_formed)`` from the XML ``<tool_call>`` format.
+
+    Signature matches the renderer's ``tool_parser`` seam; the regex never reports
+    ``ill_formed`` (unmatched text is simply left as visible text).
+    """
+    text, tool_uses = parse_xml_tool_uses(body_text, tools_schema)
+    return text, tool_uses, False
+
+
 def parse_model_output(
     raw_output: str,
     *,
     tools_schema: list[dict] | None,
 ) -> ParsedModelOutput:
     """Parse raw model text into reasoning, visible text, and tool uses."""
-    reasoning, body_text = "", raw_output
-    if "</think>" in body_text:
-        reasoning, body_text = body_text.split("</think>", 1)
-        reasoning = reasoning.removeprefix("<think>")
+    reasoning, body_text = split_reasoning(raw_output)
 
     tool_uses: list[dict[str, Any]] = []
     if tools_schema:
@@ -72,4 +91,10 @@ def parse_xml_tool_uses(body_text: str, tools_schema: list[dict]) -> tuple[str, 
     return "".join(cleaned_parts), tool_uses
 
 
-__all__ = ["ParsedModelOutput", "parse_model_output", "parse_xml_tool_uses"]
+__all__ = [
+    "ParsedModelOutput",
+    "parse_model_output",
+    "parse_tool_uses",
+    "parse_xml_tool_uses",
+    "split_reasoning",
+]

--- a/src/agentcore_rl_toolkit/rollout_gateway/render.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/render.py
@@ -9,8 +9,12 @@ inference backends (e.g. Tinker) that cannot render themselves.
 Two implementations behind one :class:`Renderer` protocol:
 
 * :class:`HfTemplateRenderer` (default, lightweight) — renders with the HF tokenizer's
-  ``apply_chat_template`` and parses output via ``parse_model_output`` (dependency-free
-  regex + ``</think>`` split). Needs only ``transformers``.
+  ``apply_chat_template`` and derenders by applying a reasoning parser then a tool
+  parser in sequence, each independently overridable via ``reasoning_parser`` /
+  ``tool_parser`` and each falling back to the dependency-free default (``</think>``
+  split / ``<tool_call><function=...>`` regex). Needs only ``transformers``; the
+  override seams are how engine-grade parsers (e.g. SGLang's detectors) plug in
+  without this package depending on any engine — the slime backend supplies them.
 * :class:`TinkerRenderer` — wraps a tinker-cookbook ``Renderer`` (install ``tinker``
   and ``tinker-cookbook`` manually; they require Python >=3.11). Its ``tinker_cookbook``
   import (which pulls torch) is deferred into ``__init__``, so importing this module
@@ -18,9 +22,16 @@ Two implementations behind one :class:`Renderer` protocol:
 """
 
 import dataclasses
+from collections.abc import Callable
 from typing import Any, Protocol, runtime_checkable
 
-from .parsing import ParsedModelOutput, parse_model_output
+from .parsing import parse_tool_uses, split_reasoning
+
+# The two derender stages, as injectable callables:
+#   ReasoningParser: raw_output -> (reasoning, body_text)
+#   ToolParser     : (body_text, tools_schema) -> (text, tool_uses, ill_formed)
+ReasoningParserFn = Callable[[str], tuple[str, str]]
+ToolParserFn = Callable[[str, list[dict]], tuple[str, list[dict[str, Any]], bool]]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -34,10 +45,6 @@ class ParsedOutput:
     text: str
     tool_uses: list[dict[str, Any]]
     ill_formed: bool = False
-
-
-def _to_parsed_output(p: ParsedModelOutput) -> ParsedOutput:
-    return ParsedOutput(reasoning=p.reasoning, text=p.text, tool_uses=p.tool_uses, ill_formed=p.ill_formed)
 
 
 @runtime_checkable
@@ -71,13 +78,24 @@ class Renderer(Protocol):
 
 
 class HfTemplateRenderer:
-    """Default renderer: HF ``apply_chat_template`` for rendering, ``parse_model_output``
-    for derendering.
+    """Default renderer: HF ``apply_chat_template`` for rendering, a reasoning stage then
+    a tool stage for derendering.
 
-    Depends only on a HF tokenizer (``transformers``). Tool calls are parsed with a
-    dependency-free regex (the common ``<tool_call>`` format) and reasoning via a
-    ``</think>`` split — no inference-engine dependency. A model whose output needs
-    engine-grade parsing is handled by a different ``Renderer`` implementation, not here.
+    Depends only on a HF tokenizer (``transformers``). Derendering runs two stages in
+    sequence — reasoning first, then tool calls on what remains (the same order the
+    inference engines use) — each independently overridable and each defaulting to the
+    dependency-free implementation in ``parsing``:
+
+    * ``reasoning_parser``: ``raw_output -> (reasoning, body_text)``.
+      Default: split on ``</think>``.
+    * ``tool_parser``: ``(body_text, tools_schema) -> (text, tool_uses, ill_formed)``,
+      called only when the request carries a tools schema.
+      Default: the ``<tool_call><function=...>`` regex.
+
+    Overriding one leaves the other on its default, so a model whose tool format needs
+    engine-grade parsing but whose reasoning is a plain ``</think>`` block needs only
+    ``tool_parser``. These seams are how engine parsers plug in (see
+    ``backends.slime.integration.sglang_parsing``) without this package importing an engine.
     """
 
     def __init__(
@@ -85,9 +103,13 @@ class HfTemplateRenderer:
         tokenizer,
         *,
         stop_sequences: list[str] | list[int] | None = None,
+        reasoning_parser: ReasoningParserFn | None = None,
+        tool_parser: ToolParserFn | None = None,
     ) -> None:
         self.tokenizer = tokenizer
         self._stop_sequences: list = list(stop_sequences) if stop_sequences else []
+        self.reasoning_parser: ReasoningParserFn = reasoning_parser or split_reasoning
+        self.tool_parser: ToolParserFn = tool_parser or parse_tool_uses
 
     def render(
         self,
@@ -117,8 +139,17 @@ class HfTemplateRenderer:
         tools_schema: list[dict] | None = None,
     ) -> ParsedOutput:
         raw_output = self.tokenizer.decode(output_ids, skip_special_tokens=False) if output_ids else ""
-        parsed = parse_model_output(raw_output, tools_schema=tools_schema)
-        return _to_parsed_output(parsed)
+        reasoning, body_text = self.reasoning_parser(raw_output)
+        tool_uses: list[dict[str, Any]] = []
+        ill_formed = False
+        if tools_schema:
+            body_text, tool_uses, ill_formed = self.tool_parser(body_text, tools_schema)
+        return ParsedOutput(
+            reasoning=(reasoning or "").strip(),
+            text=(body_text or "").strip(),
+            tool_uses=tool_uses,
+            ill_formed=ill_formed,
+        )
 
 
 class TinkerRenderer:

--- a/src/agentcore_rl_toolkit/rollout_gateway/server.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/server.py
@@ -1,0 +1,118 @@
+"""Run a :class:`RolloutGateway` on a background thread, for synchronous trainers.
+
+A sync trainer (slime, verl) blocks its thread waiting for episode results, but the
+gateway must keep answering the agent's LLM calls the whole time. Served on the same
+thread, the block would freeze the event loop and deadlock the episode — so this
+class serves ``gateway.app`` on its own daemon thread with a long-lived loop. The
+session API (``create_session`` / ``finish_session`` / ``drop_session``) stays safe
+to call from the trainer thread. Async trainers don't need this: mount
+``gateway.app`` on your own loop and ``await`` instead.
+
+The serving mechanics are adapted from slime's ``slime/agent/aiohttp_threaded.py``
+(baseline commit ``fa3c990a``; see NOTICE).
+
+Requires ``aiohttp`` (the ``[gateway]`` extra), like :class:`RolloutGateway` itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+
+from aiohttp import web
+from aiohttp.web_log import AccessLogger
+
+logger = logging.getLogger(__name__)
+
+
+class FilteredAccessLogger(AccessLogger):
+    """Log only failures and slow requests; healthy fast traffic is noise."""
+
+    SLOW_THRESHOLD_SEC = 120.0
+
+    def log(self, request, response, time):
+        if request.method == "HEAD":
+            return
+        if response.status == 200 and time <= self.SLOW_THRESHOLD_SEC:
+            return
+        super().log(request, response, time)
+
+
+class ThreadedGatewayServer:
+    """Serve an assembled :class:`RolloutGateway` on a background thread.
+
+    ``start()`` blocks until the server is bound (or raises if binding fails),
+    so callers can hand out :attr:`base_url` immediately afterwards. ``port=0``
+    binds an OS-assigned port, reflected in :attr:`port`/:attr:`base_url` after
+    ``start()``.
+
+    Session identity rides in the api-key / Bearer slot of each request, so all
+    sessions share the single fixed :attr:`base_url`.
+    """
+
+    def __init__(self, gateway, *, host: str, port: int = 0, startup_timeout: float = 120.0):
+        self.gateway = gateway
+        self.host = host
+        self.port = port
+        self.startup_timeout = startup_timeout
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._runner: web.AppRunner | None = None
+
+    @property
+    def base_url(self) -> str:
+        """Fixed OpenAI-compatible ``base_url`` shared by all sessions."""
+        return f"http://{self.host}:{self.port}/v1"
+
+    def start(self) -> None:
+        started = threading.Event()
+        startup_error: list[BaseException] = []
+
+        def _serve() -> None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                # handler_cancellation=True: a client disconnect cancels the
+                # in-flight handler coroutine, so an agent that dies mid-request
+                # doesn't leave an orphaned generate call in the sampling backend.
+                runner = web.AppRunner(
+                    self.gateway.app,
+                    handler_cancellation=True,
+                    access_log_class=FilteredAccessLogger,
+                )
+                loop.run_until_complete(runner.setup())
+                site = web.TCPSite(runner, host=self.host, port=self.port)
+                loop.run_until_complete(site.start())
+                for sock in site._server.sockets:  # resolve OS-assigned port when port=0
+                    self.port = sock.getsockname()[1]
+                    break
+                self._loop = loop
+                self._runner = runner
+                started.set()
+                loop.run_forever()
+            except BaseException as e:  # surface bind/setup failures to the caller
+                startup_error.append(e)
+                started.set()
+
+        self._thread = threading.Thread(target=_serve, name="rollout-gateway", daemon=True)
+        self._thread.start()
+        if not started.wait(timeout=self.startup_timeout):
+            raise TimeoutError(f"Rollout gateway did not start within {self.startup_timeout}s")
+        if startup_error:
+            raise RuntimeError(f"Rollout gateway failed to start on {self.host}:{self.port}") from startup_error[0]
+        logger.info("Rollout gateway serving at %s", self.base_url)
+
+    def shutdown(self) -> None:
+        if self._loop is None:
+            return
+        # Clean up on the live loop first (graceful connection shutdown +
+        # release of the listening socket), then stop the loop.
+        try:
+            fut = asyncio.run_coroutine_threadsafe(self._runner.cleanup(), self._loop)
+            fut.result(timeout=10)
+        except Exception:
+            pass
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=10)
+        self._loop = None

--- a/tests/rollout_gateway/integration_test/sglang/test_e2e_qwen_sglang.py
+++ b/tests/rollout_gateway/integration_test/sglang/test_e2e_qwen_sglang.py
@@ -8,16 +8,22 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from contextlib import asynccontextmanager
+from contextlib import contextmanager
 
 import pytest
 
-from agentcore_rl_toolkit.rollout_gateway import BaseTrace, HfTemplateRenderer, RolloutGateway
+from agentcore_rl_toolkit.rollout_gateway import (
+    BaseTrace,
+    HfTemplateRenderer,
+    RolloutGateway,
+    ThreadedGatewayServer,
+)
 
 SGLANG_URL = os.environ.get("E2E_SGLANG_URL", "http://localhost:30000")
 MODEL = os.environ.get("E2E_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
 MAX_NEW_TOKENS = 512
 SERVER_LOG = "/tmp/e2e_sglang_server.log"
+GATEWAY_PORT = 9090
 
 HAVE_DEPS = all(importlib.util.find_spec(m) for m in ("openai", "sglang"))
 
@@ -105,19 +111,16 @@ def make_gateway():
     return gateway, backend, renderer, _TOKENIZER
 
 
-@asynccontextmanager
-async def serve(gateway: RolloutGateway):
-    from aiohttp import web
-
-    runner = web.AppRunner(gateway.app)
-    await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
-    await site.start()
-    port = site._server.sockets[0].getsockname()[1]
+@contextmanager
+def serve(gateway: RolloutGateway):
+    """Serve the gateway exactly as a sync trainer would: on a
+    ThreadedGatewayServer, off the test's own event loop."""
+    gw_server = ThreadedGatewayServer(gateway, host="127.0.0.1", port=GATEWAY_PORT)
+    gw_server.start()
     try:
-        yield f"http://127.0.0.1:{port}"
+        yield f"http://127.0.0.1:{GATEWAY_PORT}"
     finally:
-        await runner.cleanup()
+        gw_server.shutdown()
 
 
 def _trained(rec) -> list[int]:
@@ -138,7 +141,7 @@ async def test_single_turn_token_exact(server):
     gateway.create_session(sid, sampling_defaults={"temperature": 0.0})
     messages = [{"role": "user", "content": "What is 2+2? Reply with just the number. /no_think"}]
 
-    async with serve(gateway) as base_url:
+    with serve(gateway) as base_url:
         import openai
 
         client = openai.AsyncOpenAI(base_url=f"{base_url}/v1", api_key=sid)
@@ -179,7 +182,7 @@ async def test_multi_turn_drift_healed_into_one_record(server):
     sid = "e2e:multi"
     gateway.create_session(sid, sampling_defaults={"temperature": 0.0})
 
-    async with serve(gateway) as base_url:
+    with serve(gateway) as base_url:
         import openai
 
         client = openai.AsyncOpenAI(base_url=f"{base_url}/v1", api_key=sid)
@@ -232,7 +235,7 @@ async def test_rewritten_echo_trains_only_final_turn(server):
     sid = "e2e:rewrite"
     gateway.create_session(sid, sampling_defaults={"temperature": 0.0})
 
-    async with serve(gateway) as base_url:
+    with serve(gateway) as base_url:
         import openai
 
         client = openai.AsyncOpenAI(base_url=f"{base_url}/v1", api_key=sid)
@@ -278,7 +281,7 @@ async def test_stateless_turns_fork_into_separate_records(server):
         "What is 3*3? Reply with just the number. /no_think",
     ]
 
-    async with serve(gateway) as base_url:
+    with serve(gateway) as base_url:
         import openai
 
         client = openai.AsyncOpenAI(base_url=f"{base_url}/v1", api_key=sid)

--- a/tests/rollout_gateway/integration_test/vllm/test_e2e_qwen_vllm.py
+++ b/tests/rollout_gateway/integration_test/vllm/test_e2e_qwen_vllm.py
@@ -8,17 +8,23 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from contextlib import asynccontextmanager
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
-from agentcore_rl_toolkit.rollout_gateway import BaseTrace, HfTemplateRenderer, RolloutGateway
+from agentcore_rl_toolkit.rollout_gateway import (
+    BaseTrace,
+    HfTemplateRenderer,
+    RolloutGateway,
+    ThreadedGatewayServer,
+)
 
 VLLM_URL = os.environ.get("E2E_VLLM_URL", "http://localhost:8000")
 MODEL = os.environ.get("E2E_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
 MAX_NEW_TOKENS = 512
 SERVER_LOG = "/tmp/e2e_vllm_server.log"
+GATEWAY_PORT = 9090
 
 HAVE_DEPS = all(importlib.util.find_spec(m) for m in ("openai", "anthropic", "vllm"))
 
@@ -106,19 +112,16 @@ def make_gateway():
     return gateway, backend, renderer, _TOKENIZER
 
 
-@asynccontextmanager
-async def serve(gateway: RolloutGateway):
-    from aiohttp import web
-
-    runner = web.AppRunner(gateway.app)
-    await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
-    await site.start()
-    port = site._server.sockets[0].getsockname()[1]
+@contextmanager
+def serve(gateway: RolloutGateway):
+    """Serve the gateway exactly as a sync trainer would: on a
+    ThreadedGatewayServer, off the test's own event loop."""
+    gw_server = ThreadedGatewayServer(gateway, host="127.0.0.1", port=GATEWAY_PORT)
+    gw_server.start()
     try:
-        yield f"http://127.0.0.1:{port}"
+        yield f"http://127.0.0.1:{GATEWAY_PORT}"
     finally:
-        await runner.cleanup()
+        gw_server.shutdown()
 
 
 def _trained(rec) -> list[int]:
@@ -139,7 +142,7 @@ async def test_single_turn_token_exact(server):
     gateway.create_session(sid, sampling_defaults={"temperature": 0.0})
     messages = [{"role": "user", "content": "What is 2+2? Reply with just the number. /no_think"}]
 
-    async with serve(gateway) as base_url:
+    with serve(gateway) as base_url:
         import openai
 
         client = openai.AsyncOpenAI(base_url=f"{base_url}/v1", api_key=sid)
@@ -180,7 +183,7 @@ async def test_multi_turn_drift_healed_into_one_record(server):
     sid = "e2e:multi"
     gateway.create_session(sid, sampling_defaults={"temperature": 0.0})
 
-    async with serve(gateway) as base_url:
+    with serve(gateway) as base_url:
         import openai
 
         client = openai.AsyncOpenAI(base_url=f"{base_url}/v1", api_key=sid)
@@ -233,7 +236,7 @@ async def test_rewritten_echo_trains_only_final_turn(server):
     sid = "e2e:rewrite"
     gateway.create_session(sid, sampling_defaults={"temperature": 0.0})
 
-    async with serve(gateway) as base_url:
+    with serve(gateway) as base_url:
         import openai
 
         client = openai.AsyncOpenAI(base_url=f"{base_url}/v1", api_key=sid)
@@ -279,7 +282,7 @@ async def test_stateless_turns_fork_into_separate_records(server):
         "What is 3*3? Reply with just the number. /no_think",
     ]
 
-    async with serve(gateway) as base_url:
+    with serve(gateway) as base_url:
         import openai
 
         client = openai.AsyncOpenAI(base_url=f"{base_url}/v1", api_key=sid)
@@ -312,7 +315,7 @@ async def test_anthropic_client_multi_turn_token_exact(server):
     sid = "e2e:anthropic"
     gateway.create_session(sid, sampling_defaults={"temperature": 0.0})
 
-    async with serve(gateway) as base_url:
+    with serve(gateway) as base_url:
         import anthropic
 
         # the anthropic SDK sends api_key as X-Api-Key; the adapter maps it to the sid
@@ -355,7 +358,7 @@ async def test_mixed_protocol_clients_share_one_trajectory(server):
     sid = "e2e:mixed-sdk"
     gateway.create_session(sid, sampling_defaults={"temperature": 0.0})
 
-    async with serve(gateway) as base_url:
+    with serve(gateway) as base_url:
         import anthropic
         import openai
 

--- a/tests/rollout_gateway/test_render.py
+++ b/tests/rollout_gateway/test_render.py
@@ -80,3 +80,80 @@ def test_parse_extracts_reasoning_from_think_block():
     out = r.parse([1], tools_schema=None)
     assert out.reasoning == "weighing options"
     assert out.text == "the answer is 4"
+
+
+# ---------------------------------------------------------------------------
+# reasoning_parser / tool_parser: the two injectable derender stages
+# ---------------------------------------------------------------------------
+# Each override leaves the other stage on its dependency-free default, and the
+# stages run in sequence: reasoning first, tool calls on what remains.
+
+TOOLS = [{"type": "function", "function": {"name": "x", "parameters": {}}}]
+
+
+class ThinkTok(StubTokenizer):
+    def decode(self, ids, skip_special_tokens=False):
+        return "<think>hmm</think>body"
+
+
+def test_stages_run_in_sequence_reasoning_then_tools():
+    seen = {}
+
+    def reasoning_parser(raw_output):
+        seen["raw"] = raw_output
+        return "R", "BODY"
+
+    def tool_parser(body_text, tools_schema):
+        seen["body"] = body_text
+        seen["tools"] = tools_schema
+        return "T", [{"name": "x", "input": {}}], True
+
+    r = HfTemplateRenderer(ThinkTok(), reasoning_parser=reasoning_parser, tool_parser=tool_parser)
+    out = r.parse([1], tools_schema=TOOLS)
+
+    assert seen["raw"] == "<think>hmm</think>body"  # reasoning stage sees raw text
+    assert seen["body"] == "BODY"  # tool stage sees the reasoning stage's remainder
+    assert seen["tools"] == TOOLS
+    assert out == ParsedOutput(reasoning="R", text="T", tool_uses=[{"name": "x", "input": {}}], ill_formed=True)
+
+
+def test_tool_parser_override_keeps_default_reasoning_split():
+    """The common case: engine-grade tool parsing, </think> reasoning left to the default."""
+
+    def tool_parser(body_text, tools_schema):
+        return "", [{"name": "x", "input": {"got": body_text}}], False
+
+    r = HfTemplateRenderer(ThinkTok(), tool_parser=tool_parser)
+    out = r.parse([1], tools_schema=TOOLS)
+    assert out.reasoning == "hmm"
+    assert out.tool_uses == [{"name": "x", "input": {"got": "body"}}]
+
+
+def test_reasoning_parser_override_keeps_default_tool_regex():
+    class XmlTok(StubTokenizer):
+        def decode(self, ids, skip_special_tokens=False):
+            return "REASON||<tool_call><function=x><parameter=q>v</parameter></function></tool_call>"
+
+    r = HfTemplateRenderer(XmlTok(), reasoning_parser=lambda raw: tuple(raw.split("||", 1)))
+    out = r.parse([1], tools_schema=TOOLS)
+    assert out.reasoning == "REASON"
+    assert out.tool_uses == [{"name": "x", "input": {"q": "v"}}]
+
+
+def test_tool_parser_skipped_without_tools_schema():
+    calls = []
+
+    def tool_parser(body_text, tools_schema):
+        calls.append(body_text)
+        return "", [], False
+
+    r = HfTemplateRenderer(ThinkTok(), tool_parser=tool_parser)
+    out = r.parse([1], tools_schema=None)
+    assert calls == []  # no tools -> tool stage never runs
+    assert out.reasoning == "hmm"
+    assert out.text == "body"
+
+
+def test_tool_parser_ill_formed_propagates():
+    r = HfTemplateRenderer(ThinkTok(), tool_parser=lambda body, tools: (body, [], True))
+    assert r.parse([1], tools_schema=TOOLS).ill_formed is True


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`HfTemplateRenderer` derendered model output with one hardcoded path: split reasoning on `</think>`, then match tool calls with a regex for the `<tool_call><function=...>` XML format. Any model whose tool-call format differs silently produced zero tool calls. 

For example, Qwen3-0.6B has parsing format:
```
  <tool_call>
  {"name": <function-name>, "arguments": <args-json-object>}
  </tool_call>
```
while the parser can only handle
```
  <tool_call>\s*<function=NAME>...<parameter=K>V</parameter>...</function>\s*</tool_call>
```

  | Stage | Signature | Default |
  |---|---|---|
  | `reasoning_parser` | `raw_output -> (reasoning, body_text)` | split on `</think>` |
  | `tool_parser` | `(body_text, tools_schema) -> (text, tool_uses, ill_formed)` | `<tool_call><function=...>` regex |

The stages run in sequence — reasoning first, tool calls on what remains — matching the order the inference engines use. Overriding one leaves the other on its default, so a model needing engine-grade tool parsing but emitting plain `</think>` reasoning supplies only `tool_parser`. The tool stage is skipped entirely when a request carries no tools schema.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
