### PR TITLE
fix(gateway): add reasoning content to history match dict, enable setting history_mode and linear_on_nonlinear in AgentCoreAgentLoop

### DIFF
--- a/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
+++ b/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
@@ -117,6 +117,8 @@ class AgentCoreAgentLoop(AgentLoopBase):
         gateway_adapters: list[str] | None = None,
         max_turns_per_sid: int | None = None,
         fork_threshold_tokens: int | None = None,
+        history_mode: str = "tree",
+        linear_on_nonlinear: str = "reset",
         reward_mode: str = "built_in",
         **kwargs,  # swallows the YAML entry's `name`, verl's `tools`, and future kwargs
     ):
@@ -163,6 +165,8 @@ class AgentCoreAgentLoop(AgentLoopBase):
             adapters=gateway_adapters,
             max_turns_per_sid=max_turns_per_sid,
             fork_threshold_tokens=fork_threshold_tokens,
+            history_mode=history_mode,
+            linear_on_nonlinear=linear_on_nonlinear,
         )
         # Default exp_id must be identical across all AgentLoopWorker processes of
         # one run, so derive it from verl's run identity instead of inventing one.

--- a/src/agentcore_rl_toolkit/backends/verl/gateway_host.py
+++ b/src/agentcore_rl_toolkit/backends/verl/gateway_host.py
@@ -153,6 +153,7 @@ def get_or_start_gateway(
     max_turns_per_sid: int | None = None,
     fork_threshold_tokens: int | None = None,
     history_mode: str = "tree",
+    linear_on_nonlinear: str = "reset",
 ) -> GatewayHandle:
     """Lazily create (or return) this process's RolloutGateway singleton.
 
@@ -175,6 +176,7 @@ def get_or_start_gateway(
             max_turns_per_sid=max_turns_per_sid,
             fork_threshold_tokens=fork_threshold_tokens,
             history_mode=history_mode,
+            linear_on_nonlinear=linear_on_nonlinear,
         )
         loop, runner, bound_port, thread = _serve_in_thread(gateway.app, host, port)
         base_url = f"http://{_url_host(public_host or _node_ip())}:{bound_port}"

--- a/src/agentcore_rl_toolkit/rollout_gateway/adapters/openai.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/adapters/openai.py
@@ -248,14 +248,14 @@ def _build_reply_parts(parsed: ParsedOutput, finish: str) -> tuple[dict[str, Any
         "content": parsed.text or None,
     }
     # manager_message must equal what the client echoes on the next request, or the
-    # history match (dict equality) diverges and the turn mounts as a new branch. It
-    # mirrors wire_message minus reasoning_content
+    # history match (dict equality) diverges and the turn mounts as a new branch.
     manager_message: dict[str, Any] = {
         "role": "assistant",
         "content": parsed.text or "",
     }
     if parsed.reasoning:
         wire_message["reasoning_content"] = parsed.reasoning
+        manager_message["reasoning_content"] = parsed.reasoning
     if wire_tool_calls:
         wire_message["tool_calls"] = wire_tool_calls
         manager_message["tool_calls"] = manager_tool_calls


### PR DESCRIPTION
This PR fixes two issues:
- In verl's `AgentCoreAgentLoop`, enabling setting `history_mode` and `linear_on_nonlinear` from init arguments so user can set them from yaml file.
- Add reasoning content to history match dict. A thinking model (e.g. Qwen 3.6-27B) generates reasoning content at one turn, and agent harness may modify reasoning content when constructing next turn (such as remove reasoning content or summarizing reasoning content). This history diverge should be detected at dict match step. If agent harness echoes the same reasoning content to next turn, dict match will pass.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
