### PR TITLE
fix(rollout-gateway): return the model's full generation to the client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,8 +257,16 @@ the source against the baseline commit below:
 Re-sync workflow: `git -C <slime> diff 90c212b5..HEAD -- slime/agent/<file>` shows upstream
 changes since the lift (same pattern for trl). Our copies are intentionally modified
 (torch-free; `Sample` → `TraceRecord`; injected backend/renderer seams; sglang parser hook
-removed), so treat the diff as a review aid, not an automatic merge. For
-`response_schemas.py`, re-sync means updating the schema dicts and recomputing the
+removed), so treat the diff as a review aid, not an automatic merge.
+
+`adapters/openai.py` additionally returns the assistant's text alongside `tool_calls`
+and every parallel call, where upstream sends `content=null` and only the first call.
+Do not re-adopt upstream's shape: it costs the agent its own text in the replayed
+history, and the replayed history then no longer reproduces the sampled tokens (see the
+mixed text + parallel tool-call test in
+`tests/rollout_gateway/test_gateway_integration.py`).
+
+For `response_schemas.py`, re-sync means updating the schema dicts and recomputing the
 sha256 hashes of the covered chat templates. Bump the baseline commit here when you re-sync.
 
 ### Sandbox SDK

--- a/src/agentcore_rl_toolkit/rollout_gateway/adapters/openai.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/adapters/openai.py
@@ -245,27 +245,20 @@ def _build_reply_parts(parsed: ParsedOutput, finish: str) -> tuple[dict[str, Any
 
     wire_message: dict[str, Any] = {
         "role": "assistant",
-        # send content=null when there are tool_calls: some OpenAI clients split
-        # a mixed text+tool_calls turn into two echoed messages otherwise, which
-        # diverges the history match against our leaf
-        "content": None if wire_tool_calls else (parsed.text or None),
+        "content": parsed.text or None,
     }
-    # manager_message must match what the client echoes on the next request, or
-    # the manager's history match (dict equality) diverges and every turn forks.
-    # Differences from wire_message, each needed to match the echo:
-    #   * no reasoning_content -- some clients strip it on echo (the reasoning
-    #     token ids are still kept in the trained tokens, only the text drops)
-    #   * only the first tool_call -- some clients drop extra parallel tool_calls
-    #   * empty content when tool_calls are present -- mirrors content=null above
+    # manager_message must equal what the client echoes on the next request, or the
+    # history match (dict equality) diverges and the turn mounts as a new branch. It
+    # mirrors wire_message minus reasoning_content
     manager_message: dict[str, Any] = {
         "role": "assistant",
-        "content": "" if wire_tool_calls else (parsed.text or ""),
+        "content": parsed.text or "",
     }
     if parsed.reasoning:
         wire_message["reasoning_content"] = parsed.reasoning
     if wire_tool_calls:
-        wire_message["tool_calls"] = wire_tool_calls[:1]
-        manager_message["tool_calls"] = manager_tool_calls[:1]
+        wire_message["tool_calls"] = wire_tool_calls
+        manager_message["tool_calls"] = manager_tool_calls
 
     if parsed.tool_uses:
         wire_finish = "tool_calls"

--- a/tests/rollout_gateway/test_gateway_integration.py
+++ b/tests/rollout_gateway/test_gateway_integration.py
@@ -51,12 +51,18 @@ class FakeRenderer:
         return []
 
     def parse(self, output_ids, *, tools_schema=None):
+        """Split a reply into leading text plus one tool use per ``CALL`` segment,
+        mirroring render()'s ``content`` then ``CALL name k=v`` layout."""
         text = self.decode(output_ids)
-        if text.startswith("CALL "):
-            parts = text.split()
-            args = dict(p.split("=", 1) for p in parts[2:])
-            return ParsedOutput(reasoning="", text="", tool_uses=[{"name": parts[1], "input": args}], ill_formed=False)
-        return ParsedOutput(reasoning="", text=text, tool_uses=[], ill_formed=False)
+        parts = text.split()
+        if "CALL" not in parts:
+            return ParsedOutput(reasoning="", text=text, tool_uses=[], ill_formed=False)
+        head = parts[: parts.index("CALL")]
+        tool_uses = []
+        for seg in " ".join(parts[parts.index("CALL") :]).split("CALL ")[1:]:
+            toks = seg.split()
+            tool_uses.append({"name": toks[0], "input": dict(p.split("=", 1) for p in toks[1:])})
+        return ParsedOutput(reasoning="", text=" ".join(head), tool_uses=tool_uses, ill_formed=False)
 
 
 class FakeBackend:
@@ -172,6 +178,58 @@ async def test_openai_tool_loop_end_to_end():
     assert all(lp == -0.5 for lp, m in zip(rec.logprobs, rec.loss_mask, strict=True) if m)
     # finish_session decoded the response tail via the tokenizer
     assert rec.response == "CALL calculator expr=2+2 tool: 4 assistant: the answer is 4"
+
+
+# ---------------------------------------------------------------------------
+# a mixed text + parallel tool-call turn reaches the client intact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mixed_text_and_parallel_tool_calls_reach_the_client():
+    """The reply must carry the assistant's text *and* every tool call.
+
+    Withholding either makes the client echo a history that no longer re-renders to
+    the sampled tokens, so the next turn drifts: the previous response span is
+    overwritten at loss_mask=0 (REALIGN) or split off (FORK). The trained-token
+    assertion below is what catches that -- it fails long before any reward metric
+    moves, and the damage grows with turn count.
+    """
+    reply1 = "checking both sums CALL calculator expr=2+2 CALL calculator expr=3+3"
+    gateway, backend = make_gateway(replies=[reply1, "the answers are 4 and 6"])
+    tools = [{"type": "function", "function": {"name": "calculator", "parameters": {"type": "object"}}}]
+    sid = "ep-mixed"
+
+    async with serve(gateway) as client:
+        gateway.create_session(sid)
+        body1 = {"model": "m", "messages": [{"role": "user", "content": "two sums"}], "tools": tools}
+        resp1 = await client.post("/v1/chat/completions", json=body1, headers=bearer(sid))
+        msg1 = (await resp1.json())["choices"][0]["message"]
+
+        assert msg1["content"] == "checking both sums"
+        assert [json.loads(c["function"]["arguments"])["expr"] for c in msg1["tool_calls"]] == ["2+2", "3+3"]
+
+        # echo the assistant turn back verbatim, then both tool results
+        body2 = {
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": "two sums"},
+                {"role": "assistant", "content": msg1["content"], "tool_calls": msg1["tool_calls"]},
+                {"role": "tool", "tool_call_id": msg1["tool_calls"][0]["id"], "content": "4"},
+                {"role": "tool", "tool_call_id": msg1["tool_calls"][1]["id"], "content": "6"},
+            ],
+            "tools": tools,
+        }
+        resp2 = await client.post("/v1/chat/completions", json=body2, headers=bearer(sid))
+        assert resp2.status == 200
+
+        records = await gateway.finish_session(sid, base_sample=BaseTrace(rollout_id="ep-mixed"))
+
+    assert len(records) == 1  # no drift -> one branch, not a fork
+    rec = records[0]
+    tail = rec.token_ids[-rec.response_length :]
+    trained = [tok for tok, m in zip(tail, rec.loss_mask, strict=True) if m]
+    assert gateway.renderer.decode(trained) == f"{reply1} the answers are 4 and 6"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The OpenAI adapter discarded part of what the model generated before replying to the client. On any turn containing tool calls it sent `content: null`, throwing away the assistant's text, and it truncated `tool_calls` to the first entry. Parsing was not at fault: the renderer derendered the generation correctly, and the loss happened one step later, in `_build_reply_parts`, when `ParsedOutput` was converted to the wire message.

## Why it matters

**Altered history.** A client can only replay what it received, so the assistant's own text vanishes from the conversation the model reads on the next turn — it re-derives intent from tool output alone. Parallel calls beyond the first are never executed, and the model tends to re-issue them several turns later.

**Broken prefix.** Because the replayed history no longer reproduces the tokens that were sampled, the next turn's prompt stops being an extension of the previous sequence, diverging exactly at the assistant turn. The inference engine loses KV prefix reuse from that point, and the captured trajectory no longer lines up with what the model actually generated.

## Evidence

The divergence is visible in the run metrics as extra rows: when a rollout's prompt stops extending its own captured sequence, it is split and contributes more than one row, so a step's row count exceeds `ppo_mini_batch_size × n`. Counting only steps that contained multi-turn rollouts, since those are the only ones that can split, a full-epoch run with the fix showed this on 1/19 such steps against 5/15 for the pre-fix reference — 6× less often, despite having more multi-turn steps available.

**E2E** — GSM8K, Qwen3-4B, full epoch (116 steps), `num_workers=2`. The val reward curve closely matches the pre-fix reference, with a minor gap (screenshot below). Every training step carried exactly `ppo_mini_batch_size × n = 256` rows.

<img width="487" height="305" alt="Screenshot 2026-08-15 at 11 55 14 AM" src="https://github.com/user-attachments/assets/dfea5ff8-5a4f-4191-9b94-ed5b729fbeb6" />

The Anthropic adapter in this package already returned the text and every `tool_use` block, so the two adapters disagreed and the OpenAI one was the outlier.

## Change

- `content` carries `parsed.text` whether or not tool calls are present (`null` only when there genuinely is no text)
- all parallel `tool_calls` are returned instead of the first
- `manager_message` mirrors the wire message, so the stored history still matches the client's echo

## Test

`test_mixed_text_and_parallel_tool_calls_reach_the_client` drives a mixed turn end to end and asserts the text and both calls reach the client, and that the session stays on one branch. It fails on the previous behavior, and independently when either half of it is restored. The fake renderer's `parse` previously forced `text=""` whenever it saw a tool call, which is why no existing test covered this shape.

## Note for re-syncing

This diverges deliberately from the vendored slime baseline (`90c212b5`), which sends `content=null` and only the first call. Recorded in `AGENTS.md` so a future re-sync doesn't reintroduce it.
