### PR TITLE
docs: reorganize roadmaps as design documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -508,6 +508,7 @@ uv pip install -e ../../ --force-reinstall --no-deps
 - GitHub pull request descriptions must not hard-wrap prose at a fixed column width. Write each Markdown paragraph as one physical line, regardless of length, and let GitHub handle visual wrapping.
 - In pull request descriptions, insert newlines only for Markdown structure: paragraph boundaries, headings, list items, blockquotes, tables, code blocks, and similar constructs.
 - This pull request formatting rule does not apply to git commit messages or repository documentation; follow their existing wrapping conventions.
+- When implementing or changing behavior covered by a document in `designs/`, update that document and its `Implementation` status in the same change.
 - Return a JSON-serializable dict from `@rollout_entrypoint` (any structure accepted — no required keys)
 - Create model and agent inside the entrypoint function (not at module level) so config comes from the `_rollout` payload
 - Use standard `OpenAIModel` for OpenAI-compatible inference endpoints (token capture during training is handled at the infrastructure layer)

--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ We welcome contributions!
 
 - **Adding examples**: Create a new folder under `examples/` with its own `pyproject.toml`
 - **Improving the core library**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup
+- **Proposing significant features or architectural changes**: See the
+  [design document process](designs/README.md)
 
 For bug reports, feature requests, and pull request guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/designs/README.md
+++ b/designs/README.md
@@ -1,0 +1,46 @@
+# Design Documents
+
+This directory contains design documents for significant features and architectural
+changes. A design remains here after implementation as part of the project's decision
+history.
+
+Design status and implementation progress are separate:
+
+- **Status** records the design decision: `Proposed`, `Accepted`, `Deprecated`, or
+  `Superseded`.
+- **Implementation** records delivery progress: `Not started`, `In progress`, or
+  `Shipped`.
+
+Every design document must declare both fields immediately after its title.
+
+Do not move documents between directories when either status changes. Update the metadata
+and this index instead so links remain stable.
+
+This directory does not track project priorities. Planned work belongs in GitHub issues or
+a GitHub Project; these documents preserve the rationale and decisions behind significant
+changes.
+
+## Index
+
+| Design | Status | Implementation |
+| --- | --- | --- |
+| [Linear-history mode for the rollout gateway](./gateway_linear.md) | Accepted | Shipped |
+| [Stable optimizer-step batching for variable-row verl rollouts](./verl_variable_trajectory_batching.md) | Accepted | Shipped |
+| [Runtime Invocation Protocol](./runtime_invocation_protocol.md) | Proposed | Not started |
+| [Dynamic Sandbox Environments on AgentCore](./sandbox_dynamic_environments.md) | Proposed | Not started |
+
+## Lifecycle
+
+1. Create a design with `Status: Proposed` before implementing a significant public API or
+   architectural change.
+2. Change the status to `Accepted` when the design is approved. Acceptance does not imply
+   that implementation is complete.
+3. Update `Implementation` as delivery progresses, and link the implementation pull
+   request from the document.
+4. Keep accepted designs as historical records after they ship.
+5. Mark a design `Deprecated` when it no longer represents a supported direction, or
+   `Superseded` when another design replaces it. A superseded design must link to its
+   replacement.
+
+Small fixes and implementation details that do not introduce a durable architectural
+decision do not need a design document.

--- a/designs/gateway_linear.md
+++ b/designs/gateway_linear.md
@@ -1,5 +1,12 @@
 # Linear-history mode for the rollout gateway (generate-time prefix healing)
 
+| Field | Value |
+| --- | --- |
+| Status | Accepted |
+| Implementation | Shipped |
+| Date | 2026-08-31 |
+| Pull request | [#119](https://github.com/awslabs/agentcore-rl-toolkit/pull/119) |
+
 ## Summary
 
 `history_mode="linear"` is an opt-in gateway mode for agents whose conversation is
@@ -14,7 +21,8 @@ no cosmetic forks.
 
 Default behavior (`history_mode="tree"`) is unchanged.
 
-**Status:** implemented (v1) in `src/agentcore_rl_toolkit/rollout_gateway/linear.py`
+The accepted v1 design is implemented in
+`src/agentcore_rl_toolkit/rollout_gateway/linear.py`
 (`LinearHealer`), wired through `RolloutGateway` and `BaseAdapter`. Unit-tested in
 `tests/rollout_gateway/test_linear_healer.py`; core template assumptions validated against
 the real Qwen3-Coder-30B tokenizer. Remaining follow-ups at the end.

--- a/designs/runtime_invocation_protocol.md
+++ b/designs/runtime_invocation_protocol.md
@@ -1,5 +1,12 @@
 # Runtime Invocation Protocol: an execution lifecycle for stateful, long-running workloads
 
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Implementation | Not started |
+| Date | 2026-09-09 |
+| Pull request | [#120](https://github.com/awslabs/agentcore-rl-toolkit/pull/120) |
+
 ## Summary
 
 Stateful, long-running workloads separate three lifetimes that a simple

--- a/designs/sandbox_dynamic_environments.md
+++ b/designs/sandbox_dynamic_environments.md
@@ -1,5 +1,12 @@
 # Dynamic Sandbox Environments on AgentCore
 
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Implementation | Not started |
+| Date | 2026-07-29 |
+| Pull request | [#89](https://github.com/awslabs/agentcore-rl-toolkit/pull/89) |
+
 ## Summary
 
 The sandbox SDK can support dynamic, Harbor-style task environments under a

--- a/designs/verl_variable_trajectory_batching.md
+++ b/designs/verl_variable_trajectory_batching.md
@@ -1,5 +1,12 @@
 # Stable optimizer-step batching for variable-row verl rollouts
 
+| Field | Value |
+| --- | --- |
+| Status | Accepted |
+| Implementation | Shipped |
+| Date | 2026-09-10 |
+| Pull request | [#131](https://github.com/awslabs/agentcore-rl-toolkit/pull/131) |
+
 ## Summary
 
 Agentic rollouts can emit a variable number of training rows: a nominal rollout may

--- a/src/agentcore_rl_toolkit/backends/verl/README.md
+++ b/src/agentcore_rl_toolkit/backends/verl/README.md
@@ -31,7 +31,7 @@ normalization or weighting. With `M=1`, all emitted rows are optimized
 together. With `M > 1`, rows from one rollout may cross optimizer steps,
 although the configured step count and additive weighting within each step
 remain stable. See the
-[variable-row batching design](../../../../roadmaps/verl_variable_trajectory_batching.md)
+[variable-row batching design](../../../../designs/verl_variable_trajectory_batching.md)
 for the derivation.
 
 ## How it works


### PR DESCRIPTION
## Motivation

The `roadmaps/` directory mixed proposed work with shipped features, while the `draft/` subdirectory used file location to imply status. This made it unclear whether a document described project priorities, an active proposal, or an implemented design, and moving documents as their status changed risked breaking links.

This organization follows the design-document lifecycle used by [Strands Agents harness-sdk](https://github.com/strands-agents/harness-sdk/tree/main/team/designs), where design records remain available as decision history and carry explicit status.

## Summary

- Replace the mixed `roadmaps/` and `roadmaps/draft/` layout with a stable `designs/` directory.
- Track design approval and implementation progress separately, and preserve shipped designs as decision history.
- Update repository links and contributor guidance to keep relevant design documents current.

## Testing

- Ran `git diff --check`.
- Verified all local links in the changed Markdown files and confirmed no references to the old `roadmaps/` paths remain.