### PR TITLE
fix(examples/rollout-gateway): change migrationbench example to use agentcore cli for ACR deployment; fix response_schema and chat_template for gpt-oss models in Rollout Gateway. 

### DIFF
--- a/examples/strands_migration_agent/.env.example
+++ b/examples/strands_migration_agent/.env.example
@@ -1,2 +1,4 @@
-BYPASS_TOOL_CONSENT=true
-STRANDS_NON_INTERACTIVE=true
+# Optional: set these if using the CodeArtifact mirror (see README)
+# CODEARTIFACT_DOMAIN=migration-aws-maven-mirror
+# CODEARTIFACT_OWNER=123456789012
+# CODEARTIFACT_REPO=maven-central-cache

--- a/examples/strands_migration_agent/Dockerfile
+++ b/examples/strands_migration_agent/Dockerfile
@@ -59,9 +59,7 @@ RUN apt-get update && \
 # ----------
 
 COPY . .
-# Install local toolkit from build context, then install example deps
-RUN --mount=type=bind,from=toolkit,source=.,target=/toolkit \
-    uv pip install /toolkit && uv pip install .
+RUN uv pip install .
 
 
 

--- a/examples/strands_migration_agent/README.md
+++ b/examples/strands_migration_agent/README.md
@@ -111,13 +111,7 @@ python preprocess.py --s3-bucket-name my-migration-bench-data
 python preprocess.py --s3-bucket-name my-migration-bench-data --max-repos-per-split 2 --skip-s3-sync
 ```
 
-After data preprocessing is done, you can start testing the agent. First, prepare the environment file so Strands runs in non-interactive server mode:
-
-```bash
-cp .env.example .env
-```
-
-Then start the vLLM server, the app, and submit a request. Each command runs in its own terminal:
+After data preprocessing is done, you can start testing the agent. Start the vLLM server, the app, and submit a request. Each command runs in its own terminal:
 
 ```bash
 # Terminal 1: Start a local vLLM server
@@ -166,60 +160,6 @@ curl -X POST http://localhost:8080/invocations \
 > agent at `repo_uri`s from a **bucket you control** — the extracted code and the prompt both
 > drive a powerful agent.
 
-## Docker
-
-### Build & run locally
-
-Build the docker image:
-
-```bash
-docker buildx build \
-  --build-context toolkit=$TOOLKIT_ROOT \
-  -t migration:dev --load \
-  -f $MIGRATION_DIR/Dockerfile \
-  $MIGRATION_DIR
-```
-
-The agent inside the container needs AWS credentials to access S3 (for saving rollout results and downloading datasets). Since Docker containers can't access your host's AWS credential, you need to pass them explicitly via an `.env` file:
-
-```bash
-cp $MIGRATION_DIR/.env.example $MIGRATION_DIR/.env
-# Edit .env and add your AWS credentials.
-# If you have configured your AWS credential, you should be able to find
-# them at ~/.aws/credentials.
-# AWS_ACCESS_KEY_ID=your_access_key_id
-# AWS_SECRET_ACCESS_KEY=your_secret_access_key
-# AWS_REGION=us-west-2
-```
-
-Then start the server as follows, and send the request.
-```bash
-# Run with host network so the agent can access the locally hosted vLLM server
-docker run --network host --env-file $MIGRATION_DIR/.env migration:dev python -m rl_app
-
-# Submit request (same curl as above)
-```
-
-### Build & push to ECR
-
-You need to build docker and push it to AWS ECR for deploying agent, running evaluation or running RL training with AgentCore.
-
-```bash
-cd $TOOLKIT_ROOT
-cp .env.example .env
-# Edit .env and fill in your AWS region, account ID, and ECR repo name before proceeding
-# AWS_REGION=us-west-2
-# AWS_ACCOUNT=your-aws-account-number
-# ECR_REPO_NAME=your-ecr-repo-name
-# The script uses the AWS CLI, which reads credentials from ~/.aws/credentials.
-# Make sure this is configured (e.g., run `aws configure`) before proceeding.
-
-./scripts/build_docker_image_and_push_to_ecr.sh \
-  --dockerfile=$MIGRATION_DIR/Dockerfile \
-  --tag=dev \
-  --context=$MIGRATION_DIR \
-  --additional-context=toolkit=$TOOLKIT_ROOT
-```
 
 ## CodeArtifact Mirror (Optional)
 
@@ -242,45 +182,13 @@ aws codeartifact associate-external-connection \
   --external-connection public:maven-central
 ```
 
-### 2. Add IAM permissions to the ACR execution role
+### 2. Set environment variables
 
-Add the following policy to the IAM execution role your ACR agent runs as (replace `REGION`, `ACCOUNT`, and `YOUR_EXECUTION_ROLE`):
+When running locally, copy the example env file and add these to your `.env` file so they are picked up by `load_dotenv()`:
 
 ```bash
-aws iam put-role-policy \
-  --role-name YOUR_EXECUTION_ROLE \
-  --policy-name CodeArtifactAccess \
-  --policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Effect": "Allow",
-        "Action": [
-          "codeartifact:GetAuthorizationToken",
-          "codeartifact:GetRepositoryEndpoint"
-        ],
-        "Resource": [
-          "arn:aws:codeartifact:REGION:ACCOUNT:domain/migration-aws-maven-mirror",
-          "arn:aws:codeartifact:REGION:ACCOUNT:repository/migration-aws-maven-mirror/maven-central-cache"
-        ]
-      },
-      {
-        "Effect": "Allow",
-        "Action": "sts:GetServiceBearerToken",
-        "Resource": "*",
-        "Condition": {
-          "StringEquals": {
-            "sts:AWSServiceName": "codeartifact.amazonaws.com"
-          }
-        }
-      }
-    ]
-  }'
+cp .env.example .env
 ```
-
-### 3. Set environment variables
-
-Add to your `.env` file (picked up by `deploy.py`):
 
 ```
 CODEARTIFACT_DOMAIN=migration-aws-maven-mirror
@@ -288,49 +196,153 @@ CODEARTIFACT_OWNER=123456789012
 CODEARTIFACT_REPO=maven-central-cache
 ```
 
-These are picked up automatically by `--env-file` when running Docker locally, and by `deploy.py` when deploying to ACR.
-
 When these environment variables are not set, the agent uses Maven Central directly (default behavior). At startup, `configure_codeartifact_token()` fetches an auth token via boto3 and generates `~/.m2/settings.xml` automatically.
 
-## Deploy
 
-Create your `config.toml` file and fill in the `[agentcore]` section:
+## Deploy to AgentCore
+
+### 1. Configure the agent
+
+Pick the option that matches where your inference server lives.
+
+**Option 1: VPC deployment** — use this when your inference server is inside a VPC (e.g., training infra on AWS).
+
+```bash
+cd $MIGRATION_DIR
+
+# Get your subnet and security group IDs from your instance's network details
+SUBNET_ID="subnet-xxxxxxxxxxxxxxxxx"
+SECURITY_GROUP_ID="sg-xxxxxxxxxxxxxxxxx"
+
+agentcore configure \
+  --entrypoint rl_app.py \
+  --name strands_migration_agent \
+  --requirements-file pyproject.toml \
+  --deployment-type container \
+  --vpc \
+  --subnets $SUBNET_ID \
+  --security-groups $SECURITY_GROUP_ID \
+  --disable-memory \
+  --non-interactive
+```
+
+**Option 2: Public net deployment** — use this when your inference server is accessible via a public URL.
+
+```bash
+cd $MIGRATION_DIR
+
+agentcore configure \
+  --entrypoint rl_app.py \
+  --name strands_migration_agent \
+  --requirements-file pyproject.toml \
+  --deployment-type container \
+  --disable-memory \
+  --non-interactive
+```
+
+### 2. Deploy the agent
+
+```bash
+cd $MIGRATION_DIR
+
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+
+agentcore deploy --agent strands_migration_agent \
+  --env CODEARTIFACT_DOMAIN=migration-aws-maven-mirror \
+  --env CODEARTIFACT_OWNER=$ACCOUNT \
+  --env CODEARTIFACT_REPO=maven-central-cache
+```
+
+> If you are not using the CodeArtifact mirror, omit the three `CODEARTIFACT_*` env vars from the deploy command.
+
+After deployment, the agent ARN is saved in `.bedrock_agentcore.yaml`. Copy it — you will need it for evaluation.
+
+### 3. Setup IAM Permissions for ACR
+Grant IAM permissions to the ACR execution role. The execution role name is stored in `.bedrock_agentcore.yaml` — the `execution_role` field, e.g.
+`arn:aws:iam::123456789:role/AmazonBedrockAgentCoreSDKRuntime-us-west-2-abc123` ->
+`AmazonBedrockAgentCoreSDKRuntime-us-west-2-abc123`.
+
+#### 3.1 Grant S3 permission
+
+```bash
+# Create an S3 bucket to store ACR rollout data
+aws s3 mb s3://agentcore-rl
+
+# Add S3 permissions to the execution role,
+# which is the first `execution_role` in `.bedrock_agentcore.yaml`.
+YOUR_EXECUTION_ROLE=$(grep -m1 'execution_role:' .bedrock_agentcore.yaml | sed 's|.*role/||')
+echo "Execution role: $YOUR_EXECUTION_ROLE"
+
+aws iam put-role-policy --role-name $YOUR_EXECUTION_ROLE \
+  --policy-name RLToolkitAccess \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["s3:PutObject", "s3:GetObject"],
+        "Resource": "arn:aws:s3:::agentcore-rl/*"
+      }
+    ]
+  }'
+```
+
+#### 3.2 Grant CodeArtifact permission
+
+Skip this step if you are not using the [CodeArtifact mirror](#codeartifact-mirror-optional).
+
+```bash
+cd $MIGRATION_DIR
+
+REGION=$(aws ec2 describe-availability-zones --query 'AvailabilityZones[0].RegionName' --output text)
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+
+aws iam put-role-policy \
+  --role-name $YOUR_EXECUTION_ROLE \
+  --policy-name CodeArtifactAccess \
+  --policy-document "$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "codeartifact:GetAuthorizationToken",
+        "codeartifact:GetRepositoryEndpoint"
+      ],
+      "Resource": [
+        "arn:aws:codeartifact:${REGION}:${ACCOUNT}:domain/migration-aws-maven-mirror",
+        "arn:aws:codeartifact:${REGION}:${ACCOUNT}:repository/migration-aws-maven-mirror/maven-central-cache"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "sts:GetServiceBearerToken",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "sts:AWSServiceName": "codeartifact.amazonaws.com"
+        }
+      }
+    }
+  ]
+}
+EOF
+)"
+```
+
+## Evaluate
+
+After deploying the agent to ACR, you can run batch evaluation against the MigrationBench dataset. The evaluation scripts use `RolloutClient` to submit requests to ACR and poll S3 for results.
+
+First, create `config.toml` from the example and fill in the `agent_arn` and `[eval]` section:
 
 ```bash
 cd $MIGRATION_DIR
 cp config.example.toml config.toml
 ```
 
-Edit `config.toml` with your deployment values:
-
-```toml
-[agentcore]
-region = "us-west-2"
-agent_name = "my_strands_migration_agent"
-image_uri = "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/example-agent:tag"  # ECR image URI from the push step
-execution_role_arn = "arn:aws:iam::ACCOUNT_ID:role/EXAMPLE_ROLE"
-
-# Network configuration (optional — omit for PUBLIC mode)
-network_mode = "VPC"
-subnets = ["subnet-xxxxxxxxxxxxxxxxx"]
-security_groups = ["sg-xxxxxxxxxxxxxxxxx"]
-```
-
-Then run:
-
-```bash
-python deploy.py
-```
-
-The deploy script will print the Amazon Resource Name (ARN) of your deployed agent in its output log. Copy this value — you will need it for evaluation.
-
-## Evaluate
-
-After deploying the agent to ACR, you can run batch evaluation against the MigrationBench dataset. The evaluation scripts use `RolloutClient` to submit requests to ACR and poll S3 for results.
-
-First, fill in the `agent_arn` and the `[eval]` section in your `config.toml`:
-
-- **`agent_arn`**: The ARN printed in the deploy step output log.
+- **`agent_arn`**: The ARN saved in `.bedrock_agentcore.yaml` after the deploy step.
 - **`s3_input_bucket`**: The S3 path where `preprocess.py` uploaded the dataset. For example, if you ran `python preprocess.py --s3-bucket-name my-migration-bench-data`, the test split is at `my-migration-bench-data/tars/test/`.
 - **`s3_output_bucket`**: The S3 bucket where evaluation rollout results will be saved.
 

--- a/examples/strands_migration_agent/config.example.toml
+++ b/examples/strands_migration_agent/config.example.toml
@@ -1,18 +1,8 @@
 # Copy this file to config.toml and fill in your values
 
 [agentcore]
-region = "us-west-2"
-agent_name = "my_strands_migration_agent"
-image_uri = "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/example-agent:tag"
-execution_role_arn = "arn:aws:iam::ACCOUNT_ID:role/EXAMPLE_ROLE"
-
-# Agent ARN (used after deployment)
+# Agent ARN printed by `agentcore deploy` (also saved in .bedrock_agentcore.yaml)
 agent_arn = "arn:aws:bedrock-agentcore:REGION:ACCOUNT_ID:runtime/AGENT_ID"
-
-# Network configuration (optional)
-network_mode = "VPC"
-subnets = ["subnet-xxxxxxxxxxxxxxxxx"]
-security_groups = ["sg-xxxxxxxxxxxxxxxxx"]
 
 [eval]
 s3_input_bucket = "my-benchmark-bucket/path/to/inputs/"

--- a/examples/strands_migration_agent/pyproject.toml
+++ b/examples/strands_migration_agent/pyproject.toml
@@ -5,6 +5,7 @@ description = "Example: Strands Java Code Migration Agent using Bedrock AgentCor
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "agentcore-rl-toolkit>=0.1.0",
     "bedrock-agentcore>=1.0.3",
     "bedrock-agentcore-starter-toolkit>=0.2.0",
     "boto3>=1.40.55",
@@ -25,4 +26,4 @@ override-dependencies = [
 
 [tool.uv.sources]
 migrationbench = { git = "https://github.com/amazon-science/MigrationBench.git", rev = "19acd9eb3a402d825f200eb14cf01584eaa1f6e9" }
-java-migration-agent = { git = "https://github.com/amazon-science/JavaMigration.git", subdirectory = "java_migration_agent" }
+java-migration-agent = { git = "https://github.com/amazon-science/JavaMigration.git", rev = "1e443fb", subdirectory = "java_migration_agent" }

--- a/examples/strands_migration_agent/rl_app.py
+++ b/examples/strands_migration_agent/rl_app.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 
 from dotenv import load_dotenv
@@ -11,6 +12,9 @@ from strands_tools import editor, shell
 from utils import configure_codeartifact_token, load_metadata_from_s3, load_repo_from_s3, setup_repo_environment
 
 from agentcore_rl_toolkit import AgentCoreRLApp
+
+os.environ.setdefault("BYPASS_TOOL_CONSENT", "true")
+os.environ.setdefault("STRANDS_NON_INTERACTIVE", "true")
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -46,6 +50,7 @@ def invoke_agent(payload: dict):
     base_url = payload["_rollout"]["base_url"]
     model_id = payload["_rollout"]["model_id"]
     params = payload["_rollout"].get("sampling_params", {})
+    api_key = payload["_rollout"].get("api_key") or "EMPTY"
     tools = [shell, editor]
 
     request = InvocationRequest(**payload)
@@ -76,7 +81,7 @@ def invoke_agent(payload: dict):
         )
         tools.append(search_dependency_version)
 
-    model = OpenAIModel(client_args={"api_key": "EMPTY", "base_url": base_url}, model_id=model_id, params=params)
+    model = OpenAIModel(client_args={"api_key": api_key, "base_url": base_url}, model_id=model_id, params=params)
 
     agent = Agent(
         model=model,

--- a/src/agentcore_rl_toolkit/rollout_gateway/render.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/render.py
@@ -33,7 +33,12 @@ from collections.abc import Callable
 from typing import Any, Protocol, runtime_checkable
 
 from .parsing import split_reasoning
-from .response_schemas import RESPONSE_SCHEMAS, resolve_schema_name
+from .response_schemas import (
+    RESPONSE_SCHEMAS,
+    patch_chat_template,
+    reasoning_render_key,
+    resolve_schema_name,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -138,10 +143,24 @@ class HfTemplateRenderer:
         # available by explicit injection.
         self.tool_parser: ToolParserFn | None = tool_parser
         self._schema: dict | None = None
+        # Render-side template repair, independent of the parse path: some templates do
+        # not render what their model generates, which breaks prefix reuse on replay.
+        # Held here and passed per-call rather than assigned onto the tokenizer, so a
+        # tokenizer shared with the trainer is never mutated.
+        self._chat_template: str | None = None
+        schema_name = resolve_schema_name(tokenizer)
+        template = getattr(tokenizer, "chat_template", None)
+        if schema_name is not None and isinstance(template, str):
+            patched = patch_chat_template(template, schema_name)
+            if patched != template:
+                self._chat_template = patched
+                logger.info("applied render-side chat-template repair for %r", schema_name)
+        # Key this template expects for assistant reasoning, when it isn't the canonical
+        # ``reasoning_content`` (see _rekey_reasoning).
+        self._reasoning_key: str | None = reasoning_render_key(schema_name)
         if reasoning_parser is None and tool_parser is None:
             # tokenizer.parse_response is guaranteed by the transformers>=5.0 floor
             # (the [gateway] extra); no availability guard needed.
-            schema_name = resolve_schema_name(tokenizer)
             if schema_name is not None:
                 self._schema = RESPONSE_SCHEMAS[schema_name]
 
@@ -156,13 +175,39 @@ class HfTemplateRenderer:
         # transformers>=5 default) bundles an attention mask, but that is a padding
         # artifact the training backend builds itself when it batches rows.
         ids = self.tokenizer.apply_chat_template(
-            messages,
+            self._rekey_reasoning(messages),
             tools=tools,
             tokenize=True,
             add_generation_prompt=add_generation_prompt,
             return_dict=False,
+            **({"chat_template": self._chat_template} if self._chat_template else {}),
         )
         return list(ids)
+
+    def _rekey_reasoning(self, messages: list[dict]) -> list[dict]:
+        """Move assistant ``reasoning_content`` to the key this template reads.
+
+        Copies before mutating, so a caller's messages (and the manager's stored
+        history, which is compared by dict equality) are never touched.
+
+        Skipped when the message also carries text: harmony renders whichever of
+        ``content``/``thinking`` is set as the analysis channel and raises outright if
+        a tool-call message sets both, so text wins and the reasoning is left out
+        rather than trading a drift for a template exception.
+        """
+        key = self._reasoning_key
+        if not key:
+            return messages
+        out: list[dict] = []
+        for msg in messages:
+            reasoning = msg.get("reasoning_content") if msg.get("role") == "assistant" else None
+            if not reasoning or msg.get("content"):
+                out.append(msg)
+                continue
+            rekeyed = {k: v for k, v in msg.items() if k != "reasoning_content"}
+            rekeyed[key] = reasoning
+            out.append(rekeyed)
+        return out
 
     def get_stop_sequences(self) -> list[str] | list[int]:
         return list(self._stop_sequences)

--- a/src/agentcore_rl_toolkit/rollout_gateway/response_schemas.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/response_schemas.py
@@ -131,26 +131,23 @@ GLM4MOE_SCHEMA = {
 }
 
 # GPT-OSS (harmony): reasoning/content are channels, tool calls carry the function
-# name in the channel header.
 GPTOSS_SCHEMA = {
-    # Normalize final content to analysis format so both map to the same "content" group.
     "x-regex-substitutions": [
         [r"<\|channel\|>final<\|message\|>(.*?)<\|return\|>", r"<|channel|>analysis<|message|>\1<|end|>"],
     ],
-    "x-regex": r"^(?:<\|channel\|>analysis<\|message\|>(?P<content>.*?)<\|end\|>(?:<\|start\|>assistant)?)?\s*(?P<tool_calls>to=functions\.\S+<\|channel\|>commentary json<\|message\|>.*?<\|call\|>)?$",  # noqa: E501
+    "x-regex": r"^(?:<\|channel\|>analysis<\|message\|>(?P<reasoning_content>.*?)<\|end\|>(?:<\|start\|>assistant)?\s*(?=<\|channel\|>))?(?:<\|channel\|>analysis<\|message\|>(?P<content>.*?)<\|end\|>)?\s*(?P<tool_calls>(?:<\|channel\|>(?:commentary|analysis)\s+to=functions\.[a-zA-Z0-9_-]+\s+(?:code|json)<\|message\|>.*?<\|call\|>.*?(?:<\|end\|>|$)\s*)+)?$",  # noqa: E501
     "type": "object",
     "properties": {
         "role": {"const": "assistant"},
         "content": {"type": "string"},
+        "reasoning_content": {"type": "string"},
         "tool_calls": {
             "type": "array",
-            "x-regex-iterator": r"(to=functions\.\S+<\|channel\|>commentary json<\|message\|>.*?<\|call\|>)",
+            "x-regex-iterator": r"(<\|channel\|>(?:commentary|analysis)\s+to=functions\.[a-zA-Z0-9_-]+\s+(?:code|json)<\|message\|>.*?<\|call\|>)",  # noqa: E501
             "items": {
-                # Convert "to=functions.NAME<|channel|>commentary json<|message|>ARGS<|call|>"
-                # into '{"name": "NAME", "arguments": ARGS}' so it can be parsed as JSON.
                 "x-regex-substitutions": [
                     [
-                        r"to=functions\.(\S+)<\|channel\|>commentary json<\|message\|>(.*?)<\|call\|>",
+                        r"<\|channel\|>(?:commentary|analysis)\s+to=functions\.([a-zA-Z0-9_-]+)\s+(?:code|json)<\|message\|>(.*?)<\|call\|>",
                         r'{"name": "\1", "arguments": \2}',
                     ],
                 ],
@@ -202,6 +199,59 @@ _TEMPLATE_HASHES: dict[str, str] = {
     "575fb74f54ed264df9047d0ecce3c98938aae953fb4f50356675706264cbb68a": "qwen3_5",  # Nemotron-3 Super
     "82753bef5cedc4932c1ed509b5c9a12be680fd86d1adb65bc3f7398d11c8eebc": "qwen3_5",  # Nemotron-3 Ultra
 }
+
+
+# --- Render-side template repairs ---------------------------------------------------
+
+# GPT-OSS renders a tool call with the recipient in the *role header* and defaults the
+# content type to "json":
+#     <|start|>assistant to=functions.NAME<|channel|>commentary json<|message|>ARGS<|call|>
+# The model instead generates the recipient *inside the channel line*, with "code":
+#     <|start|>assistant<|channel|>commentary to=functions.NAME code<|message|>ARGS<|call|>
+# (Verified at token level: the model emits a bare ` code` text token, not the harmony
+# spec's `<|constrain|>` special token 200003 — that token decodes visibly and never
+# appeared in captured rollouts.)
+#
+# Rendering a replayed history therefore does not reproduce the tokens that were
+# sampled, so the next turn's prompt stops extending the captured sequence and the
+# trajectory manager has to REALIGN (dropping the turn's loss mask) or FORK (emitting
+# an extra row). Reordering the render to match generation restores the prefix.
+#
+# Applies to the render path only; the parse path is handled by GPTOSS_SCHEMA.
+_GPTOSS_TOOLCALL_RENDER_ORIG = (
+    '            {{- "<|start|>assistant to=" }}\n'
+    '            {{- "functions." + tool_call.name + "<|channel|>commentary " }}\n'
+    '            {{- (tool_call.content_type if tool_call.content_type is defined else "json") + "<|message|>" }}'
+)
+_GPTOSS_TOOLCALL_RENDER_FIXED = (
+    '            {{- "<|start|>assistant<|channel|>commentary to=" }}\n'
+    '            {{- "functions." + tool_call.name + " " }}\n'
+    '            {{- (tool_call.content_type if tool_call.content_type is defined else "code") + "<|message|>" }}'
+)
+
+
+# Canonical messages carry reasoning under ``reasoning_content`` (both adapters
+# normalize to it). Templates disagree on the key: Qwen3 reads ``reasoning_content``
+# directly, while GPT-OSS/harmony reads ``thinking`` and silently ignores anything
+# else — so replayed reasoning renders as nothing and the prompt stops reproducing
+# the sampled tokens. Rename at the render seam for templates that need it.
+_REASONING_RENDER_KEY: dict[str, str] = {"gptoss": "thinking"}
+
+
+def reasoning_render_key(schema_name: str | None) -> str | None:
+    """Template-specific key for assistant reasoning, or None to leave messages alone."""
+    return _REASONING_RENDER_KEY.get(schema_name or "")
+
+
+def patch_chat_template(template: str, schema_name: str | None) -> str:
+    """Return ``template`` with render-side repairs applied, or unchanged.
+
+    Only rewrites a block that is present exactly once, so a template revised upstream
+    silently keeps its own rendering rather than being half-patched.
+    """
+    if schema_name != "gptoss" or template.count(_GPTOSS_TOOLCALL_RENDER_ORIG) != 1:
+        return template
+    return template.replace(_GPTOSS_TOOLCALL_RENDER_ORIG, _GPTOSS_TOOLCALL_RENDER_FIXED)
 
 
 def resolve_schema_name(tokenizer) -> str | None:


### PR DESCRIPTION
*Issue #, if available:*

## Summary
For `examples/strands_migration_agent/`, change the instructions in `README.md` file to use agentcore cli to deploy ACR.

Fix the inconsistent `response_schema` and `chat_template` for `gpt-oss` models. Before the change, they can handle regex:
```
<|start|>assistant to=functions.NAME<|channel|>commentary json<|message|>ARGS<|call|>
```
while the actual output template of `gpt-oss` model is
```
 <|start|>assistant<|channel|>commentary to=functions.NAME code<|message|>ARGS<|call|>
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
