### PR TITLE
fix(examples): strengthen example agent code security by adding input validation and safe file extraction, and security notes to agent app docstring and example agent Readme

### DIFF
--- a/examples/strands_math_agent/README.md
+++ b/examples/strands_math_agent/README.md
@@ -34,6 +34,13 @@ curl -X POST http://localhost:8080/invocations \
      -d '{"prompt": "Toula went to the bakery and bought various types of pastries. She bought 3 dozen donuts which cost $68 per dozen, 2 dozen mini cupcakes which cost $80 per dozen, and 6 dozen mini cheesecakes for $55 per dozen. How much was the total cost?"}'
 ```
 
+> **Security note:** The `/invocations` payloads shown above are validated by the
+> entrypoint before they reach the agent. Both basic app and RL app in subsequent section
+> construct an `InvocationRequest` (see `models.py`) whose `prompt` field is typed `str`, so
+> a non-string value — e.g. a `toolUse` content block — is rejected before the agent runs.
+> When adapting this example, keep that typed field: passing a `toolUse` content block to
+> a Strands agent can bypass model invocation and dispatch a tool directly.
+
 ## Run Basic App Hosted on ACR
 
 ### Deploy

--- a/examples/strands_math_agent/basic_app.py
+++ b/examples/strands_math_agent/basic_app.py
@@ -2,6 +2,7 @@ import logging
 
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from dotenv import load_dotenv
+from models import InvocationRequest
 from strands import Agent
 from strands.models import BedrockModel
 from strands_tools import calculator
@@ -31,7 +32,10 @@ def invoke_agent(payload):
     """
     Invoke the agent with a payload
     """
-    user_input = payload.get("prompt")
+    # Validate the payload: `prompt: str` rejects non-string input (e.g. toolUse
+    # content blocks) before it reaches the agent.
+    request = InvocationRequest(**payload)
+    user_input = request.prompt
 
     logger.info("User input: %s", user_input)
 

--- a/examples/strands_math_agent/models.py
+++ b/examples/strands_math_agent/models.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class InvocationRequest(BaseModel):
+    # `prompt` is typed `str` on purpose: it is passed straight to the agent, and
+    # pydantic rejects any non-string value (e.g. a list of content blocks) before
+    # the agent runs. Do NOT relax this to `str | list` / `Any` — accepting a
+    # `toolUse` content block here would let a caller bypass model invocation and
+    # dispatch a tool directly (Strands event-loop dispatch, H1-3679111).
+    prompt: str
+    # Ground truth for reward computation (RL entrypoint only); optional so the
+    # production entrypoint can accept the same payload shape.
+    answer: str | None = None

--- a/examples/strands_math_agent/rl_app.py
+++ b/examples/strands_math_agent/rl_app.py
@@ -1,5 +1,6 @@
 import logging
 
+from models import InvocationRequest
 from reward import GSM8KReward
 from strands import Agent
 from strands.models.openai import OpenAIModel
@@ -58,8 +59,12 @@ def invoke_agent(payload: dict, context):
         system_prompt=system_prompt,
     )
 
-    user_input = payload.get("prompt")
-    answer = payload.get("answer")  # used for computing reward
+    # Validate the payload: `prompt: str` rejects non-string input (e.g. toolUse
+    # content blocks) before it reaches the agent. Malformed payloads raise a
+    # pydantic ValidationError, which the entrypoint surfaces as an error result.
+    request = InvocationRequest(**payload)
+    user_input = request.prompt
+    answer = request.answer  # used for computing reward
 
     logger.info("User input: %s", user_input)
 

--- a/examples/strands_migration_agent/README.md
+++ b/examples/strands_migration_agent/README.md
@@ -158,6 +158,14 @@ curl -X POST http://localhost:8080/invocations \
   }'
 ```
 
+> **Security note — `repo_uri` is a trust boundary.** Each invocation carries a `repo_uri`
+> S3 URI; the agent downloads that repo tarball, extracts it, and runs with `shell` + `editor`
+> tools against the extracted tree. The extraction uses `filter="data"` so a crafted tar
+> cannot escape the work directory via path traversal, and `prompt` is a typed `str` (see
+> `models.py`) so a `toolUse` content block cannot bypass the model. Even so, only point this
+> agent at `repo_uri`s from a **bucket you control** — the extracted code and the prompt both
+> drive a powerful agent.
+
 ## Docker
 
 ### Build & run locally

--- a/examples/strands_migration_agent/models.py
+++ b/examples/strands_migration_agent/models.py
@@ -2,6 +2,12 @@ from pydantic import BaseModel
 
 
 class InvocationRequest(BaseModel):
+    # `prompt` is typed `str` on purpose. It is consumed via `.format(...)` and passed
+    # to an agent holding shell + editor tools, so pydantic rejecting any non-string
+    # value (e.g. a list of content blocks) before the agent runs is a security control,
+    # not just a convenience. Do NOT relax this to `str | list` / `Any` for multi-turn:
+    # accepting a `toolUse` content block here would let a caller bypass model invocation
+    # and dispatch a tool directly (Strands event-loop dispatch, H1-3679111).
     prompt: str
     repo_uri: str
     metadata_uri: str

--- a/examples/strands_migration_agent/utils.py
+++ b/examples/strands_migration_agent/utils.py
@@ -129,8 +129,13 @@ def load_repo_from_s3(s3_uri: str) -> str:
     if os.path.exists(repo_path):
         shutil.rmtree(repo_path)
 
+    # The repo archive is fetched from an attacker-influenceable S3 URI, so use
+    # filter="data" (Python 3.9+) to reject members with absolute paths or ".."
+    # traversal that would escape workdir (CVE-2007-4559). Without this, a crafted
+    # tar could overwrite files on sys.path (e.g. /app) before the agent — which
+    # holds shell + editor tools — runs against the extracted tree.
     with tarfile.open(tar_path, "r:gz") as tar:
-        tar.extractall(path=workdir)
+        tar.extractall(path=workdir, filter="data")
 
     if not os.path.exists(repo_path):
         raise ValueError(

--- a/examples/strands_officebench_agent/README.md
+++ b/examples/strands_officebench_agent/README.md
@@ -119,6 +119,25 @@ Results are saved to:
 - `results/{exp_id}/summary.json` — scores by category
 - `s3://{s3_output_bucket}/{exp_id}/...` — rollout data on S3
 
+> **Security note — where `task_uri`/`testbed_uri` come from, and why they are a trust
+> boundary.** `benchmark.py` lists the S3 prefix you populated in step 1
+> (`list_all_subtasks`) and, for each subtask, derives a `task_uri`
+> (`.../{task_id}/{subtask_id}/config.json`) and a `testbed_uri`
+> (`.../{task_id}/testbed.tar.gz`). It puts both into each invocation payload
+> (`{"task_uri": ..., "testbed_uri": ...}`) sent to the ACR agent. At rollout time the
+> agent **downloads the task config and testbed from those URIs** and then runs with
+> `shell` + all office tools against the extracted testbed and the task instruction —
+> so whoever controls those S3 objects controls what a powerful agent executes.
+>
+> This example hardens the mechanics: the task config is validated against a pydantic
+> `TaskConfig` (so `task` must be a string, never a `toolUse` content block that could
+> bypass model invocation), and the testbed tarball is extracted with `filter="data"`
+> (so a crafted archive cannot escape `/testbed` via `..`/absolute-path traversal). But
+> hardening the mechanics does not make the **content** of a task instruction safe — it
+> is free-form text driving `shell`. Only point the benchmark at a prefix in a **bucket
+> you control**; do not accept `task_uri`/`testbed_uri` values that originate from
+> untrusted principals.
+
 ## Configuration
 
 Example configuration is in `config.toml`:

--- a/examples/strands_officebench_agent/models.py
+++ b/examples/strands_officebench_agent/models.py
@@ -4,3 +4,30 @@ from pydantic import BaseModel
 class InvocationRequest(BaseModel):
     task_uri: str  # S3 URI to task config JSON (e.g. s3://bucket/officebench/1-1/config.json)
     testbed_uri: str | None = None  # S3 URI to testbed tar.gz (if task has data files)
+
+
+class EvaluationCheck(BaseModel):
+    # Each check names an evaluation function and its args. `function` is looked up
+    # against an allowlist (EVAL_FUNCTIONS in reward.py) at scoring time, so an
+    # unknown name scores 0.0 rather than executing anything.
+    function: str
+    args: dict = {}
+
+
+class TaskConfig(BaseModel):
+    # Schema for the task config JSON loaded from the (untrusted) task_uri S3 object.
+    # `task` is the natural-language instruction handed to an agent that holds
+    # shell + ALL_TOOLS, so we require it to be a string here — this guarantees a
+    # non-string/content-block value can never reach the agent, and that required
+    # fields are present before the rollout runs. Extra keys are ignored.
+    #
+    # Trust boundary: validating the shape does NOT make the *content* of `task`
+    # safe — it is free-form text driving a powerful agent. Task URIs must come
+    # from a trusted bucket you control; do not point this agent at task configs
+    # from untrusted principals.
+    task: str
+    evaluation: list[EvaluationCheck] = []
+    username: str | None = None
+    date: str | None = None
+    weekday: str | None = None
+    time: str | None = None

--- a/examples/strands_officebench_agent/reward.py
+++ b/examples/strands_officebench_agent/reward.py
@@ -4,8 +4,10 @@ Adapts evaluation logic from OfficeBench's utils/evaluate.py to run locally
 on the testbed directory. All evaluation is outcome-based: check files on disk.
 """
 
+import ast
 import difflib
 import logging
+import operator
 import os
 import re
 from glob import glob
@@ -17,6 +19,141 @@ import pytz
 from agentcore_rl_toolkit import RewardFunction
 
 logger = logging.getLogger(__name__)
+
+
+# ── Safe comparator evaluation ──────────────────────────────────────────────
+# OfficeBench task configs express a comparator as a Python lambda *string*
+# (e.g. "lambda x: x in ['1', '2', '3']"). These configs are loaded from an S3
+# URI supplied in the invocation payload, so they are untrusted input. Passing
+# them to eval() is arbitrary code execution (RCE). Instead we parse the lambda
+# with ast.parse() and evaluate it with a small allowlist interpreter: only a
+# single-arg lambda whose body is built from comparisons (including membership),
+# boolean/arithmetic/unary ops, numeric/string literals, list/tuple/set literals,
+# the lambda's own parameter, and a handful of pure numeric-coercion builtins is
+# permitted. Every other node type (attribute access, arbitrary names/calls,
+# subscripts, comprehensions, imports, ...) is rejected before any code runs, so
+# there is no reachable path to import, reflection, or the filesystem. ** is
+# deliberately excluded to avoid cheap CPU/memory blow-ups (e.g. 2 ** 10**9).
+
+# Builtins the comparator body may call. All are pure, side-effect-free coercions.
+_SAFE_COMPARATOR_BUILTINS = {
+    "int": int,
+    "float": float,
+    "str": str,
+    "len": len,
+    "abs": abs,
+    "round": round,
+    "bool": bool,
+}
+
+_SAFE_BINOPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+}
+
+_SAFE_COMPARES = {
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+    ast.Lt: operator.lt,
+    ast.LtE: operator.le,
+    ast.Gt: operator.gt,
+    ast.GtE: operator.ge,
+    ast.In: lambda a, b: a in b,
+    ast.NotIn: lambda a, b: a not in b,
+}
+
+_SAFE_UNARYOPS = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+    ast.Not: operator.not_,
+}
+
+
+class UnsafeComparatorError(ValueError):
+    """Raised when a comparator string contains constructs outside the allowlist."""
+
+
+def _make_safe_comparator(expr: str):
+    """Compile an OfficeBench comparator lambda string into a safe callable.
+
+    Accepts only a single-argument ``lambda`` whose body is composed of
+    comparisons (including ``in``/``not in``), boolean/arithmetic/unary ops,
+    numeric/string literals, list/tuple/set literals, the lambda parameter, and
+    the coercion builtins in ``_SAFE_COMPARATOR_BUILTINS``. Raises
+    ``UnsafeComparatorError`` for anything else, so a malicious task config can
+    never execute arbitrary code.
+    """
+    try:
+        tree = ast.parse(expr, mode="eval")
+    except SyntaxError as e:
+        raise UnsafeComparatorError(f"Comparator is not a valid expression: {expr!r}") from e
+
+    if not isinstance(tree.body, ast.Lambda):
+        raise UnsafeComparatorError(f"Comparator must be a lambda expression: {expr!r}")
+
+    lam = tree.body
+    args = lam.args
+    if args.posonlyargs or args.kwonlyargs or args.vararg or args.kwarg or args.defaults or len(args.args) != 1:
+        raise UnsafeComparatorError(f"Comparator lambda must take exactly one positional arg: {expr!r}")
+
+    param_name = args.args[0].arg
+    # Filled in per-call by the returned closure before evaluating the body.
+    param_holder = {}
+
+    def _eval(node):
+        if isinstance(node, ast.Constant):
+            if isinstance(node.value, (int, float, bool, str)):
+                return node.value
+            raise UnsafeComparatorError(f"Disallowed literal type: {type(node.value).__name__}")
+        if isinstance(node, ast.Name):
+            if node.id == param_name:
+                return param_holder["value"]
+            raise UnsafeComparatorError(f"Disallowed name reference: {node.id!r}")
+        if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            elts = [_eval(e) for e in node.elts]
+            if isinstance(node, ast.List):
+                return elts
+            if isinstance(node, ast.Tuple):
+                return tuple(elts)
+            return set(elts)
+        if isinstance(node, ast.BinOp) and type(node.op) in _SAFE_BINOPS:
+            return _SAFE_BINOPS[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp) and type(node.op) in _SAFE_UNARYOPS:
+            return _SAFE_UNARYOPS[type(node.op)](_eval(node.operand))
+        if isinstance(node, ast.BoolOp):
+            values = [_eval(v) for v in node.values]
+            if isinstance(node.op, ast.And):
+                return all(values)
+            return any(values)
+        if isinstance(node, ast.Compare):
+            left = _eval(node.left)
+            result = True
+            for op, comparator_node in zip(node.ops, node.comparators, strict=True):
+                op_type = type(op)
+                if op_type not in _SAFE_COMPARES:
+                    raise UnsafeComparatorError(f"Disallowed comparison operator: {op_type.__name__}")
+                right = _eval(comparator_node)
+                if not _SAFE_COMPARES[op_type](left, right):
+                    result = False
+                    break
+                left = right
+            return result
+        if isinstance(node, ast.Call):
+            if not isinstance(node.func, ast.Name) or node.func.id not in _SAFE_COMPARATOR_BUILTINS or node.keywords:
+                raise UnsafeComparatorError("Only calls to allowlisted numeric builtins are permitted")
+            fn = _SAFE_COMPARATOR_BUILTINS[node.func.id]
+            return fn(*[_eval(a) for a in node.args])
+        raise UnsafeComparatorError(f"Disallowed expression: {type(node).__name__}")
+
+    def comparator(value):
+        param_holder["value"] = value
+        return bool(_eval(lam.body))
+
+    return comparator
 
 
 # ── File reading helpers (adapted from OfficeBench apps) ────────────────────
@@ -234,7 +371,13 @@ def evaluate_excel_cell_comparator(testbed_dir: str, args: dict) -> bool:
         x = re.search(pattern, content)
         if x:
             value = x.group(1)
-            if eval(match["comparator"])(value):  # noqa: S307
+            try:
+                comparator = _make_safe_comparator(match["comparator"])
+            except UnsafeComparatorError as e:
+                # Untrusted comparator outside the safe allowlist — never execute it.
+                logger.warning("Rejected unsafe comparator %r: %s", match.get("comparator"), e)
+                return False
+            if comparator(value):
                 continue
             else:
                 return False

--- a/examples/strands_officebench_agent/utils.py
+++ b/examples/strands_officebench_agent/utils.py
@@ -5,6 +5,7 @@ import shutil
 import tarfile
 
 import boto3
+from models import TaskConfig
 
 logger = logging.getLogger(__name__)
 
@@ -20,12 +21,23 @@ def parse_s3_uri(s3_uri: str) -> tuple[str, str]:
 
 
 def load_task_from_s3(task_uri: str) -> dict:
-    """Download task config JSON from S3 and return as dict."""
+    """Download task config JSON from S3, validate its shape, and return as dict.
+
+    The task config is untrusted (task_uri comes from the invocation payload).
+    We validate it against TaskConfig before use so that `task` is guaranteed to
+    be a string — it is handed to an agent holding shell + ALL_TOOLS — and the
+    evaluation list is well-formed. A malformed config raises a pydantic
+    ValidationError, which the entrypoint surfaces as an error result instead of
+    letting a non-string/content-block value reach the agent.
+    """
     s3 = boto3.client("s3")
     bucket, key = parse_s3_uri(task_uri)
     response = s3.get_object(Bucket=bucket, Key=key)
     content = response["Body"].read().decode("utf-8")
-    return json.loads(content)
+    task_config = json.loads(content)
+    # Validate shape; raises pydantic.ValidationError on malformed configs.
+    TaskConfig(**task_config)
+    return task_config
 
 
 def setup_testbed(testbed_uri: str | None) -> str:
@@ -67,10 +79,13 @@ def setup_testbed(testbed_uri: str | None) -> str:
         s3.download_file(bucket, key, tar_path)
 
         # Extract tar.gz — the archive should contain the testbed contents
-        # (data/, calendar/, emails/ directories)
+        # (data/, calendar/, emails/ directories). The archive is fetched from an
+        # attacker-influenceable S3 URI, so use filter="data" (Python 3.9+) to reject
+        # members with absolute paths or ".." traversal that would escape TESTBED_DIR
+        # (CVE-2007-4559).
         os.makedirs(TESTBED_DIR, exist_ok=True)
         with tarfile.open(tar_path, "r:gz") as tar:
-            tar.extractall(path=TESTBED_DIR)
+            tar.extractall(path=TESTBED_DIR, filter="data")
 
         os.remove(tar_path)
         logger.info(f"Extracted testbed from {testbed_uri} to {TESTBED_DIR}")

--- a/src/agentcore_rl_toolkit/app.py
+++ b/src/agentcore_rl_toolkit/app.py
@@ -114,6 +114,17 @@ class AgentCoreRLApp(BedrockAgentCoreApp):
         3. Handles errors and saves error results for client notification
         4. Returns immediately with {"status": "processing"} for non-blocking behavior
 
+        Security — payload validation is the handler's responsibility. This decorator is
+        framework-agnostic plumbing: it forwards the raw HTTP payload to your function and
+        saves the returned dict. It does not (and cannot) know your payload schema, so it
+        performs no sanitization. If your handler passes payload fields to an agent, validate
+        them first — the recommended pattern is a pydantic model with the field typed `str`
+        (e.g. ``class InvocationRequest(BaseModel): prompt: str``), which rejects non-string
+        values such as ``toolUse`` content blocks before they reach the agent. Passing a
+        ``toolUse`` content block to a Strands agent can bypass model invocation and dispatch
+        a tool directly (Strands event-loop dispatch); a ``prompt: str`` field closes this.
+        See ``examples/strands_math_agent/models.py`` for the reference pattern.
+
         The return value must be a JSON-serializable dict when S3 save is configured.
         Any dict structure is accepted — there are no required keys. Common patterns:
         - RL training: {"rollout_data": [...], "rewards": [...]}


### PR DESCRIPTION
## Summary

  This PR hardens the example agents so that untrusted input, such as request payloads and
  data fetched from S3 (task configs, repo/testbed tarballs), is validated before it reaches an agent, 
  the filesystem, or an expression evaluator. All changes are behavior-preserving on valid inputs.

  ## Math agent (`examples/strands_math_agent`)

  - Added `models.py` with a pydantic `InvocationRequest` model whose `prompt` field is
    typed `str` (plus optional `answer`).
  - `basic_app.py` and `rl_app.py` now construct `InvocationRequest(**payload)` and read
    `request.prompt` instead of `payload.get("prompt")`, so non-string payload values are
    rejected before the agent runs.
  - README: added a note under the Invoke section explaining that the entrypoint validates
    the payload and that the `prompt: str` field should be preserved when adapting the
    example.

  ## OfficeBench agent (`examples/strands_officebench_agent`)

  - **Safe comparator evaluation (`reward.py`).** Replaced `eval(match["comparator"])(value)`
    in `evaluate_excel_cell_comparator` with `_make_safe_comparator()`, a small AST-based
    interpreter. It accepts only a single-argument `lambda` built from comparisons
    (including `in`/`not in`), boolean/arithmetic/unary ops, numeric/string literals,
    list/tuple/set literals, the lambda parameter, and a fixed allowlist of pure numeric
    builtins (`int`, `float`, `str`, `len`, `abs`, `round`, `bool`). Any other construct
    (attribute access, arbitrary names/calls, `**`, etc.) raises `UnsafeComparatorError`,
    which is logged and scored `0.0`.
  - **Task config validation (`models.py`, `utils.py`).** Added pydantic `TaskConfig` and
    `EvaluationCheck` models. `load_task_from_s3` now validates the downloaded JSON against
    `TaskConfig` (requiring `task` to be a string and a well-formed `evaluation` list) before
    returning it.
  - **Safe tarball extraction (`utils.py`).** `setup_testbed` now extracts the testbed
    archive with `tarfile.extractall(..., filter="data")`, rejecting members with absolute
    paths or `..` traversal that would escape `/testbed`.
  - README: added a note at the end of the "Run benchmark" section explaining where
    `task_uri`/`testbed_uri` come from, how they flow into the invocation payload, and the
    trust-boundary expectation that they shoud point to user-controlled S3 buckets.

  ## Migration agent (`examples/strands_migration_agent`)

  - **Safe tarball extraction (`utils.py`).** `load_repo_from_s3` now extracts the repo
    archive with `tarfile.extractall(..., filter="data")`, preventing a crafted tar from
    escaping the work directory.
  - **`models.py`.** Documented that `InvocationRequest.prompt` is intentionally typed `str`
    and should not be relaxed, since it is passed to an agent with `shell` + `editor` tools.
  - README: added a note explaining that `repo_uri` is a trust boundary and should point to
    user-controlled S3 buckets.

## Toolkit (`src/agentcore_rl_toolkit/app.py`)

  - Expanded the `rollout_entrypoint` docstring to state that payload validation is the
    handler's responsibility (the decorator is framework-agnostic plumbing and performs no
    sanitization) and to recommend the pydantic `prompt: str` pattern, pointing to
    `examples/strands_math_agent/models.py` as the reference.
