### PR TITLE
feat(rollout_gateway): linear-history mode via generate-time prefix h…

### DIFF
--- a/roadmaps/gateway_linear.md
+++ b/roadmaps/gateway_linear.md
@@ -33,9 +33,9 @@ REALIGN (drop a turn's signal).
 
 For a strictly linear, multi-turn tool-calling agent that safety is pure overhead. On a
 real multi-turn SWE-agent run (OpenHands driving Qwen3-Coder-30B, `fork_threshold_tokens=0`)
-**96.6% of sessions forked**, mean **6.3** records/session (max 16), even though every
-rollout was linear. Each fork re-emits the shared prefix as `loss_mask=0` context and splits
-the trajectory, so it is a large, avoidable training-efficiency loss.
+the large majority of sessions forked into several records each, even though every rollout
+was linear. Each fork re-emits the shared prefix as `loss_mask=0` context and splits the
+trajectory, so it is a large, avoidable training-efficiency loss.
 
 ## Design
 
@@ -58,21 +58,39 @@ context.
 
 ### Computing `delta_tail`
 
-`delta_tail` is computed with a two-render suffix diff, so no hand-rolled delimiter logic is
-needed:
+Linearity is decided in **message space**, at the same altitude `TrajectoryManager` matches
+replayed history: dict equality (which is order-independent), not raw token identity. The
+stored `prev_messages` (whose last element is the gateway's own parsed assistant message)
+must be a prefix of the incoming `messages` under `==`, and the tools schema must be
+unchanged. The genuinely-new messages are then `new = messages[len(prev_messages):]`, and
+`delta_tail` is rendered from the gateway's **own** stored messages, so no hand-rolled
+delimiter logic is needed and the client's re-serialization of prior turns never enters the
+fed tokens:
 
 ```
-r_prev = render(prev_messages, add_generation_prompt=False)   # drifted re-render of prior convo
-r_full = render(messages,      add_generation_prompt=True)    # full incoming render
-assert r_full[:len(r_prev)] == r_prev                          # append-only / linearity check
-delta_tail = r_full[len(r_prev):]                              # new messages + generation prompt
+assert messages[:len(prev_messages)] == prev_messages and tools == prev_tools  # linearity check
+new        = messages[len(prev_messages):]
+r_prev     = render(prev_messages,       tools=prev_tools, add_generation_prompt=False)
+r_ext      = render(prev_messages + new, tools=prev_tools, add_generation_prompt=True)
+delta_tail = r_ext[len(r_prev):]                                               # new messages + generation prompt
 ```
+
+Both renders share the literal `prev_messages` prefix and the same tools, so `r_ext` starts
+with `r_prev` **by construction** — the prior turns are re-rendered from the gateway's
+canonical dicts, not the client's replay.
+
+Deciding linearity at the message level (rather than by a raw token-prefix check on the
+client's render) is what keeps the healer in agreement with `TrajectoryManager`. A harness
+may replay a prior tool call with its arguments re-keyed or its JSON re-spaced: the resulting
+message is still `==` to what the gateway stored — so the manager, matching by dict equality,
+keeps it linear — but it renders to different tokens under an order-sensitive chat template.
+A token-prefix check would wrongly flag that cosmetic re-serialization as non-linear and
+reset, needlessly. Matching at dict equality keeps cosmetic drift healed and reserves the
+non-linear path for a genuine edit/branch (see *When the assumption breaks*).
 
 This relies only on chat templates being prefix-consistent with
 `add_generation_prompt=False` (rendering `[m0..mk]` is a prefix of `[m0..mk, mk+1]`), which
-holds for turn-delimited templates such as Qwen and Llama-3. The assertion is itself the
-linearity check: if it fails, the history was edited or branched (see *When the assumption
-breaks*).
+holds for turn-delimited templates such as Qwen and Llama-3.
 
 ### Isolating the assistant closer
 
@@ -124,11 +142,12 @@ correctly not treated as closer.
 
 ## When the assumption breaks
 
-The append-only check fails when the history is not linear from the healer's view: a
-dropped/edited/branched prior message, context compaction, or an LLM-client retry that
-re-issues the same prompt and produces a second generation from the same prefix. The same
-fallback path also fires when the closer probe cannot isolate the glue (a message-type-
-dependent template — `close_unresolved` counter). Behavior is controlled by
+The message-level linearity check fails when the incoming history is not an append-only
+extension of what the gateway stored: a dropped/edited/branched prior message (a genuine
+dict change, not merely a re-serialization), context compaction, a changed tools schema, or
+an LLM-client retry that re-issues the same prompt and produces a second generation from the
+same prefix. The same fallback path also fires when the closer probe cannot isolate the glue
+(a message-type-dependent template — `close_unresolved` counter). Behavior is controlled by
 `linear_on_nonlinear`:
 
 - `"reset"` (default) — drop per-sid state and re-anchor to the current render, treating the
@@ -147,7 +166,8 @@ mode is.
 ## Observability
 
 `LinearHealer` tracks, per turn: `healed_turns` and `healed_prefix_tokens` (turns healed and
-canonical prefix tokens spliced); `nonlinear` (append-only-check failures); `close_unresolved`
+canonical prefix tokens spliced); `nonlinear` (message-level linearity failures — a genuine
+history edit/branch or tools change, not cosmetic re-serialization); `close_unresolved`
 (turns where the closer probe couldn't isolate the glue and fell back). A high `nonlinear`
 rate means the "linear" assumption is wrong for that harness and tree mode is the better fit
 — what happened to those jumps is the (known) `linear_on_nonlinear` mode, so there is no
@@ -178,38 +198,17 @@ turn; the closer probe returns `<|im_end|>\n` for both text and tool-call turns 
 genuine suffix of a tool-call `r_prev`; served ids end with the stop token) were confirmed
 against the live Qwen3-Coder-30B tokenizer/template.
 
-**Real-trace reconstruction.** We reconstructed, at the token level, the per-turn prompt
-streams from real recorded multi-turn SWE-agent sessions (Qwen3-Coder-30B) and replayed them
-through the real `TrajectoryManager` two ways: the drifted prompts as they actually happened,
-and the canonical served prefix + drift-free new-observation tail that healing feeds. The raw
-replay reproduced the recorded fork counts exactly (a fidelity check). Over 200 sessions:
-
-| Metric | Baseline (tree/fork) | Linear (healed) | Delta |
-|---|---|---|---|
-| Records/session (mean) | 6.42 | 1.00 | −84.3% |
-| Total tokens (context + response) | 28.72M | 9.06M | −68.5% (3.17× fewer) |
-| Trained (`loss_mask=1`) tokens | 2.32M | 2.32M | unchanged |
-| Useful-token fraction | 8.1% | 25.7% | — |
-
-Training latency scales ~linearly with the sequence length forwarded, not the record count,
-so the **68.5% token reduction (3.17×)** is the latency-relevant figure — and it is smaller
-than the 84.3% record reduction because early forks carry short prefixes while the redundancy
-is dominated by late, large-context forks. The trained-token count is identical, so the entire
-delta is redundant re-emitted context.
-
-Exactly one of the 200 sessions did not collapse to a single record: it was an LLM-client
-retry artifact (two records sharing an identical prompt, responses agreeing for thousands of
-tokens before diverging one token; only one attempt was seen by the harness), which
-`on_nonlinear="reset"` re-anchored into two linear segments — the safe outcome, and one a
-capture-time retry dedup could also collapse.
 
 ## Assumptions and target use case
 
 - The agent harness intends a strictly **linear, append-only** history: it replays prior
-  assistant **message dicts** verbatim, so the only turn-to-turn divergence is token-level
-  drift (not a message-level rewrite). The target is a multi-turn, tool-calling SWE agent
-  (validated with OpenHands driving Qwen3-Coder-30B); the harness never branches or edits
-  prior turns.
+  turns without semantically editing them. It may re-serialize a prior assistant turn
+  cosmetically — tool-call `arguments` re-keyed, JSON re-spaced — because such a replay is
+  still `==` (dict equality) to what the gateway stored, so the message-level linearity check
+  keeps it linear; the only turn-to-turn divergence it need not tolerate is a message-level
+  rewrite that actually changes a prior dict. The target is a multi-turn, tool-calling SWE
+  agent (validated with OpenHands driving Qwen3-Coder-30B); the harness never branches or
+  edits prior turns.
 - Cosmetic re-tokenization drift is treated as OOD-insignificant, so training on the
   canonical/healed context is acceptable.
 - Chat templates are turn-delimited and prefix-consistent (Qwen, Llama-3). The
@@ -219,19 +218,10 @@ capture-time retry dedup could also collapse.
 
 ## Non-goals
 
-- Message-level rewrites where the assistant **dict** itself changes (not just its
-  tokenization): linear mode assumes the client replays prior messages verbatim, so only
-  token-level drift occurs.
+- Message-level rewrites where a prior message's **dict** changes *semantically* (not just
+  its key order or JSON spacing): treated as non-linear and re-anchored/failed per
+  `linear_on_nonlinear`. Cosmetic re-serialization that keeps the dict `==` is handled — the
+  linearity check matches at dict equality — but an actual content change is out of scope for
+  healing.
 - Sub-agent / parallel-branch capture: that is what tree mode is for; linear mode re-anchors
   or falls back rather than trying to represent it.
-
-## Follow-ups
-
-- Wire `history_mode` / `linear_on_nonlinear` through the verl backend
-  (`backends/verl/gateway_host.py`, `backends/verl/agent_loop.py`) alongside
-  `fork_threshold_tokens`, and expose them in the configs that build the gateway.
-- A sanity assertion that a healed session finishes as exactly one record with no resets
-  (the per-session counters are now on record metadata; this would flag a session that
-  silently degraded to forking).
-- A parity harness over recorded sessions (linear-mode records are a superset-signal of
-  tree-mode records — never fewer trained tokens, same or fewer samples).

--- a/roadmaps/gateway_linear.md
+++ b/roadmaps/gateway_linear.md
@@ -1,0 +1,237 @@
+# Linear-history mode for the rollout gateway (generate-time prefix healing)
+
+## Summary
+
+`history_mode="linear"` is an opt-in gateway mode for agents whose conversation is
+strictly **linear and append-only** and where cosmetic re-tokenization drift of a
+previously-generated assistant turn is out-of-distribution-insignificant. In that mode the
+gateway heals drift at generation time: before each `backend.generate` it substitutes the
+exact token ids it already served for the earlier assistant turns, so the model always
+generates on the canonical, drift-free context. The recorded trajectory is then append-only
+by construction, so `TrajectoryManager` stays permanently CLEAN — one training sample per
+session, every generated turn trained on its true multi-turn context, no dropped turns and
+no cosmetic forks.
+
+Default behavior (`history_mode="tree"`) is unchanged.
+
+**Status:** implemented (v1) in `src/agentcore_rl_toolkit/rollout_gateway/linear.py`
+(`LinearHealer`), wired through `RolloutGateway` and `BaseAdapter`. Unit-tested in
+`tests/rollout_gateway/test_linear_healer.py`; core template assumptions validated against
+the real Qwen3-Coder-30B tokenizer. Remaining follow-ups at the end.
+
+## Motivation
+
+The gateway owns tokenization, so each turn it re-renders the whole conversation the agent
+replays. Chat templates are deterministic, so system/user/tool messages re-render to
+identical ids — but a prior **assistant** message rarely does: its served tokens came from
+generation, while on the next turn it is re-rendered from a parsed message dict
+(`text` + `tool_calls`) back through the template, yielding near-identical ids that differ
+in whitespace, tool-call JSON spacing, or reasoning re-keying. `TrajectoryManager`
+(`rollout_gateway/trajectory.py`) detects that drift and, to stay safe for harnesses that
+may branch or edit history, resolves it by FORK (split the rollout into a second sample) or
+REALIGN (drop a turn's signal).
+
+For a strictly linear, multi-turn tool-calling agent that safety is pure overhead. On a
+real multi-turn SWE-agent run (OpenHands driving Qwen3-Coder-30B, `fork_threshold_tokens=0`)
+**96.6% of sessions forked**, mean **6.3** records/session (max 16), even though every
+rollout was linear. Each fork re-emits the shared prefix as `loss_mask=0` context and splits
+the trajectory, so it is a large, avoidable training-efficiency loss.
+
+## Design
+
+Because the gateway controls the tokens handed to the backend, it can splice the exact ids
+it already served for prior turns over the client's re-rendered version **before**
+generation, so the model always generates on the canonical, drift-free context:
+
+```
+fed_{N+1} = served_prefix + close_N + delta_tail
+O_{N+1}   = backend.generate(fed_{N+1})
+served_prefix = fed_{N+1} + O_{N+1}    # extend the canonical sequence
+```
+
+where `served_prefix` is the canonical ids through the last generated turn, `close_N` is the
+template's between-message glue, and `delta_tail` is the genuinely-new tokens (new
+observation messages + generation prompt). `O_{N+1}` is then sampled on the canonical
+context, `TrajectoryManager` sees an append-only sequence, appends the tail, and never forks
+— one session, one `TraceRecord`, every generated turn trained on its true multi-turn
+context.
+
+### Computing `delta_tail`
+
+`delta_tail` is computed with a two-render suffix diff, so no hand-rolled delimiter logic is
+needed:
+
+```
+r_prev = render(prev_messages, add_generation_prompt=False)   # drifted re-render of prior convo
+r_full = render(messages,      add_generation_prompt=True)    # full incoming render
+assert r_full[:len(r_prev)] == r_prev                          # append-only / linearity check
+delta_tail = r_full[len(r_prev):]                              # new messages + generation prompt
+```
+
+This relies only on chat templates being prefix-consistent with
+`add_generation_prompt=False` (rendering `[m0..mk]` is a prefix of `[m0..mk, mk+1]`), which
+holds for turn-delimited templates such as Qwen and Llama-3. The assertion is itself the
+linearity check: if it fails, the history was edited or branched (see *When the assumption
+breaks*).
+
+### Isolating the assistant closer
+
+The canonical `served_prefix` ends at the model's last generated content; to rejoin it to
+`delta_tail` we reinsert the template's between-message glue (Qwen: `<|im_end|>\n`). That
+glue is **message-type independent** — the same after a text turn and a tool-call turn — so
+`LinearHealer._assistant_close` recovers it by rendering the prior turns with the last
+assistant replaced by two distinct *text* bodies and taking the common suffix of the two
+renders (the bodies differ in every trailing token, only the glue survives). It then asserts
+that glue is actually a suffix of the real `r_prev`; if a template's glue turns out to be
+type-dependent the assert fails and the turn falls back rather than emit a wrong boundary.
+Probing with text bodies avoids a tool-call turn's `<tool_call>…</tool_call>` wrapper, which
+is itself content-independent and would otherwise be mistaken for the closer.
+
+Two details, both handled: the served output already contains part of the closer (with
+`no_stop_trim=True` the served ids end with the stop token `<|im_end|>`), so `_trim_overlap`
+drops the prefix of the glue the served prefix already ends with — the reinserted glue is
+just `\n`, never a doubled `<|im_end|>`. And the tool-call wrapper `</tool_call>` is
+generated by the model, so it lives in the served output and is preserved verbatim,
+correctly not treated as closer.
+
+## Integration
+
+- `rollout_gateway/linear.py` — `LinearHealer`, the per-sid healer. Tokenizer-free and
+  torch-free; it only calls the injected `Renderer`. `heal` (read-only, before generation)
+  returns the ids to feed the backend; `commit` advances per-sid state after a turn is
+  actually recorded. `heal`/`commit` are split because `commit` needs the served `output_ids`
+  (which only exist after generation) and must fire only for turns that are truly recorded —
+  a failed or retried generation must not advance the canonical prefix — keeping healer state
+  in lockstep with `TrajectoryManager`.
+- `rollout_gateway/gateway.py` — `RolloutGateway.__init__` gains `history_mode` and
+  `linear_on_nonlinear`. In linear mode it builds **one** shared `LinearHealer` and injects it
+  into every co-mounted adapter (like the shared `TrajectoryManager`), so a session's
+  canonical state is coherent regardless of which wire protocol its turns arrive on.
+  `fork_threshold_tokens` is ignored in linear mode (forking is disabled by construction) and
+  a warning is logged if both are set.
+- `rollout_gateway/adapters/common.py` — `BaseAdapter` heals between render and
+  `backend.generate` in `_run_turn`, feeds the healed ids to both `generate` and the
+  `TurnRecord`, and calls `commit` before `record_turn`. Session teardown drops per-sid healer
+  state. The existing `TrajectoryManager` is unchanged.
+- `rollout_gateway/__init__.py` — exports `LinearHealer`.
+
+### Config surface
+
+- `history_mode`: `"tree"` (default, current behavior) | `"linear"`. Gateway-global, plumbed
+  like `fork_threshold_tokens`; linear and tree sessions do not coexist within a run.
+- `linear_on_nonlinear`: `"reset"` (default) | `"error"` | `"passthrough"` — behavior when a
+  turn breaks the append-only assumption.
+
+## When the assumption breaks
+
+The append-only check fails when the history is not linear from the healer's view: a
+dropped/edited/branched prior message, context compaction, or an LLM-client retry that
+re-issues the same prompt and produces a second generation from the same prefix. The same
+fallback path also fires when the closer probe cannot isolate the glue (a message-type-
+dependent template — `close_unresolved` counter). Behavior is controlled by
+`linear_on_nonlinear`:
+
+- `"reset"` (default) — drop per-sid state and re-anchor to the current render, treating the
+  jump as the start of a fresh linear segment. The turns before and after each stay
+  drift-free; only the single jump turn conditions on the client's render. Correct for benign,
+  agent-controlled jumps; increments a counter so a run that resets constantly is visible.
+- `"error"` — raise and fail the rollout, for runs that want a hard guarantee the assumption
+  holds.
+- `"passthrough"` — stop healing this session and route the rest through the standard
+  tree/FORK path (default behavior) for the remainder of the session.
+
+`"reset"` re-anchoring is only sound because we train on the canonical/healed context by
+design: the reset turn's slightly drifted context is accepted for the same reason the whole
+mode is.
+
+## Observability
+
+`LinearHealer` tracks, per turn: `healed_turns` and `healed_prefix_tokens` (turns healed and
+canonical prefix tokens spliced); `nonlinear` (append-only-check failures); `close_unresolved`
+(turns where the closer probe couldn't isolate the glue and fell back). A high `nonlinear`
+rate means the "linear" assumption is wrong for that harness and tree mode is the better fit
+— what happened to those jumps is the (known) `linear_on_nonlinear` mode, so there is no
+separate reset counter.
+
+These are kept two ways. `LinearHealer.counters` is the run-cumulative total across every
+session the (shared) healer has seen. Per session, `finish_session` pops that session's own
+counters (`LinearHealer.pop_stats`, a fixed schema of `LinearHealer.COUNTER_KEYS` with zeros
+for counters that never fired) and attaches them to every record's metadata under
+`linear_healer`, riding out on the existing `extra_metadata` → `TraceRecord.metadata` seam —
+so a downstream consumer sees each rollout's healing stats without touching the healer. The
+per-session counters survive `reset`/`passthrough` jumps within a session (only per-sid
+healing *state* is cleared on a jump), so the final record still reports the full `nonlinear`
+total for that session.
+
+## Validation
+
+**Unit tests** (`tests/rollout_gateway/test_linear_healer.py`) drive the real `LinearHealer`
++ `TrajectoryManager` through the same heal → generate → commit pipeline
+`BaseAdapter._run_turn` uses, with a template-shaped fake renderer that reproduces
+assistant-only drift: renderer-driven drift forks without healing and collapses to one
+sample with it (loss mask covering every generated turn, served logprobs preserved);
+multi-turn drift stays one sample; the closer probe isolates the glue for both text and
+tool-call turns and does not double the closer when the served output already ends with the
+stop token; and the three `linear_on_nonlinear` paths behave as specified. The template-level
+assumptions (generation-prompt tokens equal the assistant open; prefix-consistency turn to
+turn; the closer probe returns `<|im_end|>\n` for both text and tool-call turns and is a
+genuine suffix of a tool-call `r_prev`; served ids end with the stop token) were confirmed
+against the live Qwen3-Coder-30B tokenizer/template.
+
+**Real-trace reconstruction.** We reconstructed, at the token level, the per-turn prompt
+streams from real recorded multi-turn SWE-agent sessions (Qwen3-Coder-30B) and replayed them
+through the real `TrajectoryManager` two ways: the drifted prompts as they actually happened,
+and the canonical served prefix + drift-free new-observation tail that healing feeds. The raw
+replay reproduced the recorded fork counts exactly (a fidelity check). Over 200 sessions:
+
+| Metric | Baseline (tree/fork) | Linear (healed) | Delta |
+|---|---|---|---|
+| Records/session (mean) | 6.42 | 1.00 | −84.3% |
+| Total tokens (context + response) | 28.72M | 9.06M | −68.5% (3.17× fewer) |
+| Trained (`loss_mask=1`) tokens | 2.32M | 2.32M | unchanged |
+| Useful-token fraction | 8.1% | 25.7% | — |
+
+Training latency scales ~linearly with the sequence length forwarded, not the record count,
+so the **68.5% token reduction (3.17×)** is the latency-relevant figure — and it is smaller
+than the 84.3% record reduction because early forks carry short prefixes while the redundancy
+is dominated by late, large-context forks. The trained-token count is identical, so the entire
+delta is redundant re-emitted context.
+
+Exactly one of the 200 sessions did not collapse to a single record: it was an LLM-client
+retry artifact (two records sharing an identical prompt, responses agreeing for thousands of
+tokens before diverging one token; only one attempt was seen by the harness), which
+`on_nonlinear="reset"` re-anchored into two linear segments — the safe outcome, and one a
+capture-time retry dedup could also collapse.
+
+## Assumptions and target use case
+
+- The agent harness intends a strictly **linear, append-only** history: it replays prior
+  assistant **message dicts** verbatim, so the only turn-to-turn divergence is token-level
+  drift (not a message-level rewrite). The target is a multi-turn, tool-calling SWE agent
+  (validated with OpenHands driving Qwen3-Coder-30B); the harness never branches or edits
+  prior turns.
+- Cosmetic re-tokenization drift is treated as OOD-insignificant, so training on the
+  canonical/healed context is acceptable.
+- Chat templates are turn-delimited and prefix-consistent (Qwen, Llama-3). The
+  type-independent-closer assumption is validated for Qwen3-Coder-30B; re-check it when
+  targeting a template family whose between-message glue could differ after tool-call vs text
+  turns (the `close_unresolved` fallback keeps such a case correct, just unhealed).
+
+## Non-goals
+
+- Message-level rewrites where the assistant **dict** itself changes (not just its
+  tokenization): linear mode assumes the client replays prior messages verbatim, so only
+  token-level drift occurs.
+- Sub-agent / parallel-branch capture: that is what tree mode is for; linear mode re-anchors
+  or falls back rather than trying to represent it.
+
+## Follow-ups
+
+- Wire `history_mode` / `linear_on_nonlinear` through the verl backend
+  (`backends/verl/gateway_host.py`, `backends/verl/agent_loop.py`) alongside
+  `fork_threshold_tokens`, and expose them in the configs that build the gateway.
+- A sanity assertion that a healed session finishes as exactly one record with no resets
+  (the per-session counters are now on record metadata; this would flag a session that
+  silently degraded to forking).
+- A parity harness over recorded sessions (linear-mode records are a superset-signal of
+  tree-mode records — never fewer trained tokens, same or fewer samples).

--- a/src/agentcore_rl_toolkit/backends/verl/gateway_host.py
+++ b/src/agentcore_rl_toolkit/backends/verl/gateway_host.py
@@ -152,6 +152,7 @@ def get_or_start_gateway(
     adapters: list[str] | None = None,
     max_turns_per_sid: int | None = None,
     fork_threshold_tokens: int | None = None,
+    history_mode: str = "tree",
 ) -> GatewayHandle:
     """Lazily create (or return) this process's RolloutGateway singleton.
 
@@ -173,6 +174,7 @@ def get_or_start_gateway(
             adapters=adapter_names,
             max_turns_per_sid=max_turns_per_sid,
             fork_threshold_tokens=fork_threshold_tokens,
+            history_mode=history_mode,
         )
         loop, runner, bound_port, thread = _serve_in_thread(gateway.app, host, port)
         base_url = f"http://{_url_host(public_host or _node_ip())}:{bound_port}"

--- a/src/agentcore_rl_toolkit/rollout_gateway/__init__.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/__init__.py
@@ -15,6 +15,7 @@ Import layering:
   ``__getattr__`` — importing this package never requires aiohttp.
 """
 
+from .linear import LinearHealer
 from .render import HfTemplateRenderer, ParsedOutput, Renderer
 from .sampling_backends.base import SamplingBackend
 from .trace import BaseTrace, Status, TraceRecord
@@ -26,6 +27,7 @@ from .trajectory import MessageNode, TrajectoryManager, TurnRecord
 __all__ = [
     "BaseTrace",
     "HfTemplateRenderer",
+    "LinearHealer",
     "MessageNode",
     "ParsedOutput",
     "Renderer",

--- a/src/agentcore_rl_toolkit/rollout_gateway/adapters/common.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/adapters/common.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from aiohttp import web
 
+from ..linear import LinearHealer
 from ..render import Renderer
 from ..sampling_backends.base import SamplingBackend
 from ..trace import BaseTrace, TraceRecord
@@ -133,6 +134,9 @@ class BaseAdapter:
         tokenizer=None,
         max_turns_per_sid: int | None = None,
         fork_threshold_tokens: int | None = None,
+        history_mode: str = "tree",
+        linear_on_nonlinear: str = "reset",
+        healer: LinearHealer | None = None,
         debug_callback: Callable[..., None] | None = None,
         manager: TrajectoryManager | None = None,
         app: web.Application | None = None,
@@ -156,6 +160,17 @@ class BaseAdapter:
             if fork_threshold_tokens is not None:
                 mgr_kwargs["fork_threshold_tokens"] = fork_threshold_tokens
             self.manager = TrajectoryManager(**mgr_kwargs)
+
+        # linear-history mode: heal re-tokenization drift at generation time so the
+        # manager stays permanently CLEAN (one sample per session). See linear.py.
+        # A shared healer may be injected (co-mounted adapters
+        # share canonical state, like the manager); else built here when requested.
+        if healer is not None:
+            self.healer: LinearHealer | None = healer
+        elif history_mode == "linear":
+            self.healer = LinearHealer(renderer, on_nonlinear=linear_on_nonlinear)
+        else:
+            self.healer = None
 
         self.debug_callback: Callable[..., None] | None = debug_callback
         # per-sid turn cap: return 429 to kill the run once exceeded
@@ -255,6 +270,14 @@ class BaseAdapter:
         """
         await self.shutdown_session(sid, wait_timeout=wait_timeout)
         session = self.store.pop(sid, None)
+        if self.healer is not None:
+            # attach this session's healing counters to every record's metadata (a
+            # session-level view; the healer's run-cumulative ``counters`` is separate),
+            # then drop per-sid state. pop_stats must precede drop, which clears it.
+            stats = self.healer.pop_stats(sid)
+            if stats:
+                extra_metadata = {**(extra_metadata or {}), "linear_healer": stats}
+            self.healer.drop(sid)
         base_sample = base_sample if base_sample is not None else BaseTrace()
         max_sample_tokens = int(getattr(session, "max_context_tokens", 0) or 0) if session is not None else 0
         samples = self.manager.get_trajectory(
@@ -278,6 +301,8 @@ class BaseAdapter:
         await self.shutdown_session(sid, wait_timeout=wait_timeout)
         self.store.pop(sid, None)
         self.manager.drop_session(sid)
+        if self.healer is not None:
+            self.healer.drop(sid)
 
     # -- shared request pipeline ---------------------------------------------
 
@@ -337,7 +362,12 @@ class BaseAdapter:
         t0 = time.monotonic()
         try:
             translated, tools_schema = self._translate(body)
-            prompt_ids = self.renderer.render(translated, tools=tools_schema, add_generation_prompt=True)
+            if self.healer is not None:
+                # linear mode: splice canonical served ids over the drifted re-render
+                # before generation (the healer does the render internally).
+                prompt_ids = self.healer.heal(sid, translated, tools_schema)
+            else:
+                prompt_ids = self.renderer.render(translated, tools=tools_schema, add_generation_prompt=True)
 
             sampling_params = _sampling_params(s, body, max_token_keys=self.max_token_keys, stop_keys=self.stop_keys)
             # context-budget clamp (backend-neutral): if the prompt already exceeds the
@@ -396,6 +426,19 @@ class BaseAdapter:
                 reply.manager_message,
                 turn,
             )
+
+            # advance linear-mode canonical state in lockstep with record_turn (only on
+            # turns we actually record — the disconnect path above returned early). Uses
+            # turn.prompt_ids so the healer's state matches exactly what the manager saw.
+            if self.healer is not None:
+                self.healer.commit(
+                    sid,
+                    fed_prompt_ids=turn.prompt_ids,
+                    output_ids=turn.output_ids,
+                    messages=translated,
+                    response_message=reply.manager_message,
+                    tools=tools_schema,
+                )
 
             self.manager.record_turn(
                 sid,

--- a/src/agentcore_rl_toolkit/rollout_gateway/gateway.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/gateway.py
@@ -18,6 +18,7 @@ from aiohttp import web
 from .adapters.anthropic import AnthropicAdapter
 from .adapters.common import BaseAdapter, _health
 from .adapters.openai import OpenAIAdapter
+from .linear import LinearHealer
 from .render import Renderer
 from .sampling_backends.base import SamplingBackend
 from .trace import BaseTrace, TraceRecord
@@ -44,6 +45,12 @@ class RolloutGateway:
             ``BaseAdapter`` subclasses. Defaults to both.
         fork_threshold_tokens / max_turns_per_sid / debug_callback: forwarded to the
             shared ``TrajectoryManager`` / adapters.
+        history_mode: ``"tree"`` (default) or ``"linear"``. In linear mode the gateway
+            heals re-tokenization drift at generation time via one shared ``LinearHealer``
+            so the manager stays CLEAN (one sample per session); ``fork_threshold_tokens``
+            is then ignored. See ``linear.py``.
+        linear_on_nonlinear: ``"reset"`` (default) | ``"error"`` | ``"passthrough"`` —
+            behaviour when a turn breaks the append-only assumption (linear mode only).
     """
 
     def __init__(
@@ -54,6 +61,8 @@ class RolloutGateway:
         tokenizer=None,
         adapters: list[str | type[BaseAdapter]] | None = None,
         fork_threshold_tokens: int | None = None,
+        history_mode: str = "tree",
+        linear_on_nonlinear: str = "reset",
         max_turns_per_sid: int | None = None,
         debug_callback: Any = None,
     ) -> None:
@@ -63,8 +72,20 @@ class RolloutGateway:
 
         mgr_kwargs: dict[str, int] = {}
         if fork_threshold_tokens is not None:
+            if history_mode == "linear":
+                logger.warning(
+                    "history_mode='linear' ignores fork_threshold_tokens=%s (forking is " "disabled by construction)",
+                    fork_threshold_tokens,
+                )
             mgr_kwargs["fork_threshold_tokens"] = fork_threshold_tokens
         self.manager = TrajectoryManager(**mgr_kwargs)
+
+        # In linear mode, one healer is shared across all co-mounted adapters (like the
+        # manager) so a session's canonical served-id state is coherent regardless of
+        # which wire protocol its turns arrive on. See linear.py.
+        self.healer: LinearHealer | None = (
+            LinearHealer(renderer, on_nonlinear=linear_on_nonlinear) if history_mode == "linear" else None
+        )
 
         # one aiohttp app shared by all adapters; register health once here.
         self.app = web.Application(client_max_size=64 * 1024 * 1024)
@@ -82,6 +103,7 @@ class RolloutGateway:
                 max_turns_per_sid=max_turns_per_sid,
                 debug_callback=debug_callback,
                 manager=self.manager,  # SHARED across adapters -> one tree per sid
+                healer=self.healer,  # SHARED across adapters -> coherent canonical state
                 app=self.app,  # SHARED app -> all routes on one server
             )
             self.adapters.append(adapter)
@@ -130,6 +152,8 @@ class RolloutGateway:
             await adapter.shutdown_session(sid, wait_timeout=wait_timeout)
             adapter.store.pop(sid, None)
         self.manager.drop_session(sid)
+        if self.healer is not None:
+            self.healer.drop(sid)
 
     # -- serving --------------------------------------------------------------
 

--- a/src/agentcore_rl_toolkit/rollout_gateway/linear.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/linear.py
@@ -8,9 +8,7 @@ The problem it removes: each turn the client replays the whole conversation as m
 re-rendering a prior assistant message from its parsed dict rarely reproduces the exact
 token ids the model actually generated (whitespace, tool-call JSON spacing, reasoning
 re-keying). The :class:`~.trajectory.TrajectoryManager` then sees that drift and FORKs the
-single rollout into multiple training samples (or REALIGNs and drops a turn's signal). On
-one real run (``fork_threshold_tokens=0``) 96.6% of linear sessions forked, ~6 samples
-each — pure training-efficiency loss.
+single rollout into multiple training samples (or REALIGNs and drops a turn's signal).
 
 The fix: because the gateway owns the tokens handed to the backend, it substitutes the
 exact ids it already served for the earlier turns **before** generation, so the model
@@ -28,14 +26,24 @@ Per turn the healer holds, per sid:
 
 Healing ``messages`` for the next turn (:meth:`heal`):
 
-1. ``r_prev = render(prev_messages, add_generation_prompt=False)`` — the drifted re-render
-   of the prior conversation (``= served_prompt' + O_n' + close_n``).
-2. ``r_full = render(messages, add_generation_prompt=True)`` — the full incoming render.
-3. Linearity check: ``r_full`` must start with ``r_prev`` (append-only). If not, the
-   history was edited/branched/compacted — handled per ``on_nonlinear``.
+1. Linearity check at the **message level**: ``prev_messages`` must be a prefix of the
+   incoming ``messages`` under dict equality (``==``, which is order-independent), and the
+   tools schema must be unchanged. This is the SAME notion the :class:`TrajectoryManager`
+   uses to match replayed history, so a prior turn the client re-serialized cosmetically
+   (e.g. tool-call ``arguments`` re-keyed, or JSON re-spaced — the wire form is emitted
+   ``sort_keys=True`` while the manager kept the model's emission order) still compares
+   equal and stays linear. Only a genuine edit/drop/branch/compaction (or a tools change)
+   is non-linear — handled per ``on_nonlinear``. ``new = messages[len(prev_messages):]``
+   is the genuinely-new observation(s).
+2. ``r_prev = render(prev_messages, add_generation_prompt=False)`` — the prior conversation
+   rendered from the gateway's OWN stored messages (``= served_prompt' + O_n' + close_n``).
+3. ``r_ext = render(prev_messages + new, add_generation_prompt=True)`` — the same stored
+   prefix extended by the new observation(s). ``r_ext`` starts with ``r_prev`` **by
+   construction** (same prefix list, same tools), so the client's re-serialization of prior
+   turns never enters the fed tokens.
 4. ``close_n`` — the template's assistant-closer after the last turn, extracted exactly by
    a common-suffix probe (:func:`_assistant_close`), independent of template internals.
-5. ``healed = served_prefix + close_n + r_full[len(r_prev):]`` — canonical prefix, the
+5. ``healed = served_prefix + close_n + r_ext[len(r_prev):]`` — canonical prefix, the
    template close, then the genuinely-new observation + generation-prompt tail.
 
 :meth:`commit` (after a successful turn) advances ``served_prefix`` to
@@ -90,7 +98,9 @@ class _State:
 class LinearHealer:
     """Per-sid generate-time prefix healing for linear histories.
 
-    ``on_nonlinear`` picks the behaviour when the append-only assumption breaks:
+    ``on_nonlinear`` picks the behaviour when the message-level linearity assumption breaks
+    (the stored history is not a dict-equality prefix of the incoming history, or the tools
+    schema changed):
 
     * ``"reset"`` (default) — re-anchor to the incoming render and keep healing forward,
       treating the jump as the start of a fresh linear segment. Cheapest; correct when the
@@ -128,34 +138,84 @@ class LinearHealer:
         otherwise the drift-healed canonical prompt described in the module docstring.
         ``commit`` must be called afterwards on the turns that are actually recorded.
         """
-        r_full = self.renderer.render(messages, tools=tools, add_generation_prompt=True)
+        # canonical tokens = assistant message in token space as sampled from the llm
+        # drifted tokens = same message but with a different token-space representation
+        # some messages render into canonical tokens, some into drifted
+        # given canonical tokens, we can't compute a message that will render into canonical tokens
+        # but if two messages are equal, then we can use canonical tokens as context for the llm
 
         st = self._state.get(sid)
         if st is None or sid in self._disabled:
-            return r_full  # first turn, or healing disabled for this sid
+            # first turn, or healing disabled for this sid: feed the plain render
+            return self.renderer.render(messages, tools=tools, add_generation_prompt=True)
 
-        r_prev = self.renderer.render(st.prev_messages, tools=st.prev_tools, add_generation_prompt=False)
-
-        if r_full[: len(r_prev)] != r_prev:
+        # Linearity is decided in MESSAGE space, not token space. st.prev_messages is this
+        # session's history before this request (including the last assistant message). The
+        # history is linear iff those messages are a prefix of the incoming messages under
+        # dict equality -- the same order-independent match the TrajectoryManager uses -- and
+        # the tools schema is unchanged. A prior assistant turn the client re-serialized
+        # cosmetically (tool-call arguments re-keyed, or JSON re-spaced: the wire form is
+        # emitted sort_keys=True while the manager keeps the model's emission order) still
+        # compares equal, so it stays linear instead of tripping a token-level prefix check.
+        new = self._linear_delta(st, messages, tools)
+        if new is None:
+            # genuine edit/drop/branch/compaction (or a tools change): re-anchor
+            r_full = self.renderer.render(messages, tools=tools, add_generation_prompt=True)
             return self._handle_nonlinear(sid, r_full)
 
+        # r_prev is the token-space render of the gateway's OWN stored history. r_ext extends
+        # that same stored prefix by only the genuinely-new (non-assistant, drift-free)
+        # messages, so r_ext starts with r_prev by construction (identical prefix list and
+        # tools) -- the client's re-serialized prior turns never enter the fed tokens.
+        r_prev = self.renderer.render(st.prev_messages, tools=st.prev_tools, add_generation_prompt=False)
+        r_ext = self.renderer.render(st.prev_messages + new, tools=st.prev_tools, add_generation_prompt=True)
+        if r_ext[: len(r_prev)] != r_prev:
+            # template glue for the prior turns depends on the appended messages, so we
+            # cannot splice the canonical prefix safely; re-anchor rather than emit garbage.
+            return self._handle_nonlinear(sid, r_ext)
+
+        # close is the token-space marker of the end of the assistant turn
         close = self._assistant_close(st.prev_messages, st.prev_tools, r_prev)
         if close is None:
             # couldn't isolate the assistant-closer (e.g. a template whose glue depends on
             # message type); don't emit a subtly-wrong sequence — fall back.
             self._bump(sid, "close_unresolved")
-            return self._handle_nonlinear(sid, r_full)
+            return self._handle_nonlinear(sid, r_ext)
 
-        # don't duplicate closer tokens the model already emitted at the end of its served
+        # don't duplicate close tokens the model already emitted at the end of its served
         # output (e.g. a trailing stop token kept by no_stop_trim): drop the prefix of
         # `close` that the served prefix already ends with.
         close = self._trim_overlap(st.served_prefix, close)
 
-        tail = r_full[len(r_prev) :]  # new observation messages + generation prompt
+        # tail is the token representation of the new messages in the incoming request
+        # these are not assistant messages, so they are masked and drift-free
+        tail = r_ext[len(r_prev) :]  # new observation messages + generation prompt
+
         self._bump(sid, "healed_turns")
-        # canonical (drift-free) prefix tokens spliced over the client's drifted render
         self._bump(sid, "healed_prefix_tokens", len(st.served_prefix) + len(close))
+
+        # st.served_prefix is the accumulation of rendered non-assistant messages
+        # and canonical tokens of assistant messsages, therefore the concatenated
+        # sequence contains zero drifted tokens
         return list(st.served_prefix) + close + tail
+
+    @staticmethod
+    def _linear_delta(st: _State, messages: list[dict], tools: list[dict] | None) -> list[dict] | None:
+        """The genuinely-new messages appended since the last turn, or ``None`` if the
+        incoming history is not a linear extension of the stored history.
+
+        Linear iff ``st.prev_messages`` is a prefix of ``messages`` under dict equality
+        (order-independent, matching :class:`TrajectoryManager`) AND the tools schema is
+        unchanged. Returns ``messages[len(prev_messages):]`` when linear (possibly empty:
+        a bare re-generation of the same turn).
+        """
+        prev = st.prev_messages
+        k = len(prev)
+        if len(messages) < k or messages[:k] != prev:
+            return None
+        if (list(tools) if tools else None) != st.prev_tools:
+            return None
+        return messages[k:]
 
     def commit(
         self,
@@ -208,7 +268,7 @@ class LinearHealer:
         if self.on_nonlinear == "error":
             raise RuntimeError(
                 f"linear history mode: sid {sid!r} broke the append-only assumption "
-                "(prior render is not a prefix of the incoming render)"
+                "(stored history is not a message-level prefix of the incoming history)"
             )
         if self.on_nonlinear == "passthrough":
             self._disabled.add(sid)

--- a/src/agentcore_rl_toolkit/rollout_gateway/linear.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/linear.py
@@ -1,0 +1,263 @@
+"""Generate-time prefix healing for strictly-linear agent histories.
+
+This is the engine behind the gateway's ``history_mode="linear"``. It targets agents whose conversation
+is **append-only** and where cosmetic re-tokenization drift of a previously-generated
+assistant turn is considered insignificant (OOD-negligible).
+
+The problem it removes: each turn the client replays the whole conversation as messages;
+re-rendering a prior assistant message from its parsed dict rarely reproduces the exact
+token ids the model actually generated (whitespace, tool-call JSON spacing, reasoning
+re-keying). The :class:`~.trajectory.TrajectoryManager` then sees that drift and FORKs the
+single rollout into multiple training samples (or REALIGNs and drops a turn's signal). On
+one real run (``fork_threshold_tokens=0``) 96.6% of linear sessions forked, ~6 samples
+each — pure training-efficiency loss.
+
+The fix: because the gateway owns the tokens handed to the backend, it substitutes the
+exact ids it already served for the earlier turns **before** generation, so the model
+always generates on the canonical, drift-free context. The recorded prompt is then an
+exact prefix extension of what the manager holds, so the manager stays permanently CLEAN
+— one sample per session, every generated turn trained on its true multi-turn context.
+
+Per turn the healer holds, per sid:
+
+* ``served_prefix`` — the canonical token ids of the conversation through the end of the
+  last turn's *generated content* (i.e. what we fed to generate last turn, plus the ids
+  the backend actually served). This is exactly what the manager holds after that turn.
+* ``prev_messages`` / ``prev_tools`` — the message list (including the generated assistant)
+  and tools schema last rendered, used to re-derive the drifted skeleton.
+
+Healing ``messages`` for the next turn (:meth:`heal`):
+
+1. ``r_prev = render(prev_messages, add_generation_prompt=False)`` — the drifted re-render
+   of the prior conversation (``= served_prompt' + O_n' + close_n``).
+2. ``r_full = render(messages, add_generation_prompt=True)`` — the full incoming render.
+3. Linearity check: ``r_full`` must start with ``r_prev`` (append-only). If not, the
+   history was edited/branched/compacted — handled per ``on_nonlinear``.
+4. ``close_n`` — the template's assistant-closer after the last turn, extracted exactly by
+   a common-suffix probe (:func:`_assistant_close`), independent of template internals.
+5. ``healed = served_prefix + close_n + r_full[len(r_prev):]`` — canonical prefix, the
+   template close, then the genuinely-new observation + generation-prompt tail.
+
+:meth:`commit` (after a successful turn) advances ``served_prefix`` to
+``healed + output_ids`` and ``prev_messages`` to ``messages + [response_message]``.
+
+The healer is tokenizer-free and torch-free: it only calls the injected ``Renderer``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from collections import Counter
+
+from .render import Renderer
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["LinearHealer"]
+
+# two clearly-distinct assistant bodies used to probe the template's between-message glue
+# (see _assistant_close). They must tokenize to different trailing tokens so the common
+# suffix of the two renders is exactly the closer, nothing of the body.
+_PROBE_A = "linprobe body alpha 00000"
+_PROBE_B = "linprobe body omega 99999"
+
+
+def _common_prefix_len(a: list[int], b: list[int]) -> int:
+    limit = min(len(a), len(b))
+    i = 0
+    while i < limit and a[i] == b[i]:
+        i += 1
+    return i
+
+
+def _common_suffix(a: list[int], b: list[int]) -> list[int]:
+    """The longest common suffix of two id lists (as a fresh list)."""
+    limit = min(len(a), len(b))
+    i = 0
+    while i < limit and a[-1 - i] == b[-1 - i]:
+        i += 1
+    return a[len(a) - i :] if i else []
+
+
+@dataclasses.dataclass
+class _State:
+    served_prefix: list[int]
+    prev_messages: list[dict]
+    prev_tools: list[dict] | None
+
+
+class LinearHealer:
+    """Per-sid generate-time prefix healing for linear histories.
+
+    ``on_nonlinear`` picks the behaviour when the append-only assumption breaks:
+
+    * ``"reset"`` (default) — re-anchor to the incoming render and keep healing forward,
+      treating the jump as the start of a fresh linear segment. Cheapest; correct when the
+      jump is a benign, agent-controlled compaction. The single jump turn conditions on the
+      client's (drifted-but-linear-from-here) render.
+    * ``"error"`` — raise, failing the rollout, for runs that want a hard guarantee.
+    * ``"passthrough"`` — stop healing this sid and hand back the raw incoming render, so
+      the caller records the drifted prompt and the manager's tree/FORK path takes over.
+    """
+
+    def __init__(self, renderer: Renderer, *, on_nonlinear: str = "reset") -> None:
+        if on_nonlinear not in ("reset", "error", "passthrough"):
+            raise ValueError(f"on_nonlinear must be reset|error|passthrough, got {on_nonlinear!r}")
+        self.renderer = renderer
+        self.on_nonlinear = on_nonlinear
+        self._state: dict[str, _State] = {}
+        # sids we have stopped healing (passthrough after a non-linear jump)
+        self._disabled: set[str] = set()
+        # run-cumulative totals across every sid this healer instance has seen
+        self.counters: Counter[str] = Counter()
+        # per-sid totals, popped at session end so they can ride out on the record's
+        # metadata (a session-level view, distinct from the run-cumulative ``counters``)
+        self._per_sid: dict[str, Counter[str]] = {}
+
+    def _bump(self, sid: str, key: str, n: int = 1) -> None:
+        self.counters[key] += n
+        self._per_sid.setdefault(sid, Counter())[key] += n
+
+    # -- public -------------------------------------------------------------
+
+    def heal(self, sid: str, messages: list[dict], tools: list[dict] | None) -> list[int]:
+        """Return the token ids to feed the backend for this turn.
+
+        For the first turn of a sid (or a passthrough sid) this is just the plain render;
+        otherwise the drift-healed canonical prompt described in the module docstring.
+        ``commit`` must be called afterwards on the turns that are actually recorded.
+        """
+        r_full = self.renderer.render(messages, tools=tools, add_generation_prompt=True)
+
+        st = self._state.get(sid)
+        if st is None or sid in self._disabled:
+            return r_full  # first turn, or healing disabled for this sid
+
+        r_prev = self.renderer.render(st.prev_messages, tools=st.prev_tools, add_generation_prompt=False)
+
+        if r_full[: len(r_prev)] != r_prev:
+            return self._handle_nonlinear(sid, r_full)
+
+        close = self._assistant_close(st.prev_messages, st.prev_tools, r_prev)
+        if close is None:
+            # couldn't isolate the assistant-closer (e.g. a template whose glue depends on
+            # message type); don't emit a subtly-wrong sequence — fall back.
+            self._bump(sid, "close_unresolved")
+            return self._handle_nonlinear(sid, r_full)
+
+        # don't duplicate closer tokens the model already emitted at the end of its served
+        # output (e.g. a trailing stop token kept by no_stop_trim): drop the prefix of
+        # `close` that the served prefix already ends with.
+        close = self._trim_overlap(st.served_prefix, close)
+
+        tail = r_full[len(r_prev) :]  # new observation messages + generation prompt
+        self._bump(sid, "healed_turns")
+        # canonical (drift-free) prefix tokens spliced over the client's drifted render
+        self._bump(sid, "healed_prefix_tokens", len(st.served_prefix) + len(close))
+        return list(st.served_prefix) + close + tail
+
+    def commit(
+        self,
+        sid: str,
+        *,
+        fed_prompt_ids: list[int],
+        output_ids: list[int],
+        messages: list[dict],
+        response_message: dict | None,
+        tools: list[dict] | None,
+    ) -> None:
+        """Advance per-sid state after a turn that was actually recorded.
+
+        ``fed_prompt_ids`` is what :meth:`heal` returned (and what the backend generated
+        against); ``output_ids`` is what the backend served.
+        """
+        if sid in self._disabled:
+            return
+        asst = response_message if response_message is not None else {"role": "assistant", "content": ""}
+        self._state[sid] = _State(
+            served_prefix=list(fed_prompt_ids) + list(output_ids),
+            prev_messages=list(messages) + [asst],
+            prev_tools=list(tools) if tools else None,
+        )
+
+    #: every counter key this healer can emit; ``pop_stats`` returns all of them (with
+    #: zeros for counters that never fired) so per-session stats have a stable schema.
+    COUNTER_KEYS = ("healed_turns", "healed_prefix_tokens", "nonlinear", "close_unresolved")
+
+    def pop_stats(self, sid: str) -> dict[str, int]:
+        """Remove and return this sid's healing counters as a fixed-schema dict.
+
+        Always includes every key in :attr:`COUNTER_KEYS` (counters that never fired are
+        zeroed), so a downstream per-session metric reduction sees the same columns for
+        every session. Called at session teardown so the per-session view can be attached
+        to the session's record metadata; the run-cumulative ``counters`` is untouched.
+        """
+        c = self._per_sid.pop(sid, None) or Counter()
+        return {k: c[k] for k in self.COUNTER_KEYS}
+
+    def drop(self, sid: str) -> None:
+        self._state.pop(sid, None)
+        self._disabled.discard(sid)
+        self._per_sid.pop(sid, None)
+
+    # -- internals ----------------------------------------------------------
+
+    def _handle_nonlinear(self, sid: str, r_full: list[int]) -> list[int]:
+        self._bump(sid, "nonlinear")
+        if self.on_nonlinear == "error":
+            raise RuntimeError(
+                f"linear history mode: sid {sid!r} broke the append-only assumption "
+                "(prior render is not a prefix of the incoming render)"
+            )
+        if self.on_nonlinear == "passthrough":
+            self._disabled.add(sid)
+            self._state.pop(sid, None)
+            logger.warning("linear healer: sid=%s non-linear jump; disabling healing for this session", sid)
+            return r_full
+        # reset: re-anchor to the incoming render as a fresh linear segment. commit() will
+        # overwrite _state; here we just clear it so this turn is treated first-turn-like.
+        # (No separate reset counter: with on_nonlinear="reset" every ``nonlinear`` jump is
+        # re-anchored, so it would just duplicate ``nonlinear``; the mode is known config.)
+        self._state.pop(sid, None)
+        logger.info("linear healer: sid=%s non-linear jump; re-anchoring", sid)
+        return r_full
+
+    def _assistant_close(
+        self, prev_messages: list[dict], tools: list[dict] | None, r_prev: list[int]
+    ) -> list[int] | None:
+        """The template's between-message glue that follows the last assistant message
+        (e.g. Qwen's ``<|im_end|>\\n``), returned as token ids (possibly empty).
+
+        The glue is **type-independent** — templates append the same tokens after a text
+        or a tool-call assistant message — and it is what re-tokenization drift never
+        touches. So we probe it with two *text* assistant bodies (no tool-call wrapper to
+        share a suffix with) appended after the same prior turns, and take the common
+        suffix of the two renders: the bodies differ in every trailing token, the glue is
+        identical.
+
+        Returns ``None`` if the probed glue is not actually a suffix of the real ``r_prev``
+        — which happens iff this template's glue depends on message type (so the text probe
+        doesn't describe the actual tool-call turn). The caller then falls back rather than
+        emit a wrong boundary.
+        """
+        before = prev_messages[:-1]
+        ra = self.renderer.render(
+            before + [{"role": "assistant", "content": _PROBE_A}], tools=tools, add_generation_prompt=False
+        )
+        rb = self.renderer.render(
+            before + [{"role": "assistant", "content": _PROBE_B}], tools=tools, add_generation_prompt=False
+        )
+        close = _common_suffix(ra, rb)
+        if close and r_prev[-len(close) :] != close:
+            return None  # glue is message-type-dependent for this template; don't guess
+        return close
+
+    @staticmethod
+    def _trim_overlap(served_prefix: list[int], close: list[int]) -> list[int]:
+        """Drop the longest prefix of ``close`` that ``served_prefix`` already ends with, so
+        a closer the model emitted in its served output isn't duplicated."""
+        for k in range(min(len(close), len(served_prefix)), 0, -1):
+            if served_prefix[-k:] == close[:k]:
+                return close[k:]
+        return close

--- a/tests/rollout_gateway/test_gateway_integration.py
+++ b/tests/rollout_gateway/test_gateway_integration.py
@@ -180,6 +180,40 @@ async def test_openai_tool_loop_end_to_end():
     assert rec.response == "CALL calculator expr=2+2 tool: 4 assistant: the answer is 4"
 
 
+@pytest.mark.asyncio
+async def test_linear_mode_attaches_healer_stats_to_metadata():
+    """In linear mode, the session's LinearHealer counters ride out on every record's
+    metadata under ``linear_healer`` (the metrics seam), alongside caller extra_metadata."""
+    gateway, backend = make_gateway(replies=["CALL calculator expr=2+2", "the answer is 4"], history_mode="linear")
+    tools = [{"type": "function", "function": {"name": "calculator", "parameters": {"type": "object"}}}]
+    sid = "ep-lin:solver"
+
+    async with serve(gateway) as client:
+        gateway.create_session(sid)
+        body1 = {"model": "m", "messages": [{"role": "user", "content": "two plus two"}], "tools": tools}
+        resp1 = await client.post("/v1/chat/completions", json=body1, headers=bearer(sid))
+        choice1 = (await resp1.json())["choices"][0]
+        call = choice1["message"]["tool_calls"][0]
+        body2 = {
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": "two plus two"},
+                {"role": "assistant", "content": None, "tool_calls": choice1["message"]["tool_calls"]},
+                {"role": "tool", "tool_call_id": call["id"], "content": "4"},
+            ],
+            "tools": tools,
+        }
+        await client.post("/v1/chat/completions", json=body2, headers=bearer(sid))
+        records = await gateway.finish_session(sid, reward=1.0, extra_metadata={"task": "math"})
+
+    assert len(records) == 1  # linear mode stays CLEAN -> one row
+    md = records[0].metadata
+    assert md["task"] == "math"  # caller metadata preserved
+    # turn 2 was healed (prior state exists); the per-session counter is surfaced.
+    assert md["linear_healer"]["healed_turns"] == 1
+    assert md["linear_healer"].get("nonlinear", 0) == 0
+
+
 # ---------------------------------------------------------------------------
 # a mixed text + parallel tool-call turn reaches the client intact
 # ---------------------------------------------------------------------------

--- a/tests/rollout_gateway/test_linear_healer.py
+++ b/tests/rollout_gateway/test_linear_healer.py
@@ -1,0 +1,357 @@
+"""Correctness tests for LinearHealer (generate-time prefix healing).
+
+These drive the healer + a real TrajectoryManager the same way ``BaseAdapter._run_turn``
+does (heal -> generate -> commit -> record_turn), using a FakeRenderer that reproduces the
+exact failure mode linear mode targets: re-rendering a previously-generated assistant
+message yields *different* token ids than the ones the backend served (cosmetic
+re-tokenization drift), while system/user/tool messages re-render identically.
+
+The FakeRenderer is deliberately tokenizer-free and template-shaped: each message renders
+to ``[ROLE_OPEN] + content_ids + [ROLE_CLOSE]`` and a generation prompt appends
+``[ASSISTANT_OPEN]``. That is enough to exercise the two-render suffix diff, the
+append-only linearity check, and the common-suffix assistant-closer probe — including the
+tool-call path — without any real tokenizer.
+"""
+
+import json
+
+import pytest
+
+from agentcore_rl_toolkit.rollout_gateway import (
+    BaseTrace,
+    LinearHealer,
+    TrajectoryManager,
+    TurnRecord,
+)
+
+# special (template) tokens, kept clear of content and served ids
+U_OPEN, U_CLOSE = 1000, 1001
+A_OPEN, A_CLOSE = 1002, 1003
+_CONTENT_BASE = 100_000  # content ids live here; served ids live in the 2000s
+
+
+def _enc(text: str) -> list[int]:
+    """Deterministic per-character encoding; distinct strings -> distinct id runs, and
+    appending anything changes the tail (so the closer probe's common-suffix stops at the
+    template closer, not inside content)."""
+    return [_CONTENT_BASE + ord(c) for c in str(text)]
+
+
+class FakeRenderer:
+    """Template-shaped renderer with controllable assistant drift.
+
+    ``render`` reconstructs assistant messages from their dict (content + tool_calls),
+    which is exactly what produces drift on replay: the reconstructed ids differ from the
+    ids the model actually generated (which the test feeds as ``output_ids``).
+    """
+
+    def _block(self, m: dict) -> list[int]:
+        role = m.get("role")
+        if role == "user":
+            return [U_OPEN, *_enc(m.get("content") or ""), U_CLOSE]
+        if role == "assistant":
+            ids = [A_OPEN]
+            content = m.get("content")
+            if isinstance(content, list):  # block content -> flatten text parts
+                content = "".join(b.get("text", "") for b in content if isinstance(b, dict))
+            if content:
+                ids += _enc(content)
+            for tc in m.get("tool_calls") or []:
+                fn = tc.get("function") or {}
+                ids += _enc(fn.get("name") or "")
+                ids += _enc(json.dumps(fn.get("arguments") or {}, sort_keys=True))
+            ids.append(A_CLOSE)
+            return ids
+        raise AssertionError(f"unexpected role {role!r}")
+
+    def render(self, messages, *, tools=None, add_generation_prompt=True) -> list[int]:
+        out: list[int] = []
+        for m in messages:
+            out += self._block(m)
+        if add_generation_prompt:
+            out.append(A_OPEN)
+        return out
+
+
+def _u(text):
+    return {"role": "user", "content": text}
+
+
+def _a(text):
+    return {"role": "assistant", "content": text}
+
+
+def _drive_turn(mgr, healer, sid, *, messages, served_ids, response_message, logprobs=None, use_healer=True):
+    """Mirror BaseAdapter._run_turn for one turn: heal -> (fake generate) -> commit ->
+    record_turn. When ``use_healer`` is False, feed the raw drifted render instead (today's
+    behavior) so tests can contrast the two paths on identical inputs."""
+    if use_healer:
+        prompt_ids = healer.heal(sid, messages, None)
+    else:
+        prompt_ids = healer.renderer.render(messages, tools=None, add_generation_prompt=True)
+    turn = TurnRecord(
+        prompt_ids=list(prompt_ids),
+        output_ids=list(served_ids),
+        finish_reason="stop",
+        output_log_probs=list(logprobs) if logprobs is not None else None,
+    )
+    if use_healer:
+        healer.commit(
+            sid,
+            fed_prompt_ids=turn.prompt_ids,
+            output_ids=turn.output_ids,
+            messages=messages,
+            response_message=response_message,
+            tools=None,
+        )
+    mgr.record_turn(sid, turn=turn, prompt_messages=messages, response_message=response_message)
+    return prompt_ids
+
+
+# ---------------------------------------------------------------------------
+# The headline: renderer-driven drift forks without healing, collapses with it.
+# ---------------------------------------------------------------------------
+
+
+def test_unhealed_drift_forks():
+    """Baseline: served ids [2001,2002] for turn 1 differ from the renderer's re-render of
+    the same assistant message, and turn 2's response is long. Feeding the raw drifted
+    render forks the linear rollout into two samples."""
+    r = FakeRenderer()
+    mgr = TrajectoryManager(fork_threshold_tokens=1)  # any drift + response -> fork
+    healer = LinearHealer(r)
+    _drive_turn(
+        mgr, healer, "s", messages=[_u("q1")], served_ids=[2001, 2002], response_message=_a("r1"), use_healer=False
+    )
+    _drive_turn(
+        mgr,
+        healer,
+        "s",
+        messages=[_u("q1"), _a("r1"), _u("q2")],
+        served_ids=[2003, 2004, 2005],
+        response_message=_a("r2"),
+        use_healer=False,
+    )
+    recs = mgr.get_trajectory("s", base_sample=BaseTrace(index=0), reward=1.0)
+    assert len(recs) == 2  # linear rollout shattered by cosmetic drift
+
+
+def test_healed_drift_stays_one_sample():
+    """Same inputs, healed: turn 2 generates on the canonical served prefix, the manager
+    stays CLEAN, and the whole session is one training sample with both turns trained."""
+    r = FakeRenderer()
+    mgr = TrajectoryManager(fork_threshold_tokens=1)
+    healer = LinearHealer(r)
+    _drive_turn(
+        mgr, healer, "s", messages=[_u("q1")], served_ids=[2001, 2002], response_message=_a("r1"), logprobs=[-0.1, -0.2]
+    )
+    healed = _drive_turn(
+        mgr,
+        healer,
+        "s",
+        messages=[_u("q1"), _a("r1"), _u("q2")],
+        served_ids=[2003, 2004, 2005],
+        response_message=_a("r2"),
+        logprobs=[-0.3, -0.4, -0.5],
+    )
+
+    recs = mgr.get_trajectory("s", base_sample=BaseTrace(index=0), reward=1.0)
+    assert len(recs) == 1
+    rec = recs[0]
+
+    # canonical prefix = turn-1 fed prompt + served [2001,2002]; then the template closer
+    # [A_CLOSE], the new user turn, a generation prompt, and turn-2 served ids.
+    turn1_prompt = [U_OPEN, *_enc("q1"), U_CLOSE, A_OPEN]
+    served_prefix = turn1_prompt + [2001, 2002]
+    tail = [A_CLOSE, U_OPEN, *_enc("q2"), U_CLOSE, A_OPEN]
+    assert healed == served_prefix + tail
+    assert rec.token_ids == served_prefix + tail + [2003, 2004, 2005]
+
+    # response region (leading turn-1 prompt stripped): o1 trained, glue masked, o2 trained
+    o1, glue, o2 = [1, 1], [0] * len(tail), [1, 1, 1]
+    assert rec.loss_mask == o1 + glue + o2
+    # served logprobs preserved for both generated turns; glue zeroed
+    assert rec.logprobs == [-0.1, -0.2] + [0.0] * len(tail) + [-0.3, -0.4, -0.5]
+    assert healer.counters["healed_turns"] == 1
+    assert healer.counters["nonlinear"] == 0
+
+
+def test_healed_does_not_duplicate_closer_in_served_output():
+    """When the served output already ends with the template closer (no_stop_trim keeps the
+    stop token), the overlap-trim must drop it from the reinserted glue so it is not
+    doubled -- otherwise the manager would see a two-closer sequence and drift."""
+    r = FakeRenderer()
+    mgr = TrajectoryManager(fork_threshold_tokens=1)
+    healer = LinearHealer(r)
+    # turn 1's served ids END with the closer token (A_CLOSE == the glue the probe finds).
+    _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001, A_CLOSE], response_message=_a("r1"))
+    healed = healer.heal("s", [_u("q1"), _a("r1"), _u("q2")], None)
+
+    turn1_prompt = [U_OPEN, *_enc("q1"), U_CLOSE, A_OPEN]
+    served_prefix = turn1_prompt + [2001, A_CLOSE]
+    tail = [U_OPEN, *_enc("q2"), U_CLOSE, A_OPEN]
+    # closer already present at the tail of served_prefix -> glue trimmed to nothing.
+    assert healed == served_prefix + tail
+    assert healed.count(A_CLOSE) == 1  # not doubled
+
+
+def test_healed_three_turns_one_sample():
+    """Drift on every replayed assistant turn across a 3-turn chain still yields exactly
+    one sample (the case that produced ~6 samples/session on the real run)."""
+    r = FakeRenderer()
+    mgr = TrajectoryManager(fork_threshold_tokens=1)
+    healer = LinearHealer(r)
+    _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
+    _drive_turn(mgr, healer, "s", messages=[_u("q1"), _a("r1"), _u("q2")], served_ids=[2002], response_message=_a("r2"))
+    _drive_turn(
+        mgr,
+        healer,
+        "s",
+        messages=[_u("q1"), _a("r1"), _u("q2"), _a("r2"), _u("q3")],
+        served_ids=[2003],
+        response_message=_a("r3"),
+    )
+    recs = mgr.get_trajectory("s", base_sample=BaseTrace(index=0), reward=1.0)
+    assert len(recs) == 1
+    # three trained tokens (2001, 2002, 2003), one per generated turn
+    assert sum(recs[0].loss_mask) == 3
+    assert healer.counters["healed_turns"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Assistant-closer probe, including the tool-call path (the doc's caveat).
+# ---------------------------------------------------------------------------
+
+
+def test_close_probe_isolates_closer_text_turn():
+    r = FakeRenderer()
+    healer = LinearHealer(r)
+    prev = [_u("q1"), _a("hello world")]
+    r_prev = r.render(prev, add_generation_prompt=False)
+    assert healer._assistant_close(prev, None, r_prev) == [A_CLOSE]
+
+
+def test_close_probe_isolates_closer_tool_call_turn():
+    """A content-less tool-call assistant message: the closer probe perturbs the tool
+    arguments (not text) and still recovers exactly the template closer."""
+    r = FakeRenderer()
+    healer = LinearHealer(r)
+    tool_msg = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"q": "cats"}}}],
+    }
+    prev = [_u("q1"), tool_msg]
+    r_prev = r.render(prev, add_generation_prompt=False)
+    assert healer._assistant_close(prev, None, r_prev) == [A_CLOSE]
+
+
+# ---------------------------------------------------------------------------
+# Non-linear history handling.
+# ---------------------------------------------------------------------------
+
+
+def test_nonlinear_reset_reanchors_and_continues():
+    """If a turn's render is not an append-only extension (here: a prior user message is
+    edited), reset re-anchors to the incoming render and keeps healing forward."""
+    r = FakeRenderer()
+    healer = LinearHealer(r, on_nonlinear="reset")
+    mgr = TrajectoryManager(fork_threshold_tokens=1)
+    _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
+    # turn 2 edits the prior user message ("q1" -> "Q1!"): r_prev is no longer a prefix.
+    healed = healer.heal("s", [_u("Q1!"), _a("r1"), _u("q2")], None)
+    assert healed == r.render([_u("Q1!"), _a("r1"), _u("q2")], add_generation_prompt=True)
+    assert healer.counters["nonlinear"] == 1
+
+
+def test_nonlinear_error_raises_when_configured():
+    r = FakeRenderer()
+    healer = LinearHealer(r, on_nonlinear="error")
+    healer.commit(
+        "s",
+        fed_prompt_ids=r.render([_u("q1")], add_generation_prompt=True),
+        output_ids=[2001],
+        messages=[_u("q1")],
+        response_message=_a("r1"),
+        tools=None,
+    )
+    with pytest.raises(RuntimeError, match="append-only"):
+        healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2")], None)
+
+
+def test_nonlinear_passthrough_disables_healing_for_session():
+    r = FakeRenderer()
+    healer = LinearHealer(r, on_nonlinear="passthrough")
+    healer.commit(
+        "s",
+        fed_prompt_ids=r.render([_u("q1")], add_generation_prompt=True),
+        output_ids=[2001],
+        messages=[_u("q1")],
+        response_message=_a("r1"),
+        tools=None,
+    )
+    healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2")], None)  # trips passthrough
+    # subsequent turns are no-ops (raw render), even if they look linear again
+    out = healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2"), _a("r2"), _u("q3")], None)
+    assert out == r.render([_u("EDITED"), _a("r1"), _u("q2"), _a("r2"), _u("q3")], add_generation_prompt=True)
+    assert healer.counters["nonlinear"] == 1
+
+
+def test_bad_on_nonlinear_rejected():
+    with pytest.raises(ValueError):
+        LinearHealer(FakeRenderer(), on_nonlinear="nope")
+
+
+# ---------------------------------------------------------------------------
+# Per-session counters (the metadata seam).
+# ---------------------------------------------------------------------------
+
+
+def test_pop_stats_is_per_session_and_isolated():
+    """pop_stats returns just this sid's counters (not the run-cumulative total), keeps
+    sessions isolated, and clears the sid so a second pop is empty."""
+    r = FakeRenderer()
+    mgr = TrajectoryManager(fork_threshold_tokens=1)
+    healer = LinearHealer(r)
+    # session A: two turns -> one healed turn.
+    _drive_turn(mgr, healer, "a", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
+    _drive_turn(mgr, healer, "a", messages=[_u("q1"), _a("r1"), _u("q2")], served_ids=[2002], response_message=_a("r2"))
+    # session B: two turns -> one healed turn.
+    _drive_turn(mgr, healer, "b", messages=[_u("p1")], served_ids=[3001], response_message=_a("s1"))
+    _drive_turn(mgr, healer, "b", messages=[_u("p1"), _a("s1"), _u("p2")], served_ids=[3002], response_message=_a("s2"))
+
+    # run-cumulative counter sees both sessions; per-sid sees only its own.
+    assert healer.counters["healed_turns"] == 2
+    stats_a = healer.pop_stats("a")
+    assert stats_a["healed_turns"] == 1
+    assert set(stats_a) == set(LinearHealer.COUNTER_KEYS)  # fixed schema
+    assert healer.pop_stats("a")["healed_turns"] == 0  # cleared after pop
+    assert healer.counters["healed_turns"] == 2  # run-cumulative untouched
+    assert healer.pop_stats("b")["healed_turns"] == 1
+
+
+def test_pop_stats_counts_nonlinear_for_session():
+    r = FakeRenderer()
+    healer = LinearHealer(r, on_nonlinear="reset")
+    healer.commit(
+        "s",
+        fed_prompt_ids=r.render([_u("q1")], add_generation_prompt=True),
+        output_ids=[2001],
+        messages=[_u("q1")],
+        response_message=_a("r1"),
+        tools=None,
+    )
+    healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2")], None)  # non-linear -> reset
+    stats = healer.pop_stats("s")
+    assert stats["nonlinear"] == 1
+
+
+def test_drop_clears_per_sid_stats():
+    r = FakeRenderer()
+    mgr = TrajectoryManager(fork_threshold_tokens=1)
+    healer = LinearHealer(r)
+    _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
+    _drive_turn(mgr, healer, "s", messages=[_u("q1"), _a("r1"), _u("q2")], served_ids=[2002], response_message=_a("r2"))
+    healer.drop("s")
+    # per-sid counters cleared -> fixed schema, all zero.
+    assert healer.pop_stats("s") == dict.fromkeys(LinearHealer.COUNTER_KEYS, 0)

--- a/tests/rollout_gateway/test_linear_healer.py
+++ b/tests/rollout_gateway/test_linear_healer.py
@@ -219,6 +219,104 @@ def test_healed_three_turns_one_sample():
 
 
 # ---------------------------------------------------------------------------
+# Message-level linearity: a re-keyed tool-call replay is dict-equal but renders
+# to different tokens under an order-sensitive template. It must stay healed.
+# ---------------------------------------------------------------------------
+
+
+class OrderSensitiveRenderer(FakeRenderer):
+    """Renders tool-call arguments in INSERTION order (like a real chat template), so a
+    replayed assistant tool-call with re-keyed arguments produces different tokens even
+    though the message dict is ``==``. This reproduces the token-level drift the
+    message-level linearity check must tolerate (the wire form is sorted, the model's
+    emission order is not)."""
+
+    def _block(self, m: dict) -> list[int]:
+        if m.get("role") == "assistant" and m.get("tool_calls"):
+            ids = [A_OPEN]
+            content = m.get("content")
+            if content:
+                ids += _enc(content)
+            for tc in m["tool_calls"]:
+                fn = tc.get("function") or {}
+                ids += _enc(fn.get("name") or "")
+                # sort_keys=False -> argument key order changes the token render
+                ids += _enc(json.dumps(fn.get("arguments") or {}, sort_keys=False))
+            ids.append(A_CLOSE)
+            return ids
+        return super()._block(m)
+
+
+def _a_tool(name, arguments, content=""):
+    return {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [{"type": "function", "function": {"name": name, "arguments": arguments}}],
+    }
+
+
+def test_reordered_tool_call_args_stay_healed():
+    """A replayed tool-call assistant whose arguments are re-keyed (dict-equal, but a
+    different token render under an order-sensitive template) must stay linear/healed --
+    the drift a token-prefix linearity check would wrongly treat as non-linear."""
+    r = OrderSensitiveRenderer()
+    mgr = TrajectoryManager(fork_threshold_tokens=1)
+    healer = LinearHealer(r)
+
+    emitted = {"path": "/f.py", "text": "x"}  # the model's emission order
+    reordered = {"text": "x", "path": "/f.py"}  # the client's sorted-wire round-trip
+    assert _a_tool("edit", emitted) == _a_tool("edit", reordered)  # manager sees them equal
+    # ... but the order-sensitive renderer does not:
+    assert r.render([_a_tool("edit", emitted)]) != r.render([_a_tool("edit", reordered)])
+
+    _drive_turn(
+        mgr,
+        healer,
+        "s",
+        messages=[_u("q1")],
+        served_ids=[2001, 2002],
+        response_message=_a_tool("edit", emitted),
+    )
+    healed = _drive_turn(
+        mgr,
+        healer,
+        "s",
+        messages=[_u("q1"), _a_tool("edit", reordered), _u("obs")],
+        served_ids=[2003],
+        response_message=_a("done"),
+    )
+
+    # healed, not reset: the fed prompt reuses the canonical served prefix (the drifted
+    # replay order never appears), and the whole session stays one training sample.
+    assert healer.counters["nonlinear"] == 0
+    assert healer.counters["healed_turns"] == 1
+    served_prefix = [U_OPEN, *_enc("q1"), U_CLOSE, A_OPEN, 2001, 2002]
+    assert healed[: len(served_prefix)] == served_prefix
+    assert len(mgr.get_trajectory("s", base_sample=BaseTrace(index=0), reward=1.0)) == 1
+
+
+def test_tools_change_is_nonlinear():
+    """A changed tools schema is not a linear continuation even when the messages extend
+    cleanly (the token-prefix check missed this when the renderer folds tools into a
+    region the drift check doesn't reach; the message-level check compares tools directly)."""
+    r = FakeRenderer()
+    healer = LinearHealer(r, on_nonlinear="reset")
+    tools_a = [{"type": "function", "function": {"name": "a"}}]
+    tools_b = [{"type": "function", "function": {"name": "b"}}]
+    healer.commit(
+        "s",
+        fed_prompt_ids=r.render([_u("q1")], add_generation_prompt=True),
+        output_ids=[2001],
+        messages=[_u("q1")],
+        response_message=_a("r1"),
+        tools=tools_a,
+    )
+    healer.heal("s", [_u("q1"), _a("r1"), _u("q2")], tools_b)
+    assert healer.counters["nonlinear"] == 1
+    assert healer.counters["healed_turns"] == 0
+
+
+# ---------------------------------------------------------------------------
 # Assistant-closer probe, including the tool-call path (the doc's caveat).
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# feat(rollout_gateway): linear-history mode via generate-time prefix healing

## Summary

Adds an opt-in `history_mode="linear"` to the rollout gateway that keeps a strictly linear, append-only agent history as **one** training sample per session instead of letting re-tokenization drift shatter it into many forked samples. It is implemented as a small `LinearHealer` (`rollout_gateway/linear.py`) that heals drift at generation time; the existing `TrajectoryManager` is unchanged and stays permanently CLEAN. Default behavior (`history_mode="tree"`) is untouched.

## Problem

The gateway owns tokenization, so each turn it re-renders the whole conversation the agent replays. Chat templates are deterministic, so system/user/tool messages re-render to identical ids — but a prior **assistant** message rarely does: its served tokens came from generation, while on the next turn it is re-rendered from a parsed message dict (`text` + `tool_calls`) back through the template, yielding near-identical ids that differ in whitespace, tool-call JSON spacing, or reasoning re-keying. `TrajectoryManager` detects that drift and, to stay safe for harnesses that may branch or edit history, resolves it by FORK (split the rollout into a second sample) or REALIGN (drop a turn's signal).

For a strictly linear, multi-turn tool-calling agent (the target use case here — a SWE agent whose history is append-only and where cosmetic drift is out-of-distribution-insignificant) that safety is pure overhead. On a real multi-turn SWE-agent run (Qwen3-Coder-30B, `fork_threshold_tokens=0`) the large majority of sessions forked into several records each, even though every rollout was linear. Each fork re-emits the shared prefix as `loss_mask=0` context and splits the trajectory, so it is a large, avoidable training-efficiency loss.

## Approach

Because the gateway controls the tokens handed to the backend, it can splice the exact ids it already served for prior turns over the client's re-rendered version **before** generation, so the model always generates on the canonical, drift-free context:

```
fed_{N+1} = served_prefix + close_N + delta_tail
O_{N+1}   = backend.generate(fed_{N+1})
served_prefix = fed_{N+1} + O_{N+1}    # extend the canonical sequence
```

where `served_prefix` is the canonical ids through the last generated turn, `close_N` is the template's between-message glue, and `delta_tail` is the genuinely-new tokens (new observation messages + generation prompt). `O_{N+1}` is then sampled on the canonical context, `TrajectoryManager` sees an append-only sequence, appends the tail, and never forks — one session, one `TraceRecord`, every generated turn trained on its true multi-turn context.

Linearity is decided in **message space**, at the same altitude `TrajectoryManager` matches replayed history: dict equality (which is order-independent), not raw token identity. The stored `prev_messages` (whose last element is the gateway's own parsed assistant message) must be a prefix of the incoming `messages` under `==`, and the tools schema must be unchanged. The genuinely-new messages are then `new = messages[len(prev_messages):]`, and `delta_tail` is rendered from the gateway's **own** stored messages, so no hand-rolled delimiter logic is needed and the client's re-serialization of prior turns never enters the fed tokens:

```
assert messages[:len(prev_messages)] == prev_messages and tools == prev_tools  # linearity check
new        = messages[len(prev_messages):]
r_prev     = render(prev_messages,       tools=prev_tools, add_generation_prompt=False)
r_ext      = render(prev_messages + new, tools=prev_tools, add_generation_prompt=True)
delta_tail = r_ext[len(r_prev):]                                               # new messages + generation prompt
```

Both renders share the literal `prev_messages` prefix and the same tools, so `r_ext` starts with `r_prev` **by construction** — the prior turns are re-rendered from the gateway's canonical dicts, not the client's replay. Deciding linearity at the message level (rather than by a raw token-prefix check on the client's render) is what keeps the healer in agreement with `TrajectoryManager`: a harness that replays a prior tool call with its arguments re-keyed (the adapter emits the wire form `sort_keys=True` while the manager keeps the model's emission order) or its JSON re-spaced produces a message that is still `==` to what the gateway stored — so the manager, matching by dict equality, keeps it linear — but it renders to different tokens under an order-sensitive template. A token-prefix check would wrongly flag that cosmetic re-serialization as non-linear and reset; matching at dict equality keeps it healed and reserves the non-linear path for a genuine edit/branch. This relies only on chat templates being prefix-consistent with `add_generation_prompt=False` (rendering `[m0..mk]` is a prefix of `[m0..mk, mk+1]`), which holds for turn-delimited templates such as Qwen and Llama-3.

## What's in this PR

- `rollout_gateway/linear.py` — `LinearHealer`, the per-sid healer. Tokenizer-free and torch-free; it only calls the injected `Renderer`. `heal` returns the ids to feed the backend; `commit` advances per-sid state after a turn is actually recorded. `heal`/`commit` are split because `commit` needs the served `output_ids` (which only exist after generation) and must fire only for turns that are truly recorded — a failed or retried generation must not advance the canonical prefix — keeping healer state in lockstep with `TrajectoryManager`.
- `rollout_gateway/gateway.py` — `RolloutGateway.__init__` gains `history_mode` and `linear_on_nonlinear`. In linear mode it builds **one** shared `LinearHealer` and injects it into every co-mounted adapter (like the shared `TrajectoryManager`), so a session's canonical state is coherent regardless of which wire protocol its turns arrive on. `fork_threshold_tokens` is ignored in linear mode (forking is disabled by construction) and a warning is logged if both are set.
- `rollout_gateway/adapters/common.py` — `BaseAdapter` heals between render and `backend.generate` in `_run_turn`, feeds the healed ids to both `generate` and the `TurnRecord`, and calls `commit` before `record_turn`. Session teardown drops per-sid healer state.
- `rollout_gateway/__init__.py` — exports `LinearHealer`.
- `tests/rollout_gateway/test_linear_healer.py` — new correctness suite (below).

### Config surface

- `history_mode`: `"tree"` (default, current behavior) | `"linear"`. Gateway-global, plumbed like `fork_threshold_tokens`; linear and tree sessions do not coexist within a run.
- `linear_on_nonlinear`: `"reset"` (default) | `"error"` | `"passthrough"` — behavior when a turn breaks the append-only assumption.

## When the assumption breaks

The message-level linearity check fails when the incoming history is not an append-only extension of what the gateway stored: a dropped/edited/branched prior message (a genuine dict change, not merely a re-serialization), context compaction, a changed tools schema, or an LLM-client retry that re-issues the same prompt and produces a second generation from the same prefix. It also falls back when the closer probe cannot isolate the between-message glue (a message-type-dependent template — the `close_unresolved` counter). Behavior is controlled by `linear_on_nonlinear`:

- `"reset"` (default) — drop per-sid state and re-anchor to the current render, treating the jump as the start of a fresh linear segment. The turns before and after each stay drift-free; only the single jump turn conditions on the client's render. Correct for benign, agent-controlled jumps; increments a counter so a run that resets constantly is visible.
- `"error"` — raise and fail the rollout, for runs that want a hard guarantee the assumption holds.
- `"passthrough"` — stop healing this session and route the rest through the standard tree/FORK path (today's behavior) for the remainder of the session.

## Validation

**Unit tests** (`tests/rollout_gateway/test_linear_healer.py`) drive the real `LinearHealer` + `TrajectoryManager` through the same heal → generate → commit pipeline `BaseAdapter._run_turn` uses, with a template-shaped fake renderer that reproduces assistant-only drift: renderer-driven drift forks without healing and collapses to one sample with it (loss mask covering every generated turn, served logprobs preserved); multi-turn drift stays one sample; the closer probe isolates the glue for both text and tool-call turns and does not double the closer when the served output already ends with the stop token; and the three `linear_on_nonlinear` paths behave as specified. The template-level assumptions (generation-prompt tokens equal the assistant open; prefix-consistency turn to turn; the closer probe returns `<|im_end|>\n` for both text and tool-call turns and is a genuine suffix of a tool-call `r_prev`; served ids end with the stop token) were confirmed against the live Qwen3-Coder-30B tokenizer/template.

**Real-trace reconstruction.** We reconstructed, at the token level, the per-turn prompt streams from real recorded multi-turn SWE-agent sessions (Qwen3-Coder-30B) and replayed them through the real `TrajectoryManager` two ways: the drifted prompts as they actually happened, and the canonical served prefix + drift-free new-observation tail that healing feeds. The raw replay reproduced the recorded fork counts exactly (fidelity check). Healing collapsed the multi-record baseline sessions to a single record each while leaving the trained (`loss_mask=1`) token count identical — so the whole difference is redundant re-emitted context that healing removes. Training latency scales ~linearly with the sequence length forwarded, not the record count, so the total-token reduction is the latency-relevant figure, and it is smaller than the record reduction because early forks carry short prefixes while the redundancy is dominated by late, large-context forks. A small number of sessions did not collapse to a single record; the observed cases were benign harness-side history rewrites — an LLM-client retry re-issuing the same prompt, or a harness recovering a hallucinated tool name into a different tool with restructured arguments — which the message-level linearity check correctly treats as non-linear and `on_nonlinear="reset"` re-anchors into separate linear segments.

## Observability

`LinearHealer` tracks per turn: `healed_turns` and `healed_prefix_tokens` (turns healed and canonical prefix tokens spliced); `nonlinear` (message-level linearity failures — a genuine history edit/branch or tools change, not cosmetic re-serialization); `close_unresolved` (turns where the closer probe couldn't isolate the glue and fell back). A high `nonlinear` rate means the "linear" assumption is wrong for that harness and tree mode is the better fit — what happened to those jumps is the (known) `linear_on_nonlinear` mode, so there is no separate reset counter.

These are surfaced two ways. `LinearHealer.counters` is the run-cumulative total across every session the shared healer has seen. Per session, `finish_session` pops that session's own counters (`LinearHealer.pop_stats`, a fixed schema with zeros for counters that never fired) and attaches them to every record's metadata under `linear_healer`, riding the existing `extra_metadata` → `TraceRecord.metadata` seam — so a downstream consumer sees each rollout's healing stats without touching the healer. The per-session counters survive `reset`/`passthrough` jumps within a session (only per-sid healing *state* is cleared on a jump), so the final record still reports the full `nonlinear` total for that session.

## Non-goals

- Message-level rewrites where a prior message's **dict** changes *semantically* (not just its key order or JSON spacing): treated as non-linear and re-anchored/failed per `linear_on_nonlinear`. Cosmetic re-serialization that keeps the dict `==` is handled — the linearity check matches at dict equality — but an actual content change (e.g. a harness that recovers a hallucinated tool name into a different tool with restructured arguments) is out of scope for healing.
- Sub-agent / parallel-branch capture: that is what tree mode is for; linear mode re-anchors or falls back rather than trying to represent it.