### PR TITLE
fix: make MessageNode.leaves() iterative to avoid RecursionError

### DIFF
--- a/src/agentcore_rl_toolkit/rollout_gateway/trajectory.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/trajectory.py
@@ -104,11 +104,16 @@ class MessageNode:
         return chain
 
     def leaves(self) -> Iterator[MessageNode]:
-        if not self.children:
-            yield self
-            return
-        for c in self.children:
-            yield from c.leaves()
+        # Iterative left-to-right DFS with an explicit stack: children are pushed
+        # in reverse so they pop in order, and depth is bounded by the tree's
+        # breadth rather than the interpreter's C stack.
+        stack: list[MessageNode] = [self]
+        while stack:
+            node = stack.pop()
+            if not node.children:
+                yield node
+            else:
+                stack.extend(reversed(node.children))
 
 
 # ===========================================================================

--- a/tests/rollout_gateway/test_trajectory.py
+++ b/tests/rollout_gateway/test_trajectory.py
@@ -12,11 +12,37 @@ import pytest
 
 from agentcore_rl_toolkit.rollout_gateway import (
     BaseTrace,
+    MessageNode,
     Status,
     TraceRecord,
     TrajectoryManager,
     TurnRecord,
 )
+
+
+def test_leaves_handles_chain_deeper_than_recursion_limit():
+    """leaves() drains a near-linear tree (one node per message, as long rollouts
+    produce) that is far deeper than the interpreter's recursion limit, bounding
+    stack use by the tree's breadth rather than its depth."""
+    depth = sys.getrecursionlimit() * 3
+    root = MessageNode()
+    node = root
+    for _ in range(depth):
+        node = node.add_child(MessageNode(role="assistant"))
+    leaves = list(root.leaves())
+    assert len(leaves) == 1
+    assert leaves[0] is node
+
+
+def test_leaves_preserves_left_to_right_dfs_order():
+    """leaves() yields in left-to-right DFS order: two branches off the root, each
+    two nodes deep, yield the left leaf before the right."""
+    root = MessageNode()
+    left = root.add_child(MessageNode(role="user", message={"content": "L"}))
+    left_leaf = left.add_child(MessageNode(role="assistant", message={"content": "L2"}))
+    right = root.add_child(MessageNode(role="user", message={"content": "R"}))
+    right_leaf = right.add_child(MessageNode(role="assistant", message={"content": "R2"}))
+    assert list(root.leaves()) == [left_leaf, right_leaf]
 
 
 def test_trace_record_rejects_loss_mask_longer_than_tokens():


### PR DESCRIPTION
# fix: make MessageNode.leaves() iterative to avoid RecursionError on long trajectories

## Summary

`MessageNode.leaves()` in `rollout_gateway/trajectory.py` was a recursive generator that descended one Python stack frame per tree level. The gateway's per-session message tree is (near-)linear — roughly one node per message — so its depth grows with the number of messages in a rollout. A trajectory whose longest root→leaf path approaches Python's default recursion limit (1000) overflows the stack and raises `RecursionError` during trajectory drain, and the whole rollout is discarded.

This bites the success path: the agent finished its rollout normally, but the gateway cannot linearize the tree into `TraceRecord`s, so the completed trajectory is thrown away as a failed rollout. Because it selectively drops the *longest* trajectories, it introduces a systematic length bias in what the trainer gets to learn from — not just random attrition. In two live runs it accounted for 6/53 and 2/5 of failed rollouts.

The fix rewrites `leaves()` as an iterative left-to-right DFS with an explicit stack (children pushed in reverse so they pop in order), preserving the previous leaf ordering while bounding stack use by the tree's breadth rather than the interpreter's C stack. It now handles arbitrarily long trajectories.

## Symptom

```
RecursionError: maximum recursion depth exceeded
  File ".../rollout_gateway/trajectory.py", line 111, in leaves
    yield from c.leaves()
  [Previous line repeated 987 more times]
```

The exception propagates out of `RolloutGateway.finish_session` after the agent's work is already done, so the completed trajectory is lost.

## Why not `sys.setrecursionlimit(...)`

Raising the limit only moves the wall: a deep enough tree then overflows the C stack and segfaults the worker instead of raising a catchable `RecursionError`. The iterative walk removes the depth ceiling entirely.

## Scope

Only `leaves()` recursed. The two other walks over the same tree — `MessageNode.path_from_root()` (`while node is not None`) and `TrajectoryManager._find_mount_point()` (`while depth < len(messages)`) — are already iterative and unaffected, so the change is contained to one method.

## Changes

- `src/agentcore_rl_toolkit/rollout_gateway/trajectory.py` — `MessageNode.leaves()` rewritten as an iterative DFS.
- `tests/rollout_gateway/test_trajectory.py` — two regression tests:
  - `test_leaves_handles_chain_deeper_than_recursion_limit` builds a chain 3× the recursion limit deep and asserts it drains to a single leaf (fails with `RecursionError` on the old implementation).
  - `test_leaves_preserves_left_to_right_dfs_order` guards the leaf ordering against a future regression.

## Testing

```
uv sync --extra dev
uv run pytest tests/rollout_gateway/test_trajectory.py
```

All tests pass. Reverting the fix reproduces the original `RecursionError` at `trajectory.py:111` for the deep-chain test, confirming the regression coverage.