### PR TITLE
Feat/reward extra info

### DIFF
--- a/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
+++ b/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
@@ -154,6 +154,7 @@ class AgentCoreAgentLoop(AgentLoopBase):
         # without a signature change. Reward semantics: see the README.
         self.reward_mode = reward_mode
         self._rei_defaults = {str(k): float(v) for k, v in (reward_extra_info_defaults or {}).items()}
+        self._rei_keys_seen: set[str] = set(self._rei_defaults)
         self.model_id = self.config.actor_rollout_ref.model.path
 
         self._gateway: GatewayHandle = get_or_start_gateway(
@@ -297,7 +298,9 @@ class AgentCoreAgentLoop(AgentLoopBase):
             primary = max(range(len(records)), key=lambda i: sum(records[i].loss_mask))
             records.append(records.pop(primary))
 
-        shared_extra["reward_extra_info"] = self._reward_extra_info(result, reward, len(records), failed=error is not None)
+        shared_extra["reward_extra_info"] = self._reward_extra_info(
+            result, reward, len(records), failed=error is not None
+        )
 
         outputs = [
             self._record_to_output(r, i, reward, num_turns, shared_extra, elapsed) for i, r in enumerate(records)
@@ -309,7 +312,7 @@ class AgentCoreAgentLoop(AgentLoopBase):
         metrics = (result or {}).get("metrics") or {}
         if isinstance(metrics, dict):
             for k, v in metrics.items():
-                if isinstance(v, bool | int | float) and not isinstance(v, str):
+                if isinstance(v, bool | int | float):
                     try:
                         info[str(k)] = float(v)
                     except (TypeError, ValueError):
@@ -317,6 +320,9 @@ class AgentCoreAgentLoop(AgentLoopBase):
         info["reward"] = float(reward)
         info["acr_failed"] = 1.0 if failed else 0.0
         info["num_trace_records"] = float(n_records)
+        for k in self._rei_keys_seen:
+            info.setdefault(k, 0.0)
+        self._rei_keys_seen.update(info)
         return info
 
     # -- helpers ---------------------------------------------------------------

--- a/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
+++ b/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
@@ -118,6 +118,7 @@ class AgentCoreAgentLoop(AgentLoopBase):
         max_turns_per_sid: int | None = None,
         fork_threshold_tokens: int | None = None,
         reward_mode: str = "built_in",
+        reward_extra_info_defaults: dict | None = None,
         **kwargs,  # swallows the YAML entry's `name`, verl's `tools`, and future kwargs
     ):
         super().__init__(trainer_config, server_manager, tokenizer, processor, dataset_cls, data_config, **kwargs)
@@ -152,6 +153,7 @@ class AgentCoreAgentLoop(AgentLoopBase):
         # Kept as config, not inlined, so a validated trainer-side mode can land
         # without a signature change. Reward semantics: see the README.
         self.reward_mode = reward_mode
+        self._rei_defaults = {str(k): float(v) for k, v in (reward_extra_info_defaults or {}).items()}
         self.model_id = self.config.actor_rollout_ref.model.path
 
         self._gateway: GatewayHandle = get_or_start_gateway(
@@ -295,10 +297,27 @@ class AgentCoreAgentLoop(AgentLoopBase):
             primary = max(range(len(records)), key=lambda i: sum(records[i].loss_mask))
             records.append(records.pop(primary))
 
+        shared_extra["reward_extra_info"] = self._reward_extra_info(result, reward, len(records), failed=error is not None)
+
         outputs = [
             self._record_to_output(r, i, reward, num_turns, shared_extra, elapsed) for i, r in enumerate(records)
         ]
         return outputs
+
+    def _reward_extra_info(self, result: dict[str, Any] | None, reward: float, n_records: int, *, failed: bool) -> dict:
+        info: dict[str, float] = dict(self._rei_defaults)
+        metrics = (result or {}).get("metrics") or {}
+        if isinstance(metrics, dict):
+            for k, v in metrics.items():
+                if isinstance(v, bool | int | float) and not isinstance(v, str):
+                    try:
+                        info[str(k)] = float(v)
+                    except (TypeError, ValueError):
+                        continue
+        info["reward"] = float(reward)
+        info["acr_failed"] = 1.0 if failed else 0.0
+        info["num_trace_records"] = float(n_records)
+        return info
 
     # -- helpers ---------------------------------------------------------------
 
@@ -402,7 +421,7 @@ class AgentCoreAgentLoop(AgentLoopBase):
                 "trace_metadata": dict(record.metadata),
                 # AgentLoopWorkerTQ reads this with brackets when broadcasting an
                 # inline reward across multiple outputs — must always exist.
-                "reward_extra_info": {},
+                "reward_extra_info": dict(shared_extra.get("reward_extra_info") or {}),
             },
         )
 

--- a/tests/backends/verl/test_agent_loop.py
+++ b/tests/backends/verl/test_agent_loop.py
@@ -93,7 +93,7 @@ async def test_run_end_to_end_inline_reward():
     assert len(out.prompt_ids) > 0
     assert out.reward_score == 0.75
     assert out.extra_fields["acr_result"]["rewards"] == 0.75
-    assert out.extra_fields["reward_extra_info"] == {}
+    assert out.extra_fields["reward_extra_info"] == {"reward": 0.75, "acr_failed": 0.0, "num_trace_records": 1.0}
 
     # invoke wiring: sid is a 36-char uuid used as both ACR session id and Bearer sid
     call = invoke.calls[0]
@@ -356,3 +356,20 @@ async def test_padded_region_cannot_exceed_max_model_len(field):
 async def test_invalid_max_tokens_per_turn_rejected(value):
     with pytest.raises(ValueError, match="max_tokens_per_turn"):
         _make_loop(max_tokens_per_turn=value)
+
+
+async def test_reward_extra_info_carries_scalar_metrics_over_defaults():
+    loop = _make_loop(FakeLLMServerClient(), reward_extra_info_defaults={"f_beta": 0.0, "reward": 0.0})
+    _wire_result(loop, {"status_code": 200, "rewards": 0.75, "metrics": {"f_beta": 0.6, "num_turns": 3, "note": "x"}})
+    outs = await loop.run({"temperature": 1.0}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"q": 1}, uid="u")
+    rei = outs[-1].extra_fields["reward_extra_info"]
+    assert rei["f_beta"] == 0.6 and rei["num_turns"] == 3.0 and rei["reward"] == 0.75
+    assert rei["acr_failed"] == 0.0 and rei["num_trace_records"] == 1.0
+    assert "note" not in rei  # non-numeric metrics are dropped (verl aggregates these as floats)
+
+
+async def test_degenerate_output_carries_reward_extra_info_defaults():
+    loop = _make_loop(FakeLLMServerClient(), reward_extra_info_defaults={"f_beta": 0.0})
+    out = loop._degenerate_output({"global_steps": 2}, "sid", "boom", 0.1, None)
+    assert out.extra_fields["reward_extra_info"] == {"f_beta": 0.0, "reward": 0.0, "acr_failed": 1.0, "num_trace_records": 0.0}
+

--- a/tests/backends/verl/test_agent_loop.py
+++ b/tests/backends/verl/test_agent_loop.py
@@ -361,15 +361,35 @@ async def test_invalid_max_tokens_per_turn_rejected(value):
 async def test_reward_extra_info_carries_scalar_metrics_over_defaults():
     loop = _make_loop(FakeLLMServerClient(), reward_extra_info_defaults={"f_beta": 0.0, "reward": 0.0})
     _wire_result(loop, {"status_code": 200, "rewards": 0.75, "metrics": {"f_beta": 0.6, "num_turns": 3, "note": "x"}})
-    outs = await loop.run({"temperature": 1.0}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"q": 1}, uid="u")
+    outs = await loop.run(
+        {"temperature": 1.0}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"q": 1}, uid="u"
+    )
     rei = outs[-1].extra_fields["reward_extra_info"]
     assert rei["f_beta"] == 0.6 and rei["num_turns"] == 3.0 and rei["reward"] == 0.75
     assert rei["acr_failed"] == 0.0 and rei["num_trace_records"] == 1.0
     assert "note" not in rei  # non-numeric metrics are dropped (verl aggregates these as floats)
 
 
-async def test_degenerate_output_carries_reward_extra_info_defaults():
+async def test_failed_rollout_carries_reward_extra_info_defaults():
     loop = _make_loop(FakeLLMServerClient(), reward_extra_info_defaults={"f_beta": 0.0})
-    out = loop._degenerate_output({"global_steps": 2}, "sid", "boom", 0.1, None)
-    assert out.extra_fields["reward_extra_info"] == {"f_beta": 0.0, "reward": 0.0, "acr_failed": 1.0, "num_trace_records": 0.0}
+    rei = loop._reward_extra_info(None, 0.0, 0, failed=True)
+    assert rei == {"f_beta": 0.0, "reward": 0.0, "acr_failed": 1.0, "num_trace_records": 0.0}
 
+
+async def test_failed_rollout_padded_with_keys_seen_on_successful_rollouts():
+    loop = _make_loop(FakeLLMServerClient(), reward_extra_info_defaults={"reward": 0.0})
+    _wire_result(loop, {"status_code": 200, "rewards": 1.0, "metrics": {"submitted": 1.0, "num_turns": 4, "ok": True}})
+    outs = await loop.run(
+        {"temperature": 1.0}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"q": 1}, uid="u"
+    )
+    assert outs[-1].extra_fields["reward_extra_info"]["ok"] == 1.0
+    rei = loop._reward_extra_info(None, 0.0, 0, failed=True)
+    assert rei == {
+        "reward": 0.0,
+        "acr_failed": 1.0,
+        "num_trace_records": 0.0,
+        "submitted": 0.0,
+        "num_turns": 0.0,
+        "ok": 0.0,
+    }
+    assert set(rei) == set(outs[-1].extra_fields["reward_extra_info"])


### PR DESCRIPTION
Populates reward_extra_info from container session which is currently left as empty.

```
   for k in self._rei_keys_seen:
            info.setdefault(k, 0.0)
        self._rei_keys_seen.update(info)
```
The keys for each session are set to zeros and then updated with the actual key values from each session. If a session does not return all the keys (possibly due to error in rollout) verl fills the missing value with None and then will crash when computing mean across values. Therefore setting missing values to zero ensures this does not occur.