### PR TITLE
docs: prevent hard-wrapped pull request prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,6 +534,9 @@ uv pip install -e ../../ --force-reinstall --no-deps
 ### Code Conventions
 
 - Commit messages must be [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`) — a commitizen pre-commit hook rejects anything else
+- GitHub pull request descriptions must not hard-wrap prose at a fixed column width. Write each Markdown paragraph as one physical line, regardless of length, and let GitHub handle visual wrapping.
+- In pull request descriptions, insert newlines only for Markdown structure: paragraph boundaries, headings, list items, blockquotes, tables, code blocks, and similar constructs.
+- This pull request formatting rule does not apply to git commit messages or repository documentation; follow their existing wrapping conventions.
 - Return a JSON-serializable dict from `@rollout_entrypoint` (any structure accepted — no required keys)
 - Create model and agent inside the entrypoint function (not at module level) so config comes from the `_rollout` payload
 - Use standard `OpenAIModel` for OpenAI-compatible inference endpoints (token capture during training is handled at the infrastructure layer)


### PR DESCRIPTION
## Summary

Add explicit guidance that GitHub pull request prose must not be hard-wrapped at a fixed column width, so each Markdown paragraph remains one physical line and GitHub handles visual wrapping.

Clarify that newlines in pull request descriptions are reserved for Markdown structure, while commit messages and repository documentation retain their existing wrapping conventions.

## Testing

- Pre-commit hooks passed.
- Documentation-only change.