### PR TITLE
fix(verl): preserve full-context agent trajectories

### DIFF
--- a/src/agentcore_rl_toolkit/backends/experimental/verl/README.md
+++ b/src/agentcore_rl_toolkit/backends/experimental/verl/README.md
@@ -181,7 +181,12 @@ The integration keeps three limits separate:
 - `rollout.max_model_len` is the inference engine's model-context capacity. It
   must be set explicitly; stock verl validates it against the model's Hugging
   Face `max_position_embeddings`.
-- `response_length` is verl's storage width for everything after the initial
+- `prompt_length` is verl's fixed storage width for the leading context of each
+  emitted training row; it does not cap the prompts the gateway sends to the
+  inference engine. A row may begin at the first model turn or at a later
+  trajectory fork, so its leading context can include a long accumulated
+  multi-turn prompt.
+- `response_length` is verl's storage width for everything after the leading
   prompt region and the gateway's cumulative trajectory budget. It must not
   exceed `max_model_len`.
 - `max_tokens_per_turn` is a required `agentcore_agent.yaml` setting. It becomes
@@ -192,10 +197,16 @@ To let variable-length prompts use the full model window, set
 `response_length = max_model_len` and enable
 `actor_rollout_ref.model.use_remove_padding=true`. This gives verl a nominal
 `prompt_length + response_length` padded width, but the gateway limits valid
-tokens to `max_model_len`. If the initial rendered prompt exceeds
-`prompt_length`, the adapter preserves its overflow at the front of the
-response region with loss mask and rollout logprob zero; the adapter performs
-no additional token slicing.
+tokens to `max_model_len`. If both lengths equal `max_model_len`, the nominal
+row width is therefore `2 * max_model_len`; remove-padding avoids most model
+compute on padding, but the wider fixed-width staging tensors still increase
+memory and transfer overhead. Set `prompt_length` high enough for the leading
+contexts expected in emitted rows (or to `max_model_len` to rule out overflow).
+If a leading context does exceed `prompt_length`, the adapter preserves its
+overflow at the front of the response region with loss mask and rollout logprob
+zero. Training remains correct, but verl's stock length metrics count those
+overflow tokens as part of the response region, so overflow should be a
+fallback rather than the normal configuration.
 
 The script name encodes the configuration axes: FSDP engine, full fine-tune, sync
 trainer mode, GRPO. Its defaults are the validated stable configuration; three

--- a/src/agentcore_rl_toolkit/backends/experimental/verl/README.md
+++ b/src/agentcore_rl_toolkit/backends/experimental/verl/README.md
@@ -166,11 +166,36 @@ python preprocess_gsm8k.py --output-dir gsm8k
 The example owns two config files, split by which config tree they feed:
 `fsdp_fft_sync_grpo.sh` sets verl-tree knobs (overridable from the CLI via its
 trailing `"$@"`), and `agentcore_agent.yaml` — the per-run agent-loop config —
-carries the loop's kwargs (ARN, bucket, `max_rollout_time`, ...).
+carries the loop's kwargs (ARN, bucket, `max_tokens_per_turn`,
+`max_rollout_time`, ...).
 Loop kwargs are NOT CLI-addressable (verl loads the YAML worker-side, outside
 hydra's override grammar): edit the YAML, or use `${oc.env:...}` interpolation
-for values that should vary per launch. Unset kwargs fall back to
-`AgentCoreAgentLoop.__init__` defaults.
+for values that should vary per launch. Except for required
+`max_tokens_per_turn`, unset kwargs fall back to `AgentCoreAgentLoop.__init__`
+defaults.
+
+## Token budgets
+
+The integration keeps three limits separate:
+
+- `rollout.max_model_len` is the inference engine's model-context capacity. It
+  must be set explicitly; stock verl validates it against the model's Hugging
+  Face `max_position_embeddings`.
+- `response_length` is verl's storage width for everything after the initial
+  prompt region and the gateway's cumulative trajectory budget. It must not
+  exceed `max_model_len`.
+- `max_tokens_per_turn` is a required `agentcore_agent.yaml` setting. It becomes
+  the gateway's default `max_new_tokens` for each model call; a smaller request
+  limit and the remaining model context can clamp it further.
+
+To let variable-length prompts use the full model window, set
+`response_length = max_model_len` and enable
+`actor_rollout_ref.model.use_remove_padding=true`. This gives verl a nominal
+`prompt_length + response_length` padded width, but the gateway limits valid
+tokens to `max_model_len`. If the initial rendered prompt exceeds
+`prompt_length`, the adapter preserves its overflow at the front of the
+response region with loss mask and rollout logprob zero; the adapter performs
+no additional token slicing.
 
 The script name encodes the configuration axes: FSDP engine, full fine-tune, sync
 trainer mode, GRPO. Its defaults are the validated stable configuration; three

--- a/src/agentcore_rl_toolkit/backends/experimental/verl/agent_loop.py
+++ b/src/agentcore_rl_toolkit/backends/experimental/verl/agent_loop.py
@@ -106,6 +106,7 @@ class AgentCoreAgentLoop(AgentLoopBase):
         *,
         agent_runtime_arn: str,
         s3_bucket: str,
+        max_tokens_per_turn: int,
         exp_id: str | None = None,
         tps_limit: int = 5,
         max_pool_connections: int = 100,
@@ -141,6 +142,12 @@ class AgentCoreAgentLoop(AgentLoopBase):
 
         self.prompt_length = self.rollout_config.prompt_length
         self.response_length = self.rollout_config.response_length
+        self.max_model_len = self.rollout_config.max_model_len
+        self._validate_token_budgets(max_tokens_per_turn)
+        self.max_tokens_per_turn = max_tokens_per_turn
+        # The gateway cannot emit more tokens than verl's response region can store.
+        # The two padded regions may sum past max_model_len; valid tokens never do.
+        self.max_context_tokens = self.response_length
         self.max_rollout_time = max_rollout_time
         # Kept as config, not inlined, so a validated trainer-side mode can land
         # without a signature change. Reward semantics: see the README.
@@ -171,6 +178,35 @@ class AgentCoreAgentLoop(AgentLoopBase):
             max_pool_connections=max_pool_connections,
         )
 
+    def _validate_token_budgets(self, max_tokens_per_turn: int) -> None:
+        if self.max_model_len is None or self.max_model_len <= 0:
+            raise ValueError(
+                "AgentCoreAgentLoop requires an explicit positive "
+                "actor_rollout_ref.rollout.max_model_len. This is the model context "
+                "capacity; verl validates it against the Hugging Face model config."
+            )
+        if self.prompt_length > self.max_model_len:
+            raise ValueError(
+                f"rollout.prompt_length ({self.prompt_length}) cannot exceed "
+                f"rollout.max_model_len ({self.max_model_len})"
+            )
+        if self.response_length > self.max_model_len:
+            raise ValueError(
+                f"rollout.response_length ({self.response_length}) cannot exceed "
+                f"rollout.max_model_len ({self.max_model_len})"
+            )
+        if (
+            not isinstance(max_tokens_per_turn, int)
+            or isinstance(max_tokens_per_turn, bool)
+            or max_tokens_per_turn <= 0
+        ):
+            raise ValueError(f"max_tokens_per_turn must be a positive integer, got {max_tokens_per_turn!r}")
+        if max_tokens_per_turn > self.max_model_len:
+            raise ValueError(
+                f"max_tokens_per_turn ({max_tokens_per_turn}) cannot exceed "
+                f"rollout.max_model_len ({self.max_model_len})"
+            )
+
     # Returning a list deliberately widens AgentLoopBase.run's annotation: the v1
     # TQ path accepts AgentLoopOutput | list[AgentLoopOutput] (one row per
     # trajectory-tree leaf); __init__ asserts trainer.use_v1 accordingly.
@@ -186,7 +222,7 @@ class AgentCoreAgentLoop(AgentLoopBase):
         self._gateway.gateway.create_session(
             sid,
             sampling_defaults=self._sampling_defaults(sampling_params),
-            max_context_tokens=self.prompt_length + self.response_length,
+            max_context_tokens=self.max_context_tokens,
         )
 
         result: dict[str, Any] = {}
@@ -306,7 +342,7 @@ class AgentCoreAgentLoop(AgentLoopBase):
                 break
 
     def _sampling_defaults(self, sampling_params: dict[str, Any]) -> dict[str, Any]:
-        defaults: dict[str, Any] = {"max_new_tokens": self.response_length}
+        defaults: dict[str, Any] = {"max_new_tokens": self.max_tokens_per_turn}
         for key in ("temperature", "top_p", "top_k"):
             if key in sampling_params:
                 defaults[key] = sampling_params[key]
@@ -338,19 +374,22 @@ class AgentCoreAgentLoop(AgentLoopBase):
         shared_extra: dict[str, Any],
         elapsed: float,
     ) -> AgentLoopOutput:
-        resp_len = len(record.loss_mask)
-        prompt_ids = record.token_ids[:-resp_len] if resp_len else list(record.token_ids)
-        response_ids = record.token_ids[-resp_len:] if resp_len else []
+        response_region_len = len(record.loss_mask)
+        prompt_end = len(record.token_ids) - response_region_len
+        initial_prompt = list(record.token_ids[:prompt_end])
+        response_region_ids = list(record.token_ids[prompt_end:])
         response_mask = list(record.loss_mask)
         response_logprobs = list(record.logprobs)
-        assert len(response_ids) == len(response_mask) == len(response_logprobs)
 
-        # verl pads prompts to prompt_length (left) and responses to
-        # response_length (right); anything longer must be truncated here.
-        prompt_ids = prompt_ids[-self.prompt_length :]
-        response_ids = response_ids[: self.response_length]
-        response_mask = response_mask[: self.response_length]
-        response_logprobs = response_logprobs[: self.response_length]
+        # verl stores prompts and responses in fixed-width regions. Preserve the
+        # complete token order when the initial prompt exceeds its region by placing
+        # the overflow at the start of the response region. These are input tokens:
+        # they remain attended to, but carry no policy loss or rollout logprob.
+        prompt_ids = initial_prompt[: self.prompt_length]
+        prompt_overflow = initial_prompt[self.prompt_length :]
+        response_ids = prompt_overflow + response_region_ids
+        response_mask = [0] * len(prompt_overflow) + response_mask
+        response_logprobs = [0.0] * len(prompt_overflow) + response_logprobs
 
         return AgentLoopOutput(
             prompt_ids=prompt_ids,

--- a/src/agentcore_rl_toolkit/backends/experimental/verl/agent_loop.py
+++ b/src/agentcore_rl_toolkit/backends/experimental/verl/agent_loop.py
@@ -195,11 +195,7 @@ class AgentCoreAgentLoop(AgentLoopBase):
                 f"rollout.response_length ({self.response_length}) cannot exceed "
                 f"rollout.max_model_len ({self.max_model_len})"
             )
-        if (
-            not isinstance(max_tokens_per_turn, int)
-            or isinstance(max_tokens_per_turn, bool)
-            or max_tokens_per_turn <= 0
-        ):
+        if type(max_tokens_per_turn) is not int or max_tokens_per_turn <= 0:  # noqa: E721 - reject bool
             raise ValueError(f"max_tokens_per_turn must be a positive integer, got {max_tokens_per_turn!r}")
         if max_tokens_per_turn > self.max_model_len:
             raise ValueError(

--- a/src/agentcore_rl_toolkit/backends/experimental/verl/examples/math_agent/agentcore_agent.yaml
+++ b/src/agentcore_rl_toolkit/backends/experimental/verl/examples/math_agent/agentcore_agent.yaml
@@ -1,13 +1,17 @@
 # Per-run agent-loop config for verl's `rollout.agent.agent_loop_config_path` —
 # part of this example, edit freely. Every key besides `name` and `_target_` is
-# passed to AgentCoreAgentLoop.__init__; unset keys use the constructor defaults
-# (see the backend README for the full kwarg reference). `${oc.env:VAR}` is
+# passed to AgentCoreAgentLoop.__init__; `max_tokens_per_turn` is required and
+# other unset keys use the constructor defaults (see the backend README).
+# `${oc.env:VAR}` is
 # OmegaConf env-var interpolation (errors if VAR is unset), keeping ARNs/buckets
 # out of committed config.
 - name: agentcore_agent
   _target_: agentcore_rl_toolkit.backends.experimental.verl.agent_loop.AgentCoreAgentLoop
   agent_runtime_arn: ${oc.env:AGENT_RUNTIME_ARN}
   s3_bucket: ${oc.env:ACR_S3_BUCKET}
+  # Maximum output from one model call. The cumulative rollout remains bounded
+  # separately by min(rollout.max_model_len, rollout.response_length).
+  max_tokens_per_turn: 2048
   # math rollouts finish in well under 2 minutes; fail hung sessions fast
   # instead of holding a TransferQueue slot for the 1800s library default
   max_rollout_time: 180

--- a/src/agentcore_rl_toolkit/backends/experimental/verl/examples/math_agent/fsdp_fft_sync_grpo.sh
+++ b/src/agentcore_rl_toolkit/backends/experimental/verl/examples/math_agent/fsdp_fft_sync_grpo.sh
@@ -47,6 +47,7 @@ test_files="['$gsm8k_test_path']"
 PROJECT_NAME=${PROJECT_NAME:-agentcore_grpo_experimental}
 EXPERIMENT_NAME=${EXPERIMENT_NAME:-gsm8k_qwen3_4b}
 CKPTS_DIR=${CKPTS_DIR:-checkpoints/${PROJECT_NAME}/${EXPERIMENT_NAME}}
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-16384}
 
 python3 -m verl.trainer.main_ppo \
     trainer.use_v1=true \
@@ -61,7 +62,7 @@ python3 -m verl.trainer.main_ppo \
     data.train_batch_size=64 \
     data.val_batch_size=256 \
     data.max_prompt_length=14336 \
-    data.max_response_length=2048 \
+    data.max_response_length=$MAX_MODEL_LEN \
     data.custom_cls.path=pkg://agentcore_rl_toolkit.backends.experimental.verl.dataset \
     data.custom_cls.name=PayloadDataset \
     actor_rollout_ref.model.path=Qwen/Qwen3-4B-Instruct-2507 \
@@ -69,7 +70,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.actor.optim.lr=5e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=64 \
     actor_rollout_ref.actor.use_dynamic_bsz=True \
-    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=16384 \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=$MAX_MODEL_LEN \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
@@ -79,8 +80,8 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.rollout.mode=async \
     actor_rollout_ref.rollout.calculate_log_probs=true \
     actor_rollout_ref.rollout.prompt_length=14336 \
-    actor_rollout_ref.rollout.response_length=2048 \
-    actor_rollout_ref.rollout.max_model_len=16384 \
+    actor_rollout_ref.rollout.response_length=$MAX_MODEL_LEN \
+    actor_rollout_ref.rollout.max_model_len=$MAX_MODEL_LEN \
     actor_rollout_ref.rollout.enforce_eager=False \
     actor_rollout_ref.rollout.temperature=1.0 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
@@ -95,7 +96,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.rollout.agent.agent_loop_config_path="$AGENT_LOOP_CONFIG" \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
     trainer.critic_warmup=0 \
-    trainer.default_local_dir=$CKPTS_DIR \
+    trainer.default_local_dir="$CKPTS_DIR" \
     trainer.resume_mode=disable \
     trainer.logger='["console"]' \
     trainer.project_name="$PROJECT_NAME" \

--- a/src/agentcore_rl_toolkit/rollout_gateway/trace.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/trace.py
@@ -66,5 +66,16 @@ class TraceRecord:
     # Off-policy / MoE fields (weight_version, routed_experts) are intentionally
     # omitted for now; add them as optional fields if a consumer needs them.
 
+    def __post_init__(self) -> None:
+        if len(self.loss_mask) > len(self.token_ids):
+            raise ValueError(
+                f"TraceRecord loss_mask has {len(self.loss_mask)} entries but token_ids "
+                f"has only {len(self.token_ids)}"
+            )
+        if len(self.logprobs) != len(self.loss_mask):
+            raise ValueError(
+                f"TraceRecord logprobs has {len(self.logprobs)} entries but loss_mask " f"has {len(self.loss_mask)}"
+            )
+
 
 __all__ = ["BaseTrace", "Status", "TraceRecord"]

--- a/tests/backends/experimental/verl/conftest.py
+++ b/tests/backends/experimental/verl/conftest.py
@@ -32,7 +32,13 @@ from verl.workers.rollout.replica import TokenOutput  # noqa: E402
 # -- config helpers -------------------------------------------------------------
 
 
-def make_trainer_config(*, use_v1: bool = True, prompt_length: int = 64, response_length: int = 32) -> DictConfigWrap:
+def make_trainer_config(
+    *,
+    use_v1: bool = True,
+    prompt_length: int = 64,
+    response_length: int = 32,
+    max_model_len: int | None = 128,
+) -> DictConfigWrap:
     """The slice of verl's trainer config AgentLoopBase + AgentCoreAgentLoop read."""
     return DictConfigWrap(
         OmegaConf.create(
@@ -40,7 +46,11 @@ def make_trainer_config(*, use_v1: bool = True, prompt_length: int = 64, respons
                 "trainer": {"use_v1": use_v1},
                 "actor_rollout_ref": {
                     "model": {"path": "test/model"},
-                    "rollout": {"prompt_length": prompt_length, "response_length": response_length},
+                    "rollout": {
+                        "prompt_length": prompt_length,
+                        "response_length": response_length,
+                        "max_model_len": max_model_len,
+                    },
                 },
             }
         )

--- a/tests/backends/experimental/verl/test_agent_loop.py
+++ b/tests/backends/experimental/verl/test_agent_loop.py
@@ -10,14 +10,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
+from agentcore_rl_toolkit.backends.experimental.verl import agent_loop as al
+from agentcore_rl_toolkit.backends.experimental.verl.agent_loop import AgentCoreAgentLoop
+from agentcore_rl_toolkit.rollout_gateway import TraceRecord
+
 from .conftest import FakeLLMServerClient, FakeTokenizer, make_data_config, make_trainer_config
 
 pytestmark = pytest.mark.asyncio
 
 
 def _make_loop(llm_client=None, *, use_v1=True, trainer_config=None, **loop_kwargs):
-    from agentcore_rl_toolkit.backends.experimental.verl.agent_loop import AgentCoreAgentLoop
-
     loop_kwargs.setdefault("max_tokens_per_turn", 8)
     with patch("agentcore_rl_toolkit.backends.experimental.verl.agent_loop.RolloutClient") as client_cls:
         client_cls.return_value = MagicMock()
@@ -154,8 +156,6 @@ async def test_separate_reward_mode_rejected():
 
 
 async def test_invalid_reward_mode_rejected():
-    from agentcore_rl_toolkit.backends.experimental.verl.agent_loop import AgentCoreAgentLoop
-
     with pytest.raises(ValueError, match="reward_mode"):
         with patch("agentcore_rl_toolkit.backends.experimental.verl.agent_loop.RolloutClient"):
             AgentCoreAgentLoop(
@@ -265,8 +265,6 @@ async def test_exp_id_derived_from_trainer_config():
 
 
 async def test_client_cached_by_config():
-    from agentcore_rl_toolkit.backends.experimental.verl import agent_loop as al
-
     loop1 = _make_loop()
     n_after_first = len(al._CLIENTS)
     loop2 = _make_loop()  # same config -> same cached client
@@ -300,8 +298,6 @@ async def test_payload_column_forwarded_verbatim():
 
 
 async def test_output_conversion_preserves_prompt_overflow():
-    from agentcore_rl_toolkit.rollout_gateway import TraceRecord
-
     loop = _make_loop(
         trainer_config=make_trainer_config(prompt_length=2, response_length=6, max_model_len=6),
         max_tokens_per_turn=4,

--- a/tests/backends/experimental/verl/test_agent_loop.py
+++ b/tests/backends/experimental/verl/test_agent_loop.py
@@ -15,13 +15,14 @@ from .conftest import FakeLLMServerClient, FakeTokenizer, make_data_config, make
 pytestmark = pytest.mark.asyncio
 
 
-def _make_loop(llm_client=None, *, use_v1=True, **loop_kwargs):
+def _make_loop(llm_client=None, *, use_v1=True, trainer_config=None, **loop_kwargs):
     from agentcore_rl_toolkit.backends.experimental.verl.agent_loop import AgentCoreAgentLoop
 
+    loop_kwargs.setdefault("max_tokens_per_turn", 8)
     with patch("agentcore_rl_toolkit.backends.experimental.verl.agent_loop.RolloutClient") as client_cls:
         client_cls.return_value = MagicMock()
         loop = AgentCoreAgentLoop(
-            make_trainer_config(use_v1=use_v1),
+            trainer_config or make_trainer_config(use_v1=use_v1),
             llm_client or FakeLLMServerClient(),
             FakeTokenizer(),
             None,
@@ -169,6 +170,7 @@ async def test_invalid_reward_mode_rejected():
                 gateway_bind_host="127.0.0.1",
                 gateway_public_host="127.0.0.1",
                 reward_mode="nope",
+                max_tokens_per_turn=8,
             )
 
 
@@ -297,16 +299,42 @@ async def test_payload_column_forwarded_verbatim():
     assert invoke.calls[0]["payload"] == {"prompt": "What is 2+2?", "answer": "4"}
 
 
-async def test_truncation_caps():
+async def test_output_conversion_preserves_prompt_overflow():
+    from agentcore_rl_toolkit.rollout_gateway import TraceRecord
+
+    loop = _make_loop(
+        trainer_config=make_trainer_config(prompt_length=2, response_length=6, max_model_len=6),
+        max_tokens_per_turn=4,
+    )
+    record = TraceRecord(
+        token_ids=[1, 2, 3, 4, 5, 6],
+        loss_mask=[1, 1],
+        logprobs=[-0.5, -0.6],
+    )
+
+    out = loop._record_to_output(record, 0, 1.0, 1, {}, 0.1)
+
+    assert out.prompt_ids == [1, 2]
+    assert out.response_ids == [3, 4, 5, 6]
+    assert out.response_mask == [0, 0, 1, 1]
+    assert out.response_logprobs == [0.0, 0.0, -0.5, -0.6]
+
+
+async def test_session_budget_matches_response_storage():
     llm = FakeLLMServerClient()
-    loop = _make_loop(llm)
-    loop.response_length = 1  # force response truncation
+    loop = _make_loop(
+        llm,
+        trainer_config=make_trainer_config(prompt_length=8, response_length=24, max_model_len=32),
+    )
     _wire_result(loop, {"status_code": 200, "rewards": 1.0})
-    outputs = await loop.run({}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"prompt": "hi"}, uid="u1")
-    out = outputs[0]
-    assert len(out.response_ids) == 1
-    assert len(out.response_mask) == 1
-    assert len(out.response_logprobs) == 1
+    gateway = loop._gateway.gateway
+    with patch.object(gateway, "create_session", wraps=gateway.create_session) as create_session:
+        await loop.run({}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"prompt": "hi"})
+
+    max_context_tokens = create_session.call_args.kwargs["max_context_tokens"]
+    assert max_context_tokens == 24
+    assert max_context_tokens == loop.response_length
+    assert max_context_tokens != loop.prompt_length + loop.response_length
 
 
 async def test_sampling_defaults_passed_to_gateway():
@@ -322,5 +350,22 @@ async def test_sampling_defaults_passed_to_gateway():
     assert sp["temperature"] == 0.3
     assert sp["top_p"] == 0.8
     assert sp["top_k"] == 20
-    # max_new_tokens defaults to response_length
-    assert sp["max_new_tokens"] == 32
+    assert sp["max_new_tokens"] == 8
+
+
+async def test_explicit_max_model_len_is_required():
+    with pytest.raises(ValueError, match="explicit positive.*max_model_len"):
+        _make_loop(trainer_config=make_trainer_config(max_model_len=None))
+
+
+@pytest.mark.parametrize("field", ["prompt_length", "response_length"])
+async def test_padded_region_cannot_exceed_max_model_len(field):
+    lengths = {field: 129}
+    with pytest.raises(ValueError, match=rf"{field} \(129\) cannot exceed .*max_model_len \(128\)"):
+        _make_loop(trainer_config=make_trainer_config(max_model_len=128, **lengths))
+
+
+@pytest.mark.parametrize("value", [0, -1, True, 129])
+async def test_invalid_max_tokens_per_turn_rejected(value):
+    with pytest.raises(ValueError, match="max_tokens_per_turn"):
+        _make_loop(max_tokens_per_turn=value)

--- a/tests/backends/experimental/verl/test_hydra_contract.py
+++ b/tests/backends/experimental/verl/test_hydra_contract.py
@@ -21,6 +21,7 @@ def test_instantiate_from_yaml_entry():
             "_target_": "agentcore_rl_toolkit.backends.experimental.verl.agent_loop.AgentCoreAgentLoop",
             "agent_runtime_arn": "arn:aws:bedrock-agentcore:us-west-2:123:runtime/test",
             "s3_bucket": "test-bucket",
+            "max_tokens_per_turn": 8,
             "max_rollout_time": 60,
             "gateway_bind_host": "127.0.0.1",
             "gateway_public_host": "127.0.0.1",

--- a/tests/backends/experimental/verl/test_hydra_contract.py
+++ b/tests/backends/experimental/verl/test_hydra_contract.py
@@ -9,12 +9,12 @@ import hydra
 from omegaconf import DictConfig, OmegaConf
 from verl.experimental.agent_loop.agent_loop import ToolListWrap
 
+from agentcore_rl_toolkit.backends.experimental.verl.agent_loop import AgentCoreAgentLoop
+
 from .conftest import FakeLLMServerClient, FakeTokenizer, make_data_config, make_trainer_config
 
 
 def test_instantiate_from_yaml_entry():
-    from agentcore_rl_toolkit.backends.experimental.verl.agent_loop import AgentCoreAgentLoop
-
     entry = OmegaConf.create(
         {
             "name": "agentcore_agent",

--- a/tests/rollout_gateway/test_trajectory.py
+++ b/tests/rollout_gateway/test_trajectory.py
@@ -8,6 +8,8 @@ propagation. No torch, no aiohttp, no network.
 import subprocess
 import sys
 
+import pytest
+
 from agentcore_rl_toolkit.rollout_gateway import (
     BaseTrace,
     Status,
@@ -15,6 +17,16 @@ from agentcore_rl_toolkit.rollout_gateway import (
     TrajectoryManager,
     TurnRecord,
 )
+
+
+def test_trace_record_rejects_loss_mask_longer_than_tokens():
+    with pytest.raises(ValueError, match="loss_mask has 3 entries.*token_ids has only 2"):
+        TraceRecord(token_ids=[1, 2], loss_mask=[1, 0, 1], logprobs=[-0.1, 0.0, -0.2])
+
+
+def test_trace_record_rejects_misaligned_logprobs():
+    with pytest.raises(ValueError, match="logprobs has 1 entries.*loss_mask has 2"):
+        TraceRecord(token_ids=[1, 2, 3], loss_mask=[1, 1], logprobs=[-0.1])
 
 
 def test_core_imports_without_torch_or_aiohttp():


### PR DESCRIPTION

## Problem

The verl integration treated `response_length` as both the per-turn generation cap and the cumulative trajectory budget. Together with verl's fixed prompt and response tensor regions, this forced a static context partition: short prompts wasted available context, while prompts that exceeded `prompt_length` could be truncated during output conversion.

## Fix

- Separate the model window (`max_model_len`), cumulative trajectory storage (`response_length`), and per-turn generation cap (`max_tokens_per_turn`).
- Preserve prompt overflow at the start of verl's response region with zero loss mask and zero rollout logprob, retaining token order without training on input tokens.
- Validate token-budget configuration and `TraceRecord` alignment at their ownership boundaries.
- Document the full-window configuration and make `max_tokens_per_turn` explicit in the math-agent example.

### Example

Given `prompt_length=4`, `response_length=max_model_len=12`, and two model turns separated by a tool result, the gateway may capture:

```text
initial prompt:  [SYS, RULES, USER, QUESTION, DETAILS, ASK]
response tokens: [CALL, CALC, TOOL_42, ANSWER, 42]
loss mask:       [   1,    1,       0,      1,  1]
```

Previously, verl's four-token prompt region retained only `[USER, QUESTION, DETAILS, ASK]`, dropping `SYS` and `RULES`. The fix preserves the original order by moving the overflow into the response prefix:

```text
prompt_ids:        [SYS, RULES, USER, QUESTION]
response_ids:      [DETAILS, ASK, CALL, CALC, TOOL_42, ANSWER, 42]
response_mask:     [      0,   0,    1,    1,       0,      1,  1]
response_logprobs: [      0,   0,   lp,   lp,       0,     lp, lp]
```

The overflow remains visible as model input but contributes no policy loss or rollout logprob. Tool output remains zero-masked, while both assistant turns remain trainable.

## Validation

- Added focused tests for prompt-overflow preservation, zero masking/logprobs, gateway context budgeting, invalid budgets, and malformed trace records.
- Completed a 116-step Qwen3-4B GSM8K run on 8 B200 GPUs with `prompt_length=14336`, `response_length=max_model_len=16384`, and `max_tokens_per_turn=2048`.
- Against the prior `14336` prompt / `2048` response configuration, validation accuracy is roughly the same.

<img width="455" height="290" alt="Screenshot 2026-08-12 at 9 16 56 PM" src="https://github.com/user-attachments/assets/955a0a11-7460-474e-a480-5692ad8055d0" />

## Follow-up

- **Context overflow:** Return an explicit error to the agent when a newly rendered prompt fills or exceeds the remaining model context, while retaining the tool result in the captured conversation and excluding the unsampled turn from training.
- **Higher padding buffer width:** To avoid confusing `prompt_length/clip_ratio` metrics, we encourage users to use a large `prompt_length` close to `max_model_len`. This causes verl to over-provision padding width, though the padding will be removed before model forward pass to avoid computation waste. Follow-ups can focus on addressing this limitation.