### PR TITLE
fix(verl): avoid duplicate reward aggregation and enforce reward_extra_info schema

### DIFF
--- a/src/agentcore_rl_toolkit/backends/verl/README.md
+++ b/src/agentcore_rl_toolkit/backends/verl/README.md
@@ -153,6 +153,11 @@ computation.
   agent-side contract error. verl contains the exception to the affected prompt
   group, so training continues without rows from that group.
 
+To aggregate numeric fields from the agent result's `metrics` dict, declare each
+field and its missing-value default under `reward_extra_info_defaults` in
+`agentcore_agent.yaml`. Only declared fields are forwarded, so every rollout has
+the same keys. `reward` is omitted because verl derives it from `rm_scores`.
+
 **Trainer-side rewards (`reward_mode="separate"`) are not supported yet** and are
 rejected at startup because verl's v1 reward managers require dataset columns that
 the payload-first contract does not provide.

--- a/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
+++ b/src/agentcore_rl_toolkit/backends/verl/agent_loop.py
@@ -155,7 +155,8 @@ class AgentCoreAgentLoop(AgentLoopBase):
         # without a signature change. Reward semantics: see the README.
         self.reward_mode = reward_mode
         self._rei_defaults = {str(k): float(v) for k, v in (reward_extra_info_defaults or {}).items()}
-        self._rei_keys_seen: set[str] = set(self._rei_defaults)
+        # verl already derives its `reward` validation metric from rm_scores.
+        self._rei_defaults.pop("reward", None)
         self.model_id = self.config.actor_rollout_ref.model.path
 
         self._gateway: GatewayHandle = get_or_start_gateway(
@@ -302,31 +303,26 @@ class AgentCoreAgentLoop(AgentLoopBase):
             primary = max(range(len(records)), key=lambda i: sum(records[i].loss_mask))
             records.append(records.pop(primary))
 
-        shared_extra["reward_extra_info"] = self._reward_extra_info(
-            result, reward, len(records), failed=error is not None
-        )
+        shared_extra["reward_extra_info"] = self._reward_extra_info(result, len(records), failed=error is not None)
 
         outputs = [
             self._record_to_output(r, i, reward, num_turns, shared_extra, elapsed) for i, r in enumerate(records)
         ]
         return outputs
 
-    def _reward_extra_info(self, result: dict[str, Any] | None, reward: float, n_records: int, *, failed: bool) -> dict:
+    def _reward_extra_info(self, result: dict[str, Any] | None, n_records: int, *, failed: bool) -> dict:
         info: dict[str, float] = dict(self._rei_defaults)
         metrics = (result or {}).get("metrics") or {}
         if isinstance(metrics, dict):
-            for k, v in metrics.items():
+            for k in self._rei_defaults:
+                v = metrics.get(k)
                 if isinstance(v, bool | int | float):
                     try:
-                        info[str(k)] = float(v)
+                        info[k] = float(v)
                     except (TypeError, ValueError):
                         continue
-        info["reward"] = float(reward)
         info["acr_failed"] = 1.0 if failed else 0.0
         info["num_trace_records"] = float(n_records)
-        for k in self._rei_keys_seen:
-            info.setdefault(k, 0.0)
-        self._rei_keys_seen.update(info)
         return info
 
     # -- helpers ---------------------------------------------------------------

--- a/tests/backends/verl/test_agent_loop.py
+++ b/tests/backends/verl/test_agent_loop.py
@@ -93,7 +93,7 @@ async def test_run_end_to_end_inline_reward():
     assert len(out.prompt_ids) > 0
     assert out.reward_score == 0.75
     assert out.extra_fields["acr_result"]["rewards"] == 0.75
-    assert out.extra_fields["reward_extra_info"] == {"reward": 0.75, "acr_failed": 0.0, "num_trace_records": 1.0}
+    assert out.extra_fields["reward_extra_info"] == {"acr_failed": 0.0, "num_trace_records": 1.0}
 
     # invoke wiring: sid is a 36-char uuid used as both ACR session id and Bearer sid
     call = invoke.calls[0]
@@ -359,37 +359,55 @@ async def test_invalid_max_tokens_per_turn_rejected(value):
 
 
 async def test_reward_extra_info_carries_scalar_metrics_over_defaults():
-    loop = _make_loop(FakeLLMServerClient(), reward_extra_info_defaults={"f_beta": 0.0, "reward": 0.0})
-    _wire_result(loop, {"status_code": 200, "rewards": 0.75, "metrics": {"f_beta": 0.6, "num_turns": 3, "note": "x"}})
+    loop = _make_loop(
+        FakeLLMServerClient(), reward_extra_info_defaults={"f_beta": 0.0, "num_turns": 0.0, "reward": 0.0}
+    )
+    _wire_result(
+        loop,
+        {
+            "status_code": 200,
+            "rewards": 0.75,
+            "metrics": {"f_beta": 0.6, "num_turns": 3, "undeclared": 9, "note": "x"},
+        },
+    )
     outs = await loop.run(
         {"temperature": 1.0}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"q": 1}, uid="u"
     )
     rei = outs[-1].extra_fields["reward_extra_info"]
-    assert rei["f_beta"] == 0.6 and rei["num_turns"] == 3.0 and rei["reward"] == 0.75
+    assert rei["f_beta"] == 0.6 and rei["num_turns"] == 3.0
     assert rei["acr_failed"] == 0.0 and rei["num_trace_records"] == 1.0
-    assert "note" not in rei  # non-numeric metrics are dropped (verl aggregates these as floats)
+    assert "reward" not in rei  # verl derives its reward metric from rm_scores
+    assert "undeclared" not in rei and "note" not in rei
 
 
 async def test_failed_rollout_carries_reward_extra_info_defaults():
     loop = _make_loop(FakeLLMServerClient(), reward_extra_info_defaults={"f_beta": 0.0})
-    rei = loop._reward_extra_info(None, 0.0, 0, failed=True)
-    assert rei == {"f_beta": 0.0, "reward": 0.0, "acr_failed": 1.0, "num_trace_records": 0.0}
+    rei = loop._reward_extra_info(None, 0, failed=True)
+    assert rei == {"f_beta": 0.0, "acr_failed": 1.0, "num_trace_records": 0.0}
 
 
-async def test_failed_rollout_padded_with_keys_seen_on_successful_rollouts():
-    loop = _make_loop(FakeLLMServerClient(), reward_extra_info_defaults={"reward": 0.0})
-    _wire_result(loop, {"status_code": 200, "rewards": 1.0, "metrics": {"submitted": 1.0, "num_turns": 4, "ok": True}})
-    outs = await loop.run(
-        {"temperature": 1.0}, raw_prompt=[{"role": "user", "content": "hi"}], payload={"q": 1}, uid="u"
+async def test_reward_extra_info_keys_are_stable_across_loop_instances():
+    defaults = {"submitted": 0.0, "num_turns": 0.0, "ok": 0.0}
+    successful_loop = _make_loop(FakeLLMServerClient(), reward_extra_info_defaults=defaults)
+    failed_loop = _make_loop(FakeLLMServerClient(), reward_extra_info_defaults=defaults)
+
+    successful = successful_loop._reward_extra_info(
+        {"metrics": {"submitted": 1.0, "num_turns": 4, "ok": True}}, 1, failed=False
     )
-    assert outs[-1].extra_fields["reward_extra_info"]["ok"] == 1.0
-    rei = loop._reward_extra_info(None, 0.0, 0, failed=True)
-    assert rei == {
-        "reward": 0.0,
-        "acr_failed": 1.0,
-        "num_trace_records": 0.0,
+    failed = failed_loop._reward_extra_info(None, 0, failed=True)
+
+    assert successful == {
+        "submitted": 1.0,
+        "num_turns": 4.0,
+        "ok": 1.0,
+        "acr_failed": 0.0,
+        "num_trace_records": 1.0,
+    }
+    assert failed == {
         "submitted": 0.0,
         "num_turns": 0.0,
         "ok": 0.0,
+        "acr_failed": 1.0,
+        "num_trace_records": 0.0,
     }
-    assert set(rei) == set(outs[-1].extra_fields["reward_extra_info"])
+    assert set(successful) == set(failed)


### PR DESCRIPTION
## Problems

PR #129 introduced two issues in the verl integration:

1. `reward` is recorded twice during v1 validation. verl already derives the canonical validation reward from `rm_scores`, then appends the toolkit's `reward_extra_info["reward"]` to the same list. With multiple validation batches, the duplicate values from earlier batches shift later batches out of the prefix consumed by `process_validation_metrics()`, producing incorrect reward aggregates.
2. Agent metrics do not have a stable key set across rollouts. In the v1 TransferQueue worker, each rollout session calls `_run_agent_loop()`, which creates a new `AgentLoop` with `hydra.utils.instantiate(...)`. The instance-local `_rei_keys_seen` set therefore cannot carry discovered keys from one rollout to another. During validation, verl pads an omitted metric with `None`; `process_validation_metrics()` then passes the mixed numeric/`None` values to NumPy aggregation and raises a `TypeError`.

## Summary

- Omit `reward` from `reward_extra_info` because verl already derives its validation reward metric from `rm_scores`.
- Treat `reward_extra_info_defaults` as the fixed schema for agent-provided metrics, so every rollout emits the same keys even though verl creates a new `AgentLoop` instance for each rollout session.
- Forward only declared numeric metrics and use their configured defaults when an agent omits them.
- Document the configuration contract and cover it with independent-loop regression tests.

## Why

### Duplicate reward aggregation

This integration requires verl's v1 trainer. `AgentCoreAgentLoop.reward_score` already becomes `rm_scores`, and `PPOTrainerSync._validate()` first appends the scores derived from `rm_scores`:

```python
scores = reward_tensor.sum(-1).cpu().tolist()
reward_extra_infos_dict["reward"].extend(scores)
```

It then appends every field from `reward_extra_info` to the same dictionary, including the toolkit's duplicate `reward`. Across two validation batches, with rewards `[0.0, 0.0]` followed by `[1.0, 1.0]`, the list grows as follows:

```text
after batch 1: [0.0, 0.0, 0.0, 0.0]
after batch 2: [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]
```

`process_validation_metrics()` iterates over the four validation samples and reads `var_vals[sample_idx]`, effectively consuming only the first four entries. It therefore aggregates `[0.0, 0.0, 0.0, 0.0]` instead of the canonical `[0.0, 0.0, 1.0, 1.0]`, logging a mean reward of `0.0` instead of `0.5`. With a single validation batch, the duplicate values are all beyond the consumed prefix, which is why the bug can appear harmless.

Removing the duplicate extra-info field does not change training rewards; the canonical values remain in `rm_scores`.

### Stable metric keys

PR #129 kept dynamically discovered metric keys in `_rei_keys_seen`. In the v1 path, `AgentLoopWorkerTQ._run_prompt()` starts `_run_agent_loop()` once per rollout session, and `_run_agent_loop()` calls `hydra.utils.instantiate(...)` before every `run()`. The set is therefore not shared across rollout rows.

For example, if one rollout returns `{"f_beta": 0.8}` and another omits `f_beta`, the v1 validation collector produces:

```python
reward_extra_infos_dict["f_beta"] == [0.8, None]
```

`process_validation_metrics()` calls `np.mean()` on those values and raises:

```text
TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'
```

Using `reward_extra_info_defaults` as the fixed key set gives every independently created loop the same schema. Undeclared fields are ignored, and a declared field uses its configured default when the agent omits it.

## Testing

- `uv run pytest tests/backends/verl/` — 72 passed
- pre-commit hooks on all changed files
- `git diff --check`
