### PR TITLE
fix: avoid blocking the rollout gateway during linear history tokenization

### DIFF
--- a/src/agentcore_rl_toolkit/backends/verl/examples/migration_agent/agentcore_agent.yaml
+++ b/src/agentcore_rl_toolkit/backends/verl/examples/migration_agent/agentcore_agent.yaml
@@ -7,5 +7,7 @@
   # Per model call; cumulative context is configured in the training script.
   max_tokens_per_turn: 8192
   max_rollout_time: 1800
+  history_mode: linear
+  linear_on_nonlinear: reset
   # Preserve sampled tokens by forking rather than realigning across turn drift.
   fork_threshold_tokens: 0

--- a/src/agentcore_rl_toolkit/rollout_gateway/adapters/common.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/adapters/common.py
@@ -368,15 +368,19 @@ class BaseAdapter:
             if self.healer is not None:
                 # linear mode: splice canonical served ids over the drifted re-render
                 # before generation (the healer does the render internally).
-                prompt_ids = self.healer.heal(sid, translated, tools_schema)
+                prompt_ids = await self.healer.heal(
+                    sid, translated, tools_schema, chat_template_kwargs=chat_template_kwargs
+                )
             else:
-                prompt_ids = self.renderer.render(
+                prompt_ids = await self.renderer.render(
                     translated,
                     tools=tools_schema,
                     add_generation_prompt=True,
-                    **({"chat_template_kwargs": chat_template_kwargs} if chat_template_kwargs else {}),
+                    chat_template_kwargs=chat_template_kwargs,
                 )
 
+            if sid in self.closed:
+                return web.Response(status=503, text="session closed")
             sampling_params = _sampling_params(s, body, max_token_keys=self.max_token_keys, stop_keys=self.stop_keys)
             # context-budget clamp (backend-neutral): if the prompt already exceeds the
             # per-sid budget, short-circuit with an empty length-capped turn.

--- a/src/agentcore_rl_toolkit/rollout_gateway/linear.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/linear.py
@@ -24,7 +24,11 @@ Per turn the healer holds, per sid:
 * ``prev_messages`` / ``prev_tools`` — the message list (including the generated assistant)
   and tools schema last rendered, used to re-derive the drifted skeleton.
 
-Healing ``messages`` for the next turn (:meth:`heal`):
+Healing ``messages`` for the next turn (``await heal(...)``) first checks message
+and tools continuity. A renderer with a verified ``render_delta`` contract supplies
+the closer and encodes only the new observation suffix. The
+canonical served prefix is never re-encoded. Other templates use this full-render
+fallback, awaiting the renderer's ``render`` method:
 
 1. Linearity check at the **message level**: ``prev_messages`` must be a prefix of the
    incoming ``messages`` under dict equality (``==``, which is order-independent), and the
@@ -131,7 +135,9 @@ class LinearHealer:
 
     # -- public -------------------------------------------------------------
 
-    def heal(self, sid: str, messages: list[dict], tools: list[dict] | None) -> list[int]:
+    async def heal(
+        self, sid: str, messages: list[dict], tools: list[dict] | None, *, chat_template_kwargs: dict | None = None
+    ) -> list[int]:
         """Return the token ids to feed the backend for this turn.
 
         For the first turn of a sid (or a passthrough sid) this is just the plain render;
@@ -147,7 +153,9 @@ class LinearHealer:
         st = self._state.get(sid)
         if st is None or sid in self._disabled:
             # first turn, or healing disabled for this sid: feed the plain render
-            return self.renderer.render(messages, tools=tools, add_generation_prompt=True)
+            return await self.renderer.render(
+                messages, tools=tools, add_generation_prompt=True, chat_template_kwargs=chat_template_kwargs
+            )
 
         # Linearity is decided in MESSAGE space, not token space. st.prev_messages is this
         # session's history before this request (including the last assistant message). The
@@ -160,28 +168,55 @@ class LinearHealer:
         new = self._linear_delta(st, messages, tools)
         if new is None:
             # genuine edit/drop/branch/compaction (or a tools change): re-anchor
-            r_full = self.renderer.render(messages, tools=tools, add_generation_prompt=True)
+            r_full = await self.renderer.render(
+                messages, tools=tools, add_generation_prompt=True, chat_template_kwargs=chat_template_kwargs
+            )
             return self._handle_nonlinear(sid, r_full)
+
+        render_delta = getattr(self.renderer, "render_delta", None)
+        delta = (
+            await render_delta(
+                st.prev_messages[-1], new, tools=st.prev_tools, chat_template_kwargs=chat_template_kwargs
+            )
+            if render_delta is not None
+            else None
+        )
+        if delta is not None:
+            close, tail = delta
+            return self._splice(sid, st, close, tail)
 
         # r_prev is the token-space render of the gateway's OWN stored history. r_ext extends
         # that same stored prefix by only the genuinely-new (non-assistant, drift-free)
         # messages, so r_ext starts with r_prev by construction (identical prefix list and
         # tools) -- the client's re-serialized prior turns never enter the fed tokens.
-        r_prev = self.renderer.render(st.prev_messages, tools=st.prev_tools, add_generation_prompt=False)
-        r_ext = self.renderer.render(st.prev_messages + new, tools=st.prev_tools, add_generation_prompt=True)
+        r_prev = await self.renderer.render(
+            st.prev_messages,
+            tools=st.prev_tools,
+            add_generation_prompt=False,
+            chat_template_kwargs=chat_template_kwargs,
+        )
+        r_ext = await self.renderer.render(
+            st.prev_messages + new,
+            tools=st.prev_tools,
+            add_generation_prompt=True,
+            chat_template_kwargs=chat_template_kwargs,
+        )
         if r_ext[: len(r_prev)] != r_prev:
             # template glue for the prior turns depends on the appended messages, so we
             # cannot splice the canonical prefix safely; re-anchor rather than emit garbage.
             return self._handle_nonlinear(sid, r_ext)
 
         # close is the token-space marker of the end of the assistant turn
-        close = self._assistant_close(st.prev_messages, st.prev_tools, r_prev)
+        close = await self._assistant_close(st.prev_messages, st.prev_tools, r_prev, chat_template_kwargs)
         if close is None:
             # couldn't isolate the assistant-closer (e.g. a template whose glue depends on
             # message type); don't emit a subtly-wrong sequence — fall back.
             self._bump(sid, "close_unresolved")
             return self._handle_nonlinear(sid, r_ext)
 
+        return self._splice(sid, st, close, r_ext[len(r_prev) :])
+
+    def _splice(self, sid: str, st: _State, close: list[int], tail: list[int]) -> list[int]:
         # don't duplicate close tokens the model already emitted at the end of its served
         # output (e.g. a trailing stop token kept by no_stop_trim): drop the prefix of
         # `close` that the served prefix already ends with.
@@ -189,8 +224,6 @@ class LinearHealer:
 
         # tail is the token representation of the new messages in the incoming request
         # these are not assistant messages, so they are masked and drift-free
-        tail = r_ext[len(r_prev) :]  # new observation messages + generation prompt
-
         self._bump(sid, "healed_turns")
         self._bump(sid, "healed_prefix_tokens", len(st.served_prefix) + len(close))
 
@@ -283,8 +316,8 @@ class LinearHealer:
         logger.info("linear healer: sid=%s non-linear jump; re-anchoring", sid)
         return r_full
 
-    def _assistant_close(
-        self, prev_messages: list[dict], tools: list[dict] | None, r_prev: list[int]
+    async def _assistant_close(
+        self, prev_messages: list[dict], tools: list[dict] | None, r_prev: list[int], chat_template_kwargs=None
     ) -> list[int] | None:
         """The template's between-message glue that follows the last assistant message
         (e.g. Qwen's ``<|im_end|>\\n``), returned as token ids (possibly empty).
@@ -302,11 +335,17 @@ class LinearHealer:
         emit a wrong boundary.
         """
         before = prev_messages[:-1]
-        ra = self.renderer.render(
-            before + [{"role": "assistant", "content": _PROBE_A}], tools=tools, add_generation_prompt=False
+        ra = await self.renderer.render(
+            before + [{"role": "assistant", "content": _PROBE_A}],
+            tools=tools,
+            add_generation_prompt=False,
+            chat_template_kwargs=chat_template_kwargs,
         )
-        rb = self.renderer.render(
-            before + [{"role": "assistant", "content": _PROBE_B}], tools=tools, add_generation_prompt=False
+        rb = await self.renderer.render(
+            before + [{"role": "assistant", "content": _PROBE_B}],
+            tools=tools,
+            add_generation_prompt=False,
+            chat_template_kwargs=chat_template_kwargs,
         )
         close = _common_suffix(ra, rb)
         if close and r_prev[-len(close) :] != close:

--- a/src/agentcore_rl_toolkit/rollout_gateway/render.py
+++ b/src/agentcore_rl_toolkit/rollout_gateway/render.py
@@ -6,7 +6,7 @@ calls. Owning both directions in one place makes loss-masking well-defined and
 eliminates cross-backend retokenization drift. It is also required for sample-only
 inference backends (e.g. Tinker) that cannot render themselves.
 
-Two implementations behind one :class:`Renderer` protocol:
+Rendering implementations:
 
 * :class:`HfTemplateRenderer` (default, lightweight) — renders with the HF tokenizer's
   ``apply_chat_template``. Derendering picks the strongest available path: when the
@@ -28,6 +28,7 @@ Two implementations behind one :class:`Renderer` protocol:
 """
 
 import dataclasses
+import hashlib
 import logging
 from collections.abc import Callable
 from typing import Any, Protocol, runtime_checkable
@@ -41,6 +42,10 @@ from .response_schemas import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Exact Qwen3-Coder template whose between-turn suffix is independent of history.
+# A shared response-parser schema is not sufficient to establish this contract.
+_QWEN_CODER_TEMPLATE = "5a38bfa05833266240066aedc497decc9b00cc0d3e3b8cceea98cf530196ab06"
 
 # The two derender stages, as injectable callables:
 #   ReasoningParser: raw_output -> (reasoning, body_text)
@@ -66,14 +71,16 @@ class ParsedOutput:
 class Renderer(Protocol):
     """The gateway's tokenization seam.
 
-    ``render``             : canonical chat messages (+ tools) -> prompt ``token_ids``;
+    ``await render``       : canonical chat messages (+ tools) -> prompt ``token_ids``;
                              ``chat_template_kwargs`` are per-request template variables
                              (e.g. ``enable_thinking``) from the client's request body
     ``get_stop_sequences`` : stop strings / token ids for sampling
     ``parse``              : sampled response ``token_ids`` -> :class:`ParsedOutput`
+
+    Renderers may also expose ``render_delta`` for incremental linear healing.
     """
 
-    def render(
+    async def render(
         self,
         messages: list[dict],
         *,
@@ -169,7 +176,59 @@ class HfTemplateRenderer:
             if schema_name is not None:
                 self._schema = RESPONSE_SCHEMAS[schema_name]
 
-    def render(
+        self._close_ids: list[int] | None = None
+
+    def _render_text(self, messages, *, tools=None, add_generation_prompt=True, chat_template_kwargs=None) -> str:
+        return self.tokenizer.apply_chat_template(
+            self._rekey_reasoning(messages),
+            tools=tools,
+            tokenize=False,
+            add_generation_prompt=add_generation_prompt,
+            return_dict=False,
+            **({"chat_template": self._chat_template} if self._chat_template else {}),
+            **{**self._chat_template_kwargs, **(chat_template_kwargs or {})},
+        )
+
+    async def _encode(
+        self, text: str, *, padding=False, truncation=False, max_length=None, return_tensors=None, **kwargs
+    ) -> list[int]:
+        """Encode rendered text with HF options and native async tokenization.
+
+        HF currently has no async equivalent of ``apply_chat_template``. The
+        setup below mirrors the encoding configuration normally handled by its
+        synchronous tokenizer wrapper, then awaits the native ``async_encode``
+        call. Template rendering itself remains synchronous in ``_render_text``.
+        """
+        if return_tensors is not None or kwargs.get("return_overflowing_tokens", False):
+            raise ValueError("The gateway requires a single list[int], not tensor or overflow batches")
+        padding_strategy, truncation_strategy, max_length, _ = self.tokenizer._get_padding_truncation_strategies(
+            padding=padding, truncation=truncation, max_length=max_length, **kwargs
+        )
+        self.tokenizer.set_truncation_and_padding(
+            padding_strategy=padding_strategy,
+            truncation_strategy=truncation_strategy,
+            max_length=max_length,
+            stride=kwargs.get("stride", 0),
+            pad_to_multiple_of=kwargs.get("pad_to_multiple_of"),
+            padding_side=kwargs.get("padding_side"),
+        )
+        backend = self.tokenizer.backend_tokenizer
+        split_special_tokens = kwargs.get("split_special_tokens")
+        backend.encode_special_tokens = (
+            self.tokenizer.split_special_tokens if split_special_tokens is None else split_special_tokens
+        )
+        # tokenizers 0.22.2 snapshots its Rust configuration when async_encode is
+        # called, before returning the future. Do not await between configuring
+        # the backend and this call; other requests can then use their own settings.
+        encoding = await backend.async_encode(
+            text,
+            pair=kwargs.get("text_pair") or None,
+            is_pretokenized=kwargs.get("is_split_into_words", False),
+            add_special_tokens=kwargs.get("add_special_tokens", False),
+        )
+        return encoding.ids
+
+    async def render(
         self,
         messages: list[dict],
         *,
@@ -177,19 +236,61 @@ class HfTemplateRenderer:
         add_generation_prompt: bool = True,
         chat_template_kwargs: dict | None = None,
     ) -> list[int]:
-        # return_dict=False: we want only the token ids. The dict form (the
-        # transformers>=5 default) bundles an attention mask, but that is a padding
-        # artifact the training backend builds itself when it batches rows.
-        ids = self.tokenizer.apply_chat_template(
-            self._rekey_reasoning(messages),
+        """Render with HF, then apply its encoding options using native async."""
+        kwargs = {**self._chat_template_kwargs, **(chat_template_kwargs or {})}
+        text = self._render_text(
+            messages,
             tools=tools,
-            tokenize=True,
             add_generation_prompt=add_generation_prompt,
-            return_dict=False,
-            **({"chat_template": self._chat_template} if self._chat_template else {}),
-            **{**self._chat_template_kwargs, **(chat_template_kwargs or {})},
+            chat_template_kwargs=kwargs,
         )
-        return list(ids)
+        tokenizer_kwargs = kwargs.get("tokenizer_kwargs")
+        return await self._encode(
+            text,
+            padding=kwargs.get("padding", False),
+            truncation=kwargs.get("truncation", False),
+            max_length=kwargs.get("max_length"),
+            return_tensors=kwargs.get("return_tensors"),
+            add_special_tokens=False,
+            **(tokenizer_kwargs if tokenizer_kwargs is not None else {}),
+        )
+
+    async def render_delta(
+        self, last_assistant, new_messages, *, tools=None, chat_template_kwargs=None
+    ) -> tuple[list[int], list[int]] | None:
+        """Return (assistant closer, new tail), or None for the full-healer fallback."""
+        template = self._chat_template or self.tokenizer.chat_template
+        kwargs = {**self._chat_template_kwargs, **(chat_template_kwargs or {})}
+        # Only use templates verified to preserve the new tail when full history
+        # is replaced by the dummy history below. The hardcoded "<|im_end|>\n"
+        # assistant closer is template-specific, not universal. Other templates
+        # may use different closers or depend on earlier messages; fall back to
+        # full-history healing unless both assumptions have been verified.
+        if (
+            not isinstance(template, str)
+            or hashlib.sha256(template.encode()).hexdigest() != _QWEN_CODER_TEMPLATE
+            or kwargs.keys() - {"enable_thinking"}
+            or last_assistant.get("role") != "assistant"
+        ):
+            return None
+        # The verified template only needs the previous role/tool-call boundary.
+        # Render all consecutive tool results together to preserve their grouping.
+        dummy = [
+            {"role": "system", "content": "dummy system"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": " ",
+                "tool_calls": last_assistant.get("tool_calls") or [],
+            },
+        ]
+        before = self._render_text(dummy, tools=tools, add_generation_prompt=False, chat_template_kwargs=kwargs)
+        after = self._render_text(dummy + new_messages, tools=tools, chat_template_kwargs=kwargs)
+        if not after.startswith(before):
+            return None
+        if self._close_ids is None:
+            self._close_ids = await self._encode("<|im_end|>\n")
+        return self._close_ids, await self._encode(after[len(before) :])
 
     def _rekey_reasoning(self, messages: list[dict]) -> list[dict]:
         """Move assistant ``reasoning_content`` to the key this template reads.

--- a/tests/backends/verl/conftest.py
+++ b/tests/backends/verl/conftest.py
@@ -26,6 +26,8 @@ import pytest
 verl = pytest.importorskip("verl", reason="requires the verl extra")
 
 from omegaconf import OmegaConf  # noqa: E402
+from tokenizers import Tokenizer, models, pre_tokenizers  # noqa: E402
+from transformers import PreTrainedTokenizerFast  # noqa: E402
 from verl.experimental.agent_loop.agent_loop import DictConfigWrap  # noqa: E402
 from verl.workers.rollout.replica import TokenOutput  # noqa: E402
 
@@ -83,15 +85,19 @@ class FakeLLMServerClient:
         return TokenOutput(token_ids=[101, 102], log_probs=[-0.5, -0.6], stop_reason="completed")
 
 
-class FakeTokenizer:
+class FakeTokenizer(PreTrainedTokenizerFast):
     """Minimal HF-tokenizer stand-in whose renders prefix-extend across turns
     (like a real chat template): an assistant message re-renders as the
     generation prompt (99) + the exact ids the fake backend generated
     (101, 102), so replayed conversations take the CLEAN merge path."""
 
-    eos_token = "</s>"
-    eos_token_id = 0
-    pad_token_id = 0
+    def __init__(self):
+        # Keep deterministic IDs while exercising HF configuration and native
+        # async encoding through the same interface as the production tokenizer.
+        vocab = {f"token{i}": i for i in range(103)}
+        backend = Tokenizer(models.WordLevel(vocab, unk_token="token0"))
+        backend.pre_tokenizer = pre_tokenizers.WhitespaceSplit()
+        super().__init__(tokenizer_object=backend, eos_token="token0", pad_token="token0")
 
     def apply_chat_template(self, messages, *, tools=None, tokenize=True, add_generation_prompt=True, **kw):
         ids = []
@@ -102,13 +108,10 @@ class FakeTokenizer:
                 ids += [10 + i, 20 + i]
         if add_generation_prompt:
             ids.append(99)
-        return ids
+        return ids if tokenize else " ".join(f"token{i}" for i in ids)
 
     def decode(self, ids, skip_special_tokens=False):
         return "hello world"
-
-    def convert_tokens_to_ids(self, token):
-        return None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/rollout_gateway/integration_test/sglang/test_e2e_qwen_sglang.py
+++ b/tests/rollout_gateway/integration_test/sglang/test_e2e_qwen_sglang.py
@@ -154,7 +154,7 @@ async def test_single_turn_token_exact(server):
     assert len(backend.calls) == 1
     prompt_ids, output_ids = backend.calls[0]["prompt_ids"], backend.calls[0]["output_ids"]
     # the gateway rendered the prompt with the REAL Qwen chat template
-    assert prompt_ids == renderer.render(messages, tools=None, add_generation_prompt=True)
+    assert prompt_ids == await renderer.render(messages, tools=None, add_generation_prompt=True)
     assert backend.calls[0]["session_id"] == sid
 
     assert len(records) == 1

--- a/tests/rollout_gateway/integration_test/vllm/test_e2e_qwen_vllm.py
+++ b/tests/rollout_gateway/integration_test/vllm/test_e2e_qwen_vllm.py
@@ -155,7 +155,7 @@ async def test_single_turn_token_exact(server):
     assert len(backend.calls) == 1
     prompt_ids, output_ids = backend.calls[0]["prompt_ids"], backend.calls[0]["output_ids"]
     # the gateway rendered the prompt with the REAL Qwen chat template
-    assert prompt_ids == renderer.render(messages, tools=None, add_generation_prompt=True)
+    assert prompt_ids == await renderer.render(messages, tools=None, add_generation_prompt=True)
     assert backend.calls[0]["session_id"] == sid
 
     assert len(records) == 1

--- a/tests/rollout_gateway/test_adapters.py
+++ b/tests/rollout_gateway/test_adapters.py
@@ -30,7 +30,7 @@ class FakeRenderer:
     def _encode(self, text: str) -> list[int]:
         return [self._id(t) for t in text.split()]
 
-    def render(self, messages, *, tools=None, add_generation_prompt=True, chat_template_kwargs=None):
+    async def render(self, messages, *, tools=None, add_generation_prompt=True, chat_template_kwargs=None):
         self.render_kwargs.append(chat_template_kwargs)
         ids: list[int] = []
         for m in messages:
@@ -145,10 +145,11 @@ async def test_bearer_sid_isolates_sessions():
 
 
 @pytest.mark.asyncio
-async def test_chat_template_kwargs_reach_renderer():
+@pytest.mark.parametrize("history_mode", ["tree", "linear"])
+async def test_chat_template_kwargs_reach_renderer(history_mode):
     renderer = FakeRenderer()
     backend = FakeBackend(renderer, replies=["four", "four"])
-    adapter = OpenAIAdapter(backend=backend, renderer=renderer, tokenizer=None)
+    adapter = OpenAIAdapter(backend=backend, renderer=renderer, tokenizer=None, history_mode=history_mode)
 
     server = TestServer(adapter.app)
     client = TestClient(server)

--- a/tests/rollout_gateway/test_gateway_integration.py
+++ b/tests/rollout_gateway/test_gateway_integration.py
@@ -1,5 +1,6 @@
 """Integration tests for ``RolloutGateway`` — the assembled serving unit."""
 
+import asyncio
 import json
 from contextlib import asynccontextmanager
 
@@ -34,7 +35,7 @@ class FakeRenderer:
         inv = {v: k for k, v in self.vocab.items()}
         return " ".join(inv.get(i, "?") for i in ids)
 
-    def render(self, messages, *, tools=None, add_generation_prompt=True):
+    async def render(self, messages, *, tools=None, add_generation_prompt=True, chat_template_kwargs=None):
         ids: list[int] = []
         for m in messages:
             ids += self._encode(f"{m['role']}:")
@@ -107,6 +108,40 @@ async def serve(gateway: RolloutGateway):
 
 def bearer(sid: str) -> dict:
     return {"Authorization": f"Bearer {sid}"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("history_mode", ["tree", "linear"])
+async def test_close_during_async_render_does_not_generate(history_mode):
+    entered, release = asyncio.Event(), asyncio.Event()
+
+    class BlockingRenderer(FakeRenderer):
+        async def render(self, messages, **kwargs):
+            entered.set()
+            await release.wait()
+            return [1]
+
+    renderer = BlockingRenderer()
+    backend = FakeBackend(renderer, ["should not be generated"])
+    gateway = RolloutGateway(backend=backend, renderer=renderer, history_mode=history_mode)
+    gateway.create_session("closing")
+    async with serve(gateway) as client:
+        request = asyncio.ensure_future(
+            client.post(
+                "/v1/chat/completions",
+                json={"model": "x", "messages": [{"role": "user", "content": "q"}]},
+                headers=bearer("closing"),
+            )
+        )
+        await asyncio.wait_for(entered.wait(), 1)
+        finishing = asyncio.create_task(gateway.finish_session("closing"))
+        await asyncio.sleep(0)  # shutdown marks the session closed before draining
+        assert "closing" in gateway.adapters[0].closed
+        release.set()
+        response = await asyncio.wait_for(request, 1)
+        assert response.status == 503
+        assert await asyncio.wait_for(finishing, 1) == []
+        assert backend.calls == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/rollout_gateway/test_linear_healer.py
+++ b/tests/rollout_gateway/test_linear_healer.py
@@ -64,7 +64,7 @@ class FakeRenderer:
             return ids
         raise AssertionError(f"unexpected role {role!r}")
 
-    def render(self, messages, *, tools=None, add_generation_prompt=True) -> list[int]:
+    async def render(self, messages, *, tools=None, add_generation_prompt=True, chat_template_kwargs=None) -> list[int]:
         out: list[int] = []
         for m in messages:
             out += self._block(m)
@@ -81,14 +81,14 @@ def _a(text):
     return {"role": "assistant", "content": text}
 
 
-def _drive_turn(mgr, healer, sid, *, messages, served_ids, response_message, logprobs=None, use_healer=True):
+async def _drive_turn(mgr, healer, sid, *, messages, served_ids, response_message, logprobs=None, use_healer=True):
     """Mirror BaseAdapter._run_turn for one turn: heal -> (fake generate) -> commit ->
     record_turn. When ``use_healer`` is False, feed the raw drifted render instead (today's
     behavior) so tests can contrast the two paths on identical inputs."""
     if use_healer:
-        prompt_ids = healer.heal(sid, messages, None)
+        prompt_ids = await healer.heal(sid, messages, None)
     else:
-        prompt_ids = healer.renderer.render(messages, tools=None, add_generation_prompt=True)
+        prompt_ids = await healer.renderer.render(messages, tools=None, add_generation_prompt=True)
     turn = TurnRecord(
         prompt_ids=list(prompt_ids),
         output_ids=list(served_ids),
@@ -113,17 +113,18 @@ def _drive_turn(mgr, healer, sid, *, messages, served_ids, response_message, log
 # ---------------------------------------------------------------------------
 
 
-def test_unhealed_drift_forks():
+@pytest.mark.asyncio
+async def test_unhealed_drift_forks():
     """Baseline: served ids [2001,2002] for turn 1 differ from the renderer's re-render of
     the same assistant message, and turn 2's response is long. Feeding the raw drifted
     render forks the linear rollout into two samples."""
     r = FakeRenderer()
     mgr = TrajectoryManager(fork_threshold_tokens=1)  # any drift + response -> fork
     healer = LinearHealer(r)
-    _drive_turn(
+    await _drive_turn(
         mgr, healer, "s", messages=[_u("q1")], served_ids=[2001, 2002], response_message=_a("r1"), use_healer=False
     )
-    _drive_turn(
+    await _drive_turn(
         mgr,
         healer,
         "s",
@@ -136,16 +137,17 @@ def test_unhealed_drift_forks():
     assert len(recs) == 2  # linear rollout shattered by cosmetic drift
 
 
-def test_healed_drift_stays_one_sample():
+@pytest.mark.asyncio
+async def test_healed_drift_stays_one_sample():
     """Same inputs, healed: turn 2 generates on the canonical served prefix, the manager
     stays CLEAN, and the whole session is one training sample with both turns trained."""
     r = FakeRenderer()
     mgr = TrajectoryManager(fork_threshold_tokens=1)
     healer = LinearHealer(r)
-    _drive_turn(
+    await _drive_turn(
         mgr, healer, "s", messages=[_u("q1")], served_ids=[2001, 2002], response_message=_a("r1"), logprobs=[-0.1, -0.2]
     )
-    healed = _drive_turn(
+    healed = await _drive_turn(
         mgr,
         healer,
         "s",
@@ -176,7 +178,8 @@ def test_healed_drift_stays_one_sample():
     assert healer.counters["nonlinear"] == 0
 
 
-def test_healed_does_not_duplicate_closer_in_served_output():
+@pytest.mark.asyncio
+async def test_healed_does_not_duplicate_closer_in_served_output():
     """When the served output already ends with the template closer (no_stop_trim keeps the
     stop token), the overlap-trim must drop it from the reinserted glue so it is not
     doubled -- otherwise the manager would see a two-closer sequence and drift."""
@@ -184,8 +187,8 @@ def test_healed_does_not_duplicate_closer_in_served_output():
     mgr = TrajectoryManager(fork_threshold_tokens=1)
     healer = LinearHealer(r)
     # turn 1's served ids END with the closer token (A_CLOSE == the glue the probe finds).
-    _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001, A_CLOSE], response_message=_a("r1"))
-    healed = healer.heal("s", [_u("q1"), _a("r1"), _u("q2")], None)
+    await _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001, A_CLOSE], response_message=_a("r1"))
+    healed = await healer.heal("s", [_u("q1"), _a("r1"), _u("q2")], None)
 
     turn1_prompt = [U_OPEN, *_enc("q1"), U_CLOSE, A_OPEN]
     served_prefix = turn1_prompt + [2001, A_CLOSE]
@@ -195,15 +198,18 @@ def test_healed_does_not_duplicate_closer_in_served_output():
     assert healed.count(A_CLOSE) == 1  # not doubled
 
 
-def test_healed_three_turns_one_sample():
+@pytest.mark.asyncio
+async def test_healed_three_turns_one_sample():
     """Drift on every replayed assistant turn across a 3-turn chain still yields exactly
     one sample (the case that produced ~6 samples/session on the real run)."""
     r = FakeRenderer()
     mgr = TrajectoryManager(fork_threshold_tokens=1)
     healer = LinearHealer(r)
-    _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
-    _drive_turn(mgr, healer, "s", messages=[_u("q1"), _a("r1"), _u("q2")], served_ids=[2002], response_message=_a("r2"))
-    _drive_turn(
+    await _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
+    await _drive_turn(
+        mgr, healer, "s", messages=[_u("q1"), _a("r1"), _u("q2")], served_ids=[2002], response_message=_a("r2")
+    )
+    await _drive_turn(
         mgr,
         healer,
         "s",
@@ -255,7 +261,8 @@ def _a_tool(name, arguments, content=""):
     }
 
 
-def test_reordered_tool_call_args_stay_healed():
+@pytest.mark.asyncio
+async def test_reordered_tool_call_args_stay_healed():
     """A replayed tool-call assistant whose arguments are re-keyed (dict-equal, but a
     different token render under an order-sensitive template) must stay linear/healed --
     the drift a token-prefix linearity check would wrongly treat as non-linear."""
@@ -267,9 +274,9 @@ def test_reordered_tool_call_args_stay_healed():
     reordered = {"text": "x", "path": "/f.py"}  # the client's sorted-wire round-trip
     assert _a_tool("edit", emitted) == _a_tool("edit", reordered)  # manager sees them equal
     # ... but the order-sensitive renderer does not:
-    assert r.render([_a_tool("edit", emitted)]) != r.render([_a_tool("edit", reordered)])
+    assert await r.render([_a_tool("edit", emitted)]) != await r.render([_a_tool("edit", reordered)])
 
-    _drive_turn(
+    await _drive_turn(
         mgr,
         healer,
         "s",
@@ -277,7 +284,7 @@ def test_reordered_tool_call_args_stay_healed():
         served_ids=[2001, 2002],
         response_message=_a_tool("edit", emitted),
     )
-    healed = _drive_turn(
+    healed = await _drive_turn(
         mgr,
         healer,
         "s",
@@ -295,7 +302,8 @@ def test_reordered_tool_call_args_stay_healed():
     assert len(mgr.get_trajectory("s", base_sample=BaseTrace(index=0), reward=1.0)) == 1
 
 
-def test_tools_change_is_nonlinear():
+@pytest.mark.asyncio
+async def test_tools_change_is_nonlinear():
     """A changed tools schema is not a linear continuation even when the messages extend
     cleanly (the token-prefix check missed this when the renderer folds tools into a
     region the drift check doesn't reach; the message-level check compares tools directly)."""
@@ -305,13 +313,13 @@ def test_tools_change_is_nonlinear():
     tools_b = [{"type": "function", "function": {"name": "b"}}]
     healer.commit(
         "s",
-        fed_prompt_ids=r.render([_u("q1")], add_generation_prompt=True),
+        fed_prompt_ids=await r.render([_u("q1")], add_generation_prompt=True),
         output_ids=[2001],
         messages=[_u("q1")],
         response_message=_a("r1"),
         tools=tools_a,
     )
-    healer.heal("s", [_u("q1"), _a("r1"), _u("q2")], tools_b)
+    await healer.heal("s", [_u("q1"), _a("r1"), _u("q2")], tools_b)
     assert healer.counters["nonlinear"] == 1
     assert healer.counters["healed_turns"] == 0
 
@@ -321,15 +329,17 @@ def test_tools_change_is_nonlinear():
 # ---------------------------------------------------------------------------
 
 
-def test_close_probe_isolates_closer_text_turn():
+@pytest.mark.asyncio
+async def test_close_probe_isolates_closer_text_turn():
     r = FakeRenderer()
     healer = LinearHealer(r)
     prev = [_u("q1"), _a("hello world")]
-    r_prev = r.render(prev, add_generation_prompt=False)
-    assert healer._assistant_close(prev, None, r_prev) == [A_CLOSE]
+    r_prev = await r.render(prev, add_generation_prompt=False)
+    assert await healer._assistant_close(prev, None, r_prev) == [A_CLOSE]
 
 
-def test_close_probe_isolates_closer_tool_call_turn():
+@pytest.mark.asyncio
+async def test_close_probe_isolates_closer_tool_call_turn():
     """A content-less tool-call assistant message: the closer probe perturbs the tool
     arguments (not text) and still recovers exactly the template closer."""
     r = FakeRenderer()
@@ -340,8 +350,8 @@ def test_close_probe_isolates_closer_tool_call_turn():
         "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"q": "cats"}}}],
     }
     prev = [_u("q1"), tool_msg]
-    r_prev = r.render(prev, add_generation_prompt=False)
-    assert healer._assistant_close(prev, None, r_prev) == [A_CLOSE]
+    r_prev = await r.render(prev, add_generation_prompt=False)
+    assert await healer._assistant_close(prev, None, r_prev) == [A_CLOSE]
 
 
 # ---------------------------------------------------------------------------
@@ -349,49 +359,52 @@ def test_close_probe_isolates_closer_tool_call_turn():
 # ---------------------------------------------------------------------------
 
 
-def test_nonlinear_reset_reanchors_and_continues():
+@pytest.mark.asyncio
+async def test_nonlinear_reset_reanchors_and_continues():
     """If a turn's render is not an append-only extension (here: a prior user message is
     edited), reset re-anchors to the incoming render and keeps healing forward."""
     r = FakeRenderer()
     healer = LinearHealer(r, on_nonlinear="reset")
     mgr = TrajectoryManager(fork_threshold_tokens=1)
-    _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
+    await _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
     # turn 2 edits the prior user message ("q1" -> "Q1!"): r_prev is no longer a prefix.
-    healed = healer.heal("s", [_u("Q1!"), _a("r1"), _u("q2")], None)
-    assert healed == r.render([_u("Q1!"), _a("r1"), _u("q2")], add_generation_prompt=True)
+    healed = await healer.heal("s", [_u("Q1!"), _a("r1"), _u("q2")], None)
+    assert healed == await r.render([_u("Q1!"), _a("r1"), _u("q2")], add_generation_prompt=True)
     assert healer.counters["nonlinear"] == 1
 
 
-def test_nonlinear_error_raises_when_configured():
+@pytest.mark.asyncio
+async def test_nonlinear_error_raises_when_configured():
     r = FakeRenderer()
     healer = LinearHealer(r, on_nonlinear="error")
     healer.commit(
         "s",
-        fed_prompt_ids=r.render([_u("q1")], add_generation_prompt=True),
+        fed_prompt_ids=await r.render([_u("q1")], add_generation_prompt=True),
         output_ids=[2001],
         messages=[_u("q1")],
         response_message=_a("r1"),
         tools=None,
     )
     with pytest.raises(RuntimeError, match="append-only"):
-        healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2")], None)
+        await healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2")], None)
 
 
-def test_nonlinear_passthrough_disables_healing_for_session():
+@pytest.mark.asyncio
+async def test_nonlinear_passthrough_disables_healing_for_session():
     r = FakeRenderer()
     healer = LinearHealer(r, on_nonlinear="passthrough")
     healer.commit(
         "s",
-        fed_prompt_ids=r.render([_u("q1")], add_generation_prompt=True),
+        fed_prompt_ids=await r.render([_u("q1")], add_generation_prompt=True),
         output_ids=[2001],
         messages=[_u("q1")],
         response_message=_a("r1"),
         tools=None,
     )
-    healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2")], None)  # trips passthrough
+    await healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2")], None)  # trips passthrough
     # subsequent turns are no-ops (raw render), even if they look linear again
-    out = healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2"), _a("r2"), _u("q3")], None)
-    assert out == r.render([_u("EDITED"), _a("r1"), _u("q2"), _a("r2"), _u("q3")], add_generation_prompt=True)
+    out = await healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2"), _a("r2"), _u("q3")], None)
+    assert out == await r.render([_u("EDITED"), _a("r1"), _u("q2"), _a("r2"), _u("q3")], add_generation_prompt=True)
     assert healer.counters["nonlinear"] == 1
 
 
@@ -405,18 +418,23 @@ def test_bad_on_nonlinear_rejected():
 # ---------------------------------------------------------------------------
 
 
-def test_pop_stats_is_per_session_and_isolated():
+@pytest.mark.asyncio
+async def test_pop_stats_is_per_session_and_isolated():
     """pop_stats returns just this sid's counters (not the run-cumulative total), keeps
     sessions isolated, and clears the sid so a second pop is empty."""
     r = FakeRenderer()
     mgr = TrajectoryManager(fork_threshold_tokens=1)
     healer = LinearHealer(r)
     # session A: two turns -> one healed turn.
-    _drive_turn(mgr, healer, "a", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
-    _drive_turn(mgr, healer, "a", messages=[_u("q1"), _a("r1"), _u("q2")], served_ids=[2002], response_message=_a("r2"))
+    await _drive_turn(mgr, healer, "a", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
+    await _drive_turn(
+        mgr, healer, "a", messages=[_u("q1"), _a("r1"), _u("q2")], served_ids=[2002], response_message=_a("r2")
+    )
     # session B: two turns -> one healed turn.
-    _drive_turn(mgr, healer, "b", messages=[_u("p1")], served_ids=[3001], response_message=_a("s1"))
-    _drive_turn(mgr, healer, "b", messages=[_u("p1"), _a("s1"), _u("p2")], served_ids=[3002], response_message=_a("s2"))
+    await _drive_turn(mgr, healer, "b", messages=[_u("p1")], served_ids=[3001], response_message=_a("s1"))
+    await _drive_turn(
+        mgr, healer, "b", messages=[_u("p1"), _a("s1"), _u("p2")], served_ids=[3002], response_message=_a("s2")
+    )
 
     # run-cumulative counter sees both sessions; per-sid sees only its own.
     assert healer.counters["healed_turns"] == 2
@@ -428,28 +446,32 @@ def test_pop_stats_is_per_session_and_isolated():
     assert healer.pop_stats("b")["healed_turns"] == 1
 
 
-def test_pop_stats_counts_nonlinear_for_session():
+@pytest.mark.asyncio
+async def test_pop_stats_counts_nonlinear_for_session():
     r = FakeRenderer()
     healer = LinearHealer(r, on_nonlinear="reset")
     healer.commit(
         "s",
-        fed_prompt_ids=r.render([_u("q1")], add_generation_prompt=True),
+        fed_prompt_ids=await r.render([_u("q1")], add_generation_prompt=True),
         output_ids=[2001],
         messages=[_u("q1")],
         response_message=_a("r1"),
         tools=None,
     )
-    healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2")], None)  # non-linear -> reset
+    await healer.heal("s", [_u("EDITED"), _a("r1"), _u("q2")], None)  # non-linear -> reset
     stats = healer.pop_stats("s")
     assert stats["nonlinear"] == 1
 
 
-def test_drop_clears_per_sid_stats():
+@pytest.mark.asyncio
+async def test_drop_clears_per_sid_stats():
     r = FakeRenderer()
     mgr = TrajectoryManager(fork_threshold_tokens=1)
     healer = LinearHealer(r)
-    _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
-    _drive_turn(mgr, healer, "s", messages=[_u("q1"), _a("r1"), _u("q2")], served_ids=[2002], response_message=_a("r2"))
+    await _drive_turn(mgr, healer, "s", messages=[_u("q1")], served_ids=[2001], response_message=_a("r1"))
+    await _drive_turn(
+        mgr, healer, "s", messages=[_u("q1"), _a("r1"), _u("q2")], served_ids=[2002], response_message=_a("r2")
+    )
     healer.drop("s")
     # per-sid counters cleared -> fixed schema, all zero.
     assert healer.pop_stats("s") == dict.fromkeys(LinearHealer.COUNTER_KEYS, 0)

--- a/tests/rollout_gateway/test_render.py
+++ b/tests/rollout_gateway/test_render.py
@@ -1,13 +1,15 @@
 """HfTemplateRenderer round-trip tests.
 
-Uses a tiny stub tokenizer (no transformers download) to assert the renderer calls
-apply_chat_template with the expected kwargs and decodes/parses output correctly. A
-real-tokenizer parity check lives in the Step 2 E2E path (against the live server).
+Rendering uses a locally built HF/Rust tokenizer, compared directly with HF's
+apply_chat_template. Parsing uses small stubs. Neither needs model downloads.
 The schema-derender path (recognized chat template -> tokenizer.parse_response) is
 covered in test_response_schemas.py; this module covers the two-stage fallback.
 """
 
+import asyncio
+import hashlib
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -16,31 +18,22 @@ from agentcore_rl_toolkit.rollout_gateway.render import HfTemplateRenderer, Pars
 
 
 class StubTokenizer:
-    def __init__(self):
-        self.last_kwargs = None
-
-    def apply_chat_template(self, messages, *, tools=None, tokenize=True, add_generation_prompt=True, return_dict=True):
-        self.last_kwargs = dict(
-            tools=tools, tokenize=tokenize, add_generation_prompt=add_generation_prompt, return_dict=return_dict
-        )
-        # deterministic: one id per message, +99 sentinel for the generation prompt
-        ids = [len(m.get("content") or "") for m in messages]
-        if add_generation_prompt:
-            ids.append(99)
-        # mirror the real API: the default dict form bundles extras the renderer
-        # must opt out of with return_dict=False
-        return ids if not return_dict else {"input_ids": ids, "attention_mask": [1] * len(ids)}
-
     def decode(self, ids, skip_special_tokens=False):
         return " ".join(str(i) for i in ids)
 
 
-def test_render_passes_expected_kwargs_and_returns_list():
-    tok = StubTokenizer()
+@pytest.mark.asyncio
+async def test_render_passes_expected_kwargs_and_returns_list(fast_tokenizer):
+    tok = fast_tokenizer
     r = HfTemplateRenderer(tok)
-    ids = r.render([{"role": "user", "content": "abc"}], tools=None, add_generation_prompt=True)
-    assert ids == [3, 99]
-    assert tok.last_kwargs == {"tools": None, "tokenize": True, "add_generation_prompt": True, "return_dict": False}
+    messages = [{"role": "user", "content": "abc"}]
+    expected = tok.apply_chat_template(messages, tokenize=True, add_generation_prompt=True, return_dict=False)
+    with patch.object(tok, "apply_chat_template", wraps=tok.apply_chat_template) as template:
+        ids = await r.render(messages, tools=None, add_generation_prompt=True)
+    assert isinstance(ids, list) and ids == expected
+    template.assert_called_once_with(
+        messages, tools=None, tokenize=False, add_generation_prompt=True, return_dict=False
+    )
 
 
 def test_parse_no_tools_returns_plain_text():
@@ -176,27 +169,176 @@ def test_tool_parser_skipped_without_tools_schema():
     assert out.text == "body"
 
 
-class KwargsStubTokenizer(StubTokenizer):
-    """StubTokenizer that also records template kwargs (enable_thinking & co.)."""
-
-    def apply_chat_template(self, messages, **kwargs):
-        self.template_kwargs = {
-            k: v for k, v in kwargs.items() if k not in ("tools", "tokenize", "add_generation_prompt", "return_dict")
-        }
-        return super().apply_chat_template(
-            messages,
-            **{k: v for k, v in kwargs.items() if k in ("tools", "tokenize", "add_generation_prompt", "return_dict")},
-        )
-
-
-def test_render_forwards_chat_template_kwargs_renderer_default_and_per_call():
-    tok = KwargsStubTokenizer()
+@pytest.mark.asyncio
+async def test_render_forwards_chat_template_kwargs_renderer_default_and_per_call(fast_tokenizer):
+    tok = fast_tokenizer
     r = HfTemplateRenderer(tok, chat_template_kwargs={"enable_thinking": False})
-    r.render([{"role": "user", "content": "abc"}])
-    assert tok.template_kwargs == {"enable_thinking": False}
-    # a per-call value (the request body's chat_template_kwargs) wins over the renderer default
-    r.render([{"role": "user", "content": "abc"}], chat_template_kwargs={"enable_thinking": True, "x": 1})
-    assert tok.template_kwargs == {"enable_thinking": True, "x": 1}
-    # no kwargs anywhere -> nothing extra reaches the tokenizer (stock behaviour)
-    HfTemplateRenderer(tok).render([{"role": "user", "content": "abc"}])
-    assert tok.template_kwargs == {}
+    with patch.object(tok, "apply_chat_template", wraps=tok.apply_chat_template) as template:
+        await r.render([{"role": "user", "content": "abc"}])
+        assert template.call_args.kwargs["enable_thinking"] is False
+        # Request variables override renderer defaults.
+        await r.render([{"role": "user", "content": "abc"}], chat_template_kwargs={"enable_thinking": True, "x": 1})
+        assert template.call_args.kwargs["enable_thinking"] is True
+        assert template.call_args.kwargs["x"] == 1
+        await HfTemplateRenderer(tok).render([{"role": "user", "content": "abc"}])
+        assert "enable_thinking" not in template.call_args.kwargs
+        assert "x" not in template.call_args.kwargs
+
+
+@pytest.fixture
+def fast_tokenizer():
+    """Actual HF/Rust tokenizer, built locally without model downloads."""
+    from tokenizers import Tokenizer, decoders, models, normalizers, pre_tokenizers
+    from transformers import PreTrainedTokenizerFast
+
+    vocab = {c: i for i, c in enumerate(sorted(pre_tokenizers.ByteLevel.alphabet()))}
+    backend = Tokenizer(models.BPE(vocab=vocab, merges=[]))
+    backend.normalizer = normalizers.NFC()
+    backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+    backend.decoder = decoders.ByteLevel()
+    return PreTrainedTokenizerFast(
+        tokenizer_object=backend,
+        pad_token="<pad>",
+        eos_token="<|im_end|>",
+        additional_special_tokens=["<|im_start|>", "<extra>"],
+        chat_template=(
+            "{% for m in messages %}{{ '<|im_start|>' + m.role + '\\n' + m.content + '<|im_end|>\\n' }}"
+            "{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\\n' }}"
+            "{% if enable_thinking | default(false) %}{{ '<think>\\n' }}{% endif %}{% endif %}"
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_encoding_matches_hf(fast_tokenizer):
+    tok = fast_tokenizer
+    renderer = HfTemplateRenderer(tok, chat_template_kwargs={"enable_thinking": False})
+    messages = [{"role": "user", "content": "中文🙂 e\u0301 <extra>\r\n" * 100}]
+    expected = tok.apply_chat_template(
+        messages, tokenize=True, add_generation_prompt=True, return_dict=False, enable_thinking=True
+    )
+    outputs = await asyncio.gather(
+        *[renderer.render(messages, chat_template_kwargs={"enable_thinking": True}) for _ in range(16)]
+    )
+    assert all(ids == expected for ids in outputs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "options",
+    [
+        {
+            "padding": False,
+            "truncation": False,
+            "continue_final_message": False,
+            "return_assistant_tokens_mask": False,
+            "return_tensors": None,
+            "tokenizer_kwargs": {"return_overflowing_tokens": False},
+        },
+        {"max_length": 8},  # HF ignores max_length when truncation/padding are off.
+        {"truncation": True, "max_length": 16},
+        {"truncation": "only_first", "max_length": 16},
+        {"padding": "max_length", "max_length": 256, "tokenizer_kwargs": {"padding_side": "left"}},
+        {"padding": True, "tokenizer_kwargs": {"pad_to_multiple_of": 64}},
+        {"tokenizer_kwargs": {"split_special_tokens": True}},
+        {"tokenizer_kwargs": {"text_pair": "another sequence"}},
+        {"continue_final_message": True},
+        {"continue_final_message": "content"},
+    ],
+)
+async def test_async_render_preserves_hf_options(fast_tokenizer, options):
+    renderer = HfTemplateRenderer(fast_tokenizer)
+    messages = [{"role": "user", "content": "中文 <extra> question"}, {"role": "assistant", "content": "prefill"}]
+    kwargs = {"add_generation_prompt": not options.get("continue_final_message"), "chat_template_kwargs": options}
+    expected = fast_tokenizer.apply_chat_template(
+        messages, tokenize=True, add_generation_prompt=kwargs["add_generation_prompt"], return_dict=False, **options
+    )
+    actual = await renderer.render(messages, **kwargs)
+    assert actual == expected
+    assert all(isinstance(token_id, int) for token_id in actual)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_async_render_uses_each_requests_hf_options(fast_tokenizer):
+    renderer = HfTemplateRenderer(fast_tokenizer, chat_template_kwargs={"max_length": 16, "truncation": True})
+    messages = [{"role": "user", "content": "中文 <extra>" * 20}]
+    options = [
+        {},
+        {"max_length": 8},
+        {"truncation": False},
+        {"padding": "max_length", "max_length": 512},
+        {"tokenizer_kwargs": {"split_special_tokens": True}},
+    ] * 4
+    expected = [
+        fast_tokenizer.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_dict=False,
+            **{"max_length": 16, "truncation": True, **kw},
+        )
+        for kw in options
+    ]
+    actual = await asyncio.gather(*(renderer.render(messages, chat_template_kwargs=kw) for kw in options))
+    assert actual == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"continue_final_message": True},  # incompatible with add_generation_prompt
+        {"return_assistant_tokens_mask": True},  # renderer returns IDs, not a dict
+        {"padding": True, "truncation": True, "max_length": 15, "tokenizer_kwargs": {"pad_to_multiple_of": 8}},
+    ],
+)
+async def test_async_render_preserves_hf_validation(fast_tokenizer, options):
+    renderer = HfTemplateRenderer(fast_tokenizer)
+    messages = [{"role": "assistant", "content": "prefill"}]
+    with pytest.raises(ValueError) as expected:
+        fast_tokenizer.apply_chat_template(
+            messages, tokenize=True, add_generation_prompt=True, return_dict=False, **options
+        )
+    with pytest.raises(ValueError) as actual:
+        await renderer.render(messages, chat_template_kwargs=options)
+    assert str(actual.value) == str(expected.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ending", ["", "<|im_end|>", "<|im_end|>\n", "<|endoftext|>"])
+async def test_incremental_tokens_equal_full_healing_and_preserve_sampled_prefix(fast_tokenizer, monkeypatch, ending):
+    from agentcore_rl_toolkit.rollout_gateway import render
+    from agentcore_rl_toolkit.rollout_gateway.linear import LinearHealer
+
+    # This tiny template has the same tested closer contract. Production admission
+    # is hash-gated; the actual Qwen template/BPE is also exercised in local replay.
+    monkeypatch.setattr(
+        render, "_QWEN_CODER_TEMPLATE", hashlib.sha256(fast_tokenizer.chat_template.encode()).hexdigest()
+    )
+    incremental = HfTemplateRenderer(fast_tokenizer)
+    full = HfTemplateRenderer(fast_tokenizer)
+    full.render_delta = None
+    prior = [{"role": "user", "content": "old context" * 100}]
+    last = {"role": "assistant", "content": "Client-replayed text"}
+    new = [{"role": "tool", "content": "中文 <extra>"}, {"role": "tool", "content": "second result"}]
+    seed = fast_tokenizer.apply_chat_template(prior, tokenize=True, add_generation_prompt=True, return_dict=False)
+    output = fast_tokenizer.encode("Raw  sampled tokens." + ending, add_special_tokens=False)
+    hs = [LinearHealer(r) for r in (incremental, full)]
+    for h in hs:
+        h.commit("s", fed_prompt_ids=seed, output_ids=output, messages=prior, response_message=last, tools=None)
+
+    # Normal append must not call full render on the incremental renderer.
+    async def no_full_render(*args, **kwargs):
+        raise AssertionError("re-encoded full history")
+
+    incremental.render = no_full_render
+    actual = await hs[0].heal("s", prior + [last] + new, None)
+    assert actual == await hs[1].heal("s", prior + [last] + new, None)
+    assert actual[: len(seed) + len(output)] == seed + output
+
+
+@pytest.mark.asyncio
+async def test_unknown_template_does_not_use_parser_schema_as_incremental_contract(fast_tokenizer):
+    renderer = HfTemplateRenderer(fast_tokenizer)
+    renderer._schema = {"same": "parser"}
+    assert await renderer.render_delta({"role": "assistant", "content": "x"}, []) is None


### PR DESCRIPTION
Linear history healing currently tokenizes the full conversation four times per appended turn on the gateway's HTTP event loop. With long MigrationBench conversations and 512 rollouts per training batch, this can stall the gateway and cause agent connection timeouts. This change uses native async encoding and, for a verified Qwen Coder template, encodes only the new tail while preserving the tokens actually served to the model.

**Draft for early visibility and feedback — still waiting on E2E.** Full training throughput and learning-quality results are pending.

## Observed issue

The stopped linear run had **411 failures among 1,327 saved training rollout results (30.97%)**, including **405 `ConnectTimeout` failures**. These are counts from an S3 snapshot that includes an in-progress training step, not final run totals. The failures occurred while connecting to the model gateway, rather than waiting for the 1,800-second rollout deadline.

During the incident, a local gateway health request received no response within eight seconds and the accept queue approached its limit. A separate local reproduction confirmed event-loop stalls from synchronous tokenization; profiling attributed about 96% of the measured rendering time to encoding. We did not obtain a live stack profile of the stopped training process.

The four full-history encodes are the previous history, the extended history, and two probes used to identify the assistant closing tokens.

## Changes

- Make HF gateway rendering asynchronous using the tokenizer's native `async_encode`, preserving HF encoding configuration for the gateway's token-ID output.
- Add incremental suffix rendering for the verified Qwen Coder template, following the minimal-history approach used by [Miles TiTo](https://www.lmsys.org/blog/2026-05-13-no-token-left-behind/). Keep full-history healing as the fallback for other templates or unsupported options.
- Gate the optimization by the exact template: both the dummy-history substitution and the assistant closer (`<|im_end|>\n`) are template-specific.
- Forward request-level `chat_template_kwargs` through linear healing and avoid starting generation if a session closes while encoding is awaited.
- Enable linear mode in the existing MigrationBench example configuration.

Template rendering itself remains synchronous; native token encoding is awaited.

## Validation

- 81 gateway tests and 72 verl tests passed, run separately.
- Real Qwen tokenizer checks passed for token/boundary consistency, multi-turn trajectories, long histories/tool results, and concurrent encoding.
- Offline Qwen prompt-preparation benchmark: appending a short tail took **58.7 → 0.29 ms** with ~13k history tokens and **503.5 → 0.92 ms** with ~101k, comparing full-history synchronous healing before the fix with incremental async healing after it. These are medians of seven measurements after warm-up, excluding inference.
- During implementation, the local HTTP stress check completed 512/512 requests with matching token IDs, loss masks, and logprobs. Inference was mocked; this is not a measurement of training throughput.
- Native async encoding was tested with `transformers==5.12.1` and `tokenizers==0.22.2`.

## E2E pending

The new full run reuses the existing MigrationBench data, agent runtime, and constant optimizer-step configuration from the experiment following #131. It runs Qwen3-Coder-30B-A3B-Instruct on eight B200 GPUs, with 32 prompts × 16 rollouts and 101 planned training steps.

Still waiting on full E2E results.

Before marking this ready, check failure rates under full training load, training rows and step time, and reward against the existing baselines. No E2E speedup or learning-quality claim is made yet.
