### PR TITLE
fix(verl): drop trace-less failed rollouts

### DIFF
--- a/src/agentcore_rl_toolkit/backends/verl/README.md
+++ b/src/agentcore_rl_toolkit/backends/verl/README.md
@@ -37,11 +37,6 @@ verl main_ppo (v1) ──> AgentLoopWorker ──> AgentCoreAgentLoop.run()
 - A session's trajectory tree can fork (sub-agents, context compaction); every leaf
   becomes its own training row (`run()` returns `list[AgentLoopOutput]`) — hence the
   hard `trainer.use_v1=true` requirement.
-- Failed rollouts (timeout, ACR error, agent error) never raise. They yield a
-  single-pad-token fallback row: `response_mask=[1]` (verl's rollout-correction
-  helper requires ≥1 valid response token per row — an all-zero mask is rejected),
-  logprob 0, reward 0. See the TODO below for its current gradient semantics.
-
 The agent must forward the trainer-supplied key when it constructs its model client:
 
 ```python

--- a/src/agentcore_rl_toolkit/backends/verl/README.md
+++ b/src/agentcore_rl_toolkit/backends/verl/README.md
@@ -182,10 +182,13 @@ zero. Training remains correct, but verl's stock length metrics count those
 overflow tokens as part of the response region, so overflow should be a
 fallback rather than the normal configuration.
 
+Trace-less rollout failures raise from the agent loop and produce no synthetic
+training row. Other sessions for the same prompt remain trainable.
+
 ## Troubleshooting
 
-- **Every rollout degenerates, warning about "static session 'EMPTY'"**: the deployed
-  agent image predates the session-key contract and sends a fixed api key — its turns
+- **Every rollout fails, warning about "static session 'EMPTY'"**: the deployed agent
+  image predates the session-key contract and sends a fixed api key — its turns
   accumulate under one shared session while each rollout's real session drains empty.
   Rebuild/redeploy the agent image with the contract above.
 - **Agent-side 404s on every rollout**: an agent constructing its own URL paths
@@ -195,13 +198,3 @@ fallback rather than the normal configuration.
 - Sub-agents that reuse the same session id fork within one tree and are captured; a
   sub-agent given a *different* session id becomes a separate tree and is not joined
   to the episode (cross-session grouping is future work).
-
-## TODO
-
-- **Make trace-less failed rollouts gradient-free.** A timeout or dispatch failure
-  that produces no trace currently becomes a single pad-token response with
-  `response_mask=[1]`, logprob 0, and reward 0 because verl's rollout-correction
-  helpers reject an entirely empty response mask. In a mixed GRPO group, that
-  synthetic row can receive a negative group-relative advantage and therefore is
-  not strictly inert. A follow-up should exclude or zero-mask failed rows while
-  preserving a valid all-failed-batch path.

--- a/src/agentcore_rl_toolkit/backends/verl/README.md
+++ b/src/agentcore_rl_toolkit/backends/verl/README.md
@@ -178,7 +178,11 @@ overflow tokens as part of the response region, so overflow should be a
 fallback rather than the normal configuration.
 
 Trace-less rollout failures raise from the agent loop and produce no synthetic
-training row. Other sessions for the same prompt remain trainable.
+training row. With synchronous replay, successful sessions for the same prompt
+remain trainable. With asynchronous replay, verl's existing failed-group policy
+evicts and refills the entire prompt group, including successful sibling
+trajectories. Preserving partial failed groups in asynchronous training requires
+session-level or partial-group failure handling in verl's replay buffer.
 
 ## Troubleshooting
 

--- a/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
+++ b/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
@@ -263,7 +263,7 @@ class AgentCoreAgentLoop(AgentLoopBase):
 
         if not records:
             self._warn_if_static_session_capture(sid)
-            reason = error or "agent produced no LLM turns"
+            reason = error or "no model turns were captured"
             raise RuntimeError(f"ACR rollout produced no trainable trajectory (sid={sid}): {reason}")
 
         reward = self._resolve_reward(result, error, sid)

--- a/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
+++ b/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
@@ -263,7 +263,8 @@ class AgentCoreAgentLoop(AgentLoopBase):
 
         if not records:
             self._warn_if_static_session_capture(sid)
-            return [self._degenerate_output(kwargs, sid, error or "agent produced no LLM turns", elapsed, result)]
+            reason = error or "agent produced no LLM turns"
+            raise RuntimeError(f"ACR rollout produced no trainable trajectory (sid={sid}): {reason}")
 
         reward = self._resolve_reward(result, error, sid)
 
@@ -402,52 +403,6 @@ class AgentCoreAgentLoop(AgentLoopBase):
                 # AgentLoopWorkerTQ reads this with brackets when broadcasting an
                 # inline reward across multiple outputs — must always exist.
                 "reward_extra_info": {},
-            },
-        )
-
-    def _degenerate_output(
-        self, kwargs: dict[str, Any], sid: str, error: str, elapsed: float, result: dict[str, Any] | None = None
-    ) -> AgentLoopOutput:
-        """A valid-but-inert output for failed rollouts. Never raise — a raised
-        exception marks the whole prompt group as failed in the v1 replay buffer.
-
-        The single pad-token response carries response_mask=[1] (NOT 0: verl's
-        rollout-correction helper requires at least one valid response token per
-        row) with rollout_log_probs=[0.0], and scores 0.0 in built_in mode."""
-        pad_id = self.tokenizer.pad_token_id or self.tokenizer.eos_token_id or 0
-        prompt_ids = [pad_id]
-        raw_prompt = kwargs.get("raw_prompt")
-        if raw_prompt is not None:
-            try:
-                prompt_ids = self.tokenizer.apply_chat_template(
-                    list(raw_prompt), add_generation_prompt=True, tokenize=True
-                )
-                if hasattr(prompt_ids, "input_ids"):  # BatchEncoding
-                    prompt_ids = prompt_ids.input_ids
-                prompt_ids = list(prompt_ids)[-self.prompt_length :]
-            except Exception:
-                prompt_ids = [pad_id]
-
-        return AgentLoopOutput(
-            prompt_ids=prompt_ids,
-            response_ids=[pad_id],
-            response_mask=[1],
-            response_logprobs=[0.0],
-            # None is reserved for reward_mode="separate", which __init__ rejects today
-            reward_score=0.0 if self.reward_mode == "built_in" else None,
-            num_turns=1,
-            metrics=AgentLoopMetrics(generate_sequences=elapsed),
-            extra_fields={
-                "acr_failed": True,
-                "acr_error": error,
-                "acr_result": result or {},
-                "acr_session_id": sid,
-                "num_trace_records": 0,
-                "trace_index": 0,
-                "reward_extra_info": {},
-                # v1 staleness tags must be real ints (see run())
-                "min_global_steps": int(kwargs.get("global_steps", 0)),
-                "max_global_steps": int(kwargs.get("global_steps", 0)),
             },
         )
 

--- a/tests/backends/verl/test_agent_loop.py
+++ b/tests/backends/verl/test_agent_loop.py
@@ -130,8 +130,7 @@ async def test_malformed_reward_raises():
 
 
 async def test_malformed_reward_on_failed_rollout_still_scores_zero():
-    """Failures score 0.0 before the reward is even parsed, so a garbage reward
-    on an already-failed rollout stays an inert row (no raise)."""
+    """A failed rollout with a real partial trace trains that trace at reward 0."""
     loop = _make_loop()
     _wire_result(loop, {"status_code": 500, "stop_reason": "boom", "rewards": "invalid"})
     outputs = await loop.run({}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"prompt": "hi"}, uid="u1")
@@ -184,7 +183,7 @@ async def test_multi_turn_merges_to_one_record():
     assert outputs[0].num_turns == 4  # 3 LLM turns + 1
 
 
-async def test_timeout_returns_degenerate_output():
+async def test_timeout_without_trace_raises():
     loop = _make_loop()
 
     async def fake_invoke_async(payload, session_id=None, input_id=None, **overrides):
@@ -193,23 +192,15 @@ async def test_timeout_returns_degenerate_output():
         return future
 
     loop._client.invoke_async = fake_invoke_async
-    outputs = await loop.run({}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"prompt": "hi"}, uid="u1")
-
-    assert len(outputs) == 1
-    out = outputs[0]
-    assert out.extra_fields["acr_failed"] is True
-    # [1], not [0]: verl's rollout-correction helper requires >=1 valid response
-    # token per row; logprob 0.0 + reward 0 keeps the row inert.
-    assert out.response_mask == [1]
-    assert out.reward_score == 0.0
+    with pytest.raises(RuntimeError, match="timed out"):
+        await loop.run({}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"prompt": "hi"}, uid="u1")
 
 
-async def test_invoke_error_returns_degenerate_output():
+async def test_invoke_error_without_trace_raises():
     loop = _make_loop()
     loop._client.invoke_async = AsyncMock(side_effect=RuntimeError("throttled"))
-    outputs = await loop.run({}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"prompt": "hi"}, uid="u1")
-    assert outputs[0].extra_fields["acr_failed"] is True
-    assert "throttled" in outputs[0].extra_fields["acr_error"]
+    with pytest.raises(RuntimeError, match="throttled"):
+        await loop.run({}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"prompt": "hi"}, uid="u1")
 
 
 async def test_agent_error_status_with_trace_scores_zero():
@@ -230,8 +221,8 @@ async def test_use_v1_required():
 
 async def test_static_session_warning(caplog):
     """Stale agent image: the agent calls in with api_key='EMPTY' instead of its
-    ACR session id, so the real sid drains empty -> degenerate output plus a
-    warning naming the static session."""
+    ACR session id, so the real sid drains empty and raises after warning about
+    the static session."""
     loop = _make_loop()
 
     async def fake_invoke_async(payload, session_id=None, input_id=None, **overrides):
@@ -252,9 +243,9 @@ async def test_static_session_warning(caplog):
 
     loop._client.invoke_async = fake_invoke_async
     with caplog.at_level(logging.WARNING):
-        outputs = await loop.run({}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"prompt": "hi"}, uid="u1")
+        with pytest.raises(RuntimeError, match="no trainable trajectory"):
+            await loop.run({}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"prompt": "hi"}, uid="u1")
 
-    assert outputs[0].extra_fields["acr_failed"] is True
     assert any("static session 'EMPTY'" in r.message for r in caplog.records)
 
 


### PR DESCRIPTION
## Motivation

When an AgentCore rollout failed before producing any `TraceRecord`, the agent loop created a one-token pad trajectory with `response_mask=[1]`. Although its reward and log probability were zero, the token still entered actor loss and GRPO group statistics, producing invalid advantage, rollout-correction, and importance-ratio signals.

## Summary

- Raise when a rollout produces no real trace instead of storing a synthetic training row.
- Preserve the existing partial-failure behavior: if real trace data was captured before failure, train it with reward zero.
- Allow GRPO to operate on the real rows that remain. If a training batch has no materializable trajectory, allow the existing failure to surface.

## verl failed-group behavior

The V1 TQ worker marks the prompt group as failed if any session raises, after allowing all sibling sessions to settle. This PR does not change verl's existing group-level failure policies:

- Synchronous replay with `sync_refill_failed_groups=false` (the default and current configuration) keeps failed groups sampleable. Any successful sibling rows are materialized and GRPO uses only those remaining real rows.
- Synchronous replay with `sync_refill_failed_groups=true` refills failed groups only when they contain no materializable trajectory. Partial groups with successful sibling rows remain usable.
- Asynchronous replay evicts and refills every failed prompt group, including any successful sibling rows. Supporting partial failed groups in async training would require a separate change to verl's replay-buffer policy.

This implementation intentionally prioritizes training correctness over rollout efficiency. In asynchronous training, that can discard valid sibling work and require a refill, but it avoids admitting a fabricated row into actor loss or GRPO statistics. A synthetic row sharing the prompt UID affects GRPO mean and standard deviation even if its response mask is zero, because group statistics are computed before masking. verl's safe batch padding instead uses an independent padding UID downstream, after trajectory materialization; using that mechanism to represent a failed session would require coordinated TQ worker and replay-buffer changes.

## Testing

- `pytest tests/backends/verl/` — 53 passed.
- `pre-commit run --all-files` — passed.
- Real AgentCore math-agent smoke test covered both trace-less failure and successful trace capture.
- Synchronous verl V1 mixed-session harness retained two successful rows after one session failed and computed GRPO advantages from the remaining rows.
